### PR TITLE
breaking: remove `$lib` in favor of `#lib`

### DIFF
--- a/.changeset/fluffy-clouds-sing.md
+++ b/.changeset/fluffy-clouds-sing.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/enhanced-img': patch
+---
+
+chore: replace the `$lib` alias with `#lib` in docs

--- a/.changeset/happy-coins-think.md
+++ b/.changeset/happy-coins-think.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/package': minor
+---
+
+feat: transform import aliases into relative imports in files

--- a/.changeset/lib-alias-to-hash-lib.md
+++ b/.changeset/lib-alias-to-hash-lib.md
@@ -1,6 +1,5 @@
 ---
 '@sveltejs/kit': major
-'@sveltejs/enhanced-img': minor
 ---
 
-breaking: replace the `$lib` alias with `#lib`, leveraging Node's built-in subpath imports
+breaking: replace the `$lib` alias with `#lib` and remove `files.lib` config.

--- a/.changeset/lib-alias-to-hash-lib.md
+++ b/.changeset/lib-alias-to-hash-lib.md
@@ -1,0 +1,6 @@
+---
+'@sveltejs/kit': major
+'@sveltejs/enhanced-img': minor
+---
+
+breaking: replace the `$lib` alias with `#lib`, leveraging Node's built-in subpath imports

--- a/.changeset/neat-llamas-guess.md
+++ b/.changeset/neat-llamas-guess.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': major
+---
+
+breaking: Server-only directories (`/server/` in the path) are now treated as server-only everywhere inside the project (except `src/routes` and the assets directory)

--- a/documentation/docs/10-getting-started/30-project-structure.md
+++ b/documentation/docs/10-getting-started/30-project-structure.md
@@ -36,7 +36,7 @@ You'll also find common files like `.gitignore` and `.npmrc` (and `.prettierrc` 
 
 The `src` directory contains the meat of your project. Everything except `src/routes` and `src/app.html` is optional.
 
-- `lib` contains your library code (utilities and components), which can be imported via the [`$lib`]($lib) alias, or packaged up for distribution using [`svelte-package`](packaging)
+- `lib` contains your library code (utilities and components), which can be imported via the [`#lib`]($lib) alias (configured in your `package.json` `imports` field; previously `$lib`), or packaged up for distribution using [`svelte-package`](packaging)
   - directories named `server`, at any depth, mark any code within as [server only](server-only-modules). SvelteKit will prevent you from importing these in client code.
 - `params` contains any [param matchers](advanced-routing#Matching) your app needs
 - `routes` contains the [routes](routing) of your application. You can also colocate other components that are only used within a single route here

--- a/documentation/docs/10-getting-started/30-project-structure.md
+++ b/documentation/docs/10-getting-started/30-project-structure.md
@@ -36,7 +36,7 @@ You'll also find common files like `.gitignore` and `.npmrc` (and `.prettierrc` 
 
 The `src` directory contains the meat of your project. Everything except `src/routes` and `src/app.html` is optional.
 
-- `lib` contains your library code (utilities and components), which can be imported via the [`#lib`]($lib) alias (configured in your `package.json` `imports` field; previously `$lib`), or packaged up for distribution using [`svelte-package`](packaging)
+- `lib` contains your library code (utilities and components), which can be imported via the [`#lib`]($lib) alias, or packaged up for distribution using [`svelte-package`](packaging)
   - directories named `server`, at any depth, mark any code within as [server only](server-only-modules). SvelteKit will prevent you from importing these in client code.
 - `params` contains any [param matchers](advanced-routing#Matching) your app needs
 - `routes` contains the [routes](routing) of your application. You can also colocate other components that are only used within a single route here

--- a/documentation/docs/20-core-concepts/10-routing.md
+++ b/documentation/docs/20-core-concepts/10-routing.md
@@ -444,7 +444,7 @@ You can read more about omitting `$types` in our [blog post](/blog/zero-config-t
 
 Any other files inside a route directory are ignored by SvelteKit. This means you can colocate components and utility modules with the routes that need them.
 
-If components and modules are needed by multiple routes, it's a good idea to put them in [`$lib`]($lib).
+If components and modules are needed by multiple routes, it's a good idea to put them in [`#lib`]($lib).
 
 ## Further reading
 

--- a/documentation/docs/20-core-concepts/20-load.md
+++ b/documentation/docs/20-core-concepts/20-load.md
@@ -51,13 +51,13 @@ A more realistic version of your blog post's `load` function, that only runs on 
 ```js
 /// file: src/routes/blog/[slug]/+page.server.js
 // @filename: ambient.d.ts
-declare module '$lib/server/database' {
+declare module '#lib/server/database' {
 	export function getPost(slug: string): Promise<{ title: string, content: string }>
 }
 
 // @filename: index.js
 // ---cut---
-import * as db from '$lib/server/database';
+import * as db from '#lib/server/database';
 
 /** @type {import('./$types').PageServerLoad} */
 export async function load({ params }) {
@@ -76,13 +76,13 @@ Your `+layout.svelte` files can also load data, via `+layout.js` or `+layout.ser
 ```js
 /// file: src/routes/blog/[slug]/+layout.server.js
 // @filename: ambient.d.ts
-declare module '$lib/server/database' {
+declare module '#lib/server/database' {
 	export function getPostSummaries(): Promise<Array<{ title: string, slug: string }>>
 }
 
 // @filename: index.js
 // ---cut---
-import * as db from '$lib/server/database';
+import * as db from '#lib/server/database';
 
 /** @type {import('./$types').LayoutServerLoad} */
 export async function load() {
@@ -297,13 +297,13 @@ A server `load` function can get [`cookies`](@sveltejs-kit#Cookies) as shown bel
 ```js
 /// file: src/routes/+layout.server.js
 // @filename: ambient.d.ts
-declare module '$lib/server/database' {
+declare module '#lib/server/database' {
 	export function getUser(sessionid: string | undefined): Promise<{ name: string, avatar: string }>
 }
 
 // @filename: index.js
 // ---cut---
-import * as db from '$lib/server/database';
+import * as db from '#lib/server/database';
 
 /** @type {import('./$types').LayoutServerLoad} */
 export async function load({ cookies }) {
@@ -578,13 +578,13 @@ For example, given a pair of `load` functions like these...
 ```js
 /// file: src/routes/blog/[slug]/+page.server.js
 // @filename: ambient.d.ts
-declare module '$lib/server/database' {
+declare module '#lib/server/database' {
 	export function getPost(slug: string): Promise<{ title: string, content: string }>
 }
 
 // @filename: index.js
 // ---cut---
-import * as db from '$lib/server/database';
+import * as db from '#lib/server/database';
 
 /** @type {import('./$types').PageServerLoad} */
 export async function load({ params }) {
@@ -597,13 +597,13 @@ export async function load({ params }) {
 ```js
 /// file: src/routes/blog/[slug]/+layout.server.js
 // @filename: ambient.d.ts
-declare module '$lib/server/database' {
+declare module '#lib/server/database' {
 	export function getPostSummaries(): Promise<Array<{ title: string, slug: string }>>
 }
 
 // @filename: index.js
 // ---cut---
-import * as db from '$lib/server/database';
+import * as db from '#lib/server/database';
 
 /** @type {import('./$types').LayoutServerLoad} */
 export async function load() {
@@ -756,7 +756,7 @@ Now, you can call `requireLogin` in any `load` function (or [form action](form-a
 /// file: +page.server.js
 // @filename: ambient.d.ts
 
-declare module '$lib/server/auth' {
+declare module '#lib/server/auth' {
 	interface User {
 		name: string;
 	}
@@ -766,7 +766,7 @@ declare module '$lib/server/auth' {
 
 // @filename: index.ts
 // ---cut---
-import { requireLogin } from '$lib/server/auth';
+import { requireLogin } from '#lib/server/auth';
 
 export function load() {
 	const user = requireLogin();

--- a/documentation/docs/20-core-concepts/30-form-actions.md
+++ b/documentation/docs/20-core-concepts/30-form-actions.md
@@ -107,11 +107,11 @@ Each action receives a `RequestEvent` object, allowing you to read the data with
 ```js
 /// file: src/routes/login/+page.server.js
 // @filename: ambient.d.ts
-declare module '$lib/server/db';
+declare module '#lib/server/db';
 
 // @filename: index.js
 // ---cut---
-import * as db from '$lib/server/db';
+import * as db from '#lib/server/db';
 
 /** @type {import('./$types').PageServerLoad} */
 export async function load({ cookies }) {
@@ -170,12 +170,12 @@ When using `use:enhance` (or making a `fetch` request with the `accept: applicat
 ```js
 /// file: src/routes/login/+page.server.js
 // @filename: ambient.d.ts
-declare module '$lib/server/db';
+declare module '#lib/server/db';
 
 // @filename: index.js
 // ---cut---
 +++import { fail } from '@sveltejs/kit';+++
-import * as db from '$lib/server/db';
+import * as db from '#lib/server/db';
 
 /** @satisfies {import('./$types').Actions} */
 export const actions = {
@@ -234,12 +234,12 @@ Redirects (and errors) work exactly the same as in [`load`](load#Redirects):
 // @errors: 2345
 /// file: src/routes/login/+page.server.js
 // @filename: ambient.d.ts
-declare module '$lib/server/db';
+declare module '#lib/server/db';
 
 // @filename: index.js
 // ---cut---
 import { fail, +++redirect+++ } from '@sveltejs/kit';
-import * as db from '$lib/server/db';
+import * as db from '#lib/server/db';
 
 /** @satisfies {import('./$types').Actions} */
 export const actions = {

--- a/documentation/docs/20-core-concepts/50-state-management.md
+++ b/documentation/docs/20-core-concepts/50-state-management.md
@@ -45,13 +45,13 @@ For the same reason, your `load` functions should be _pure_ — no side-effects 
 ```js
 /// file: +page.js
 // @filename: ambient.d.ts
-declare module '$lib/user' {
+declare module '#lib/user' {
 	export const user: { set: (value: any) => void };
 }
 
 // @filename: index.js
 // ---cut---
-import { user } from '$lib/user';
+import { user } from '#lib/user';
 
 /** @type {import('./$types').PageLoad} */
 export async function load({ fetch }) {

--- a/documentation/docs/20-core-concepts/60-remote-functions.md
+++ b/documentation/docs/20-core-concepts/60-remote-functions.md
@@ -46,13 +46,13 @@ The `query` function allows you to read dynamic data from the server.
 ```js
 /// file: src/routes/blog/data.remote.js
 // @filename: ambient.d.ts
-declare module '$lib/server/database' {
+declare module '#lib/server/database' {
 	export function sql(strings: TemplateStringsArray, ...values: any[]): Promise<any[]>;
 }
 // @filename: index.js
 // ---cut---
 import { query } from '$app/server';
-import * as db from '$lib/server/database';
+import * as db from '#lib/server/database';
 
 export const getPosts = query(async () => {
 	const posts = await db.sql`
@@ -66,7 +66,7 @@ export const getPosts = query(async () => {
 });
 ```
 
-> [!NOTE] Throughout this page, you'll see imports from fictional modules like `$lib/server/database` and `$lib/server/auth`. These are purely for illustrative purposes — you can use whatever database client and auth setup you like.
+> [!NOTE] Throughout this page, you'll see imports from fictional modules like `#lib/server/database` and `#lib/server/auth`. These are purely for illustrative purposes — you can use whatever database client and auth setup you like.
 >
 > The `db.sql` function above is a [tagged template function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates) that escapes any interpolated values.
 
@@ -139,7 +139,7 @@ Since `getPost` exposes an HTTP endpoint, it's important to validate this argume
 ```js
 /// file: src/routes/blog/data.remote.js
 // @filename: ambient.d.ts
-declare module '$lib/server/database' {
+declare module '#lib/server/database' {
 	export function sql(strings: TemplateStringsArray, ...values: any[]): Promise<any[]>;
 }
 // @filename: index.js
@@ -147,7 +147,7 @@ declare module '$lib/server/database' {
 import * as v from 'valibot';
 import { error } from '@sveltejs/kit';
 import { query } from '$app/server';
-import * as db from '$lib/server/database';
+import * as db from '#lib/server/database';
 
 export const getPosts = query(async () => { /* ... */ });
 
@@ -211,14 +211,14 @@ On the server, the callback receives an array of the arguments the function was 
 ```js
 /// file: weather.remote.js
 // @filename: ambient.d.ts
-declare module '$lib/server/database' {
+declare module '#lib/server/database' {
 	export function sql(strings: TemplateStringsArray, ...values: any[]): Promise<any[]>;
 }
 // @filename: index.js
 // ---cut---
 import * as v from 'valibot';
 import { query } from '$app/server';
-import * as db from '$lib/server/database';
+import * as db from '#lib/server/database';
 
 export const getWeather = query.batch(v.string(), async (cityIds) => {
 	const weather = await db.sql`
@@ -323,11 +323,11 @@ The `form` function makes it easy to write data to the server. It takes a callba
 ```ts
 /// file: src/routes/blog/data.remote.js
 // @filename: ambient.d.ts
-declare module '$lib/server/database' {
+declare module '#lib/server/database' {
 	export function sql(strings: TemplateStringsArray, ...values: any[]): Promise<any[]>;
 }
 
-declare module '$lib/server/auth' {
+declare module '#lib/server/auth' {
 	interface User {
 		name: string;
 	}
@@ -342,8 +342,8 @@ declare module '$lib/server/auth' {
 import * as v from 'valibot';
 import { error, redirect } from '@sveltejs/kit';
 import { query, form } from '$app/server';
-import * as db from '$lib/server/database';
-import * as auth from '$lib/server/auth';
+import * as db from '#lib/server/database';
+import * as auth from '#lib/server/auth';
 
 export const getPosts = query(async () => { /* ... */ });
 
@@ -568,7 +568,7 @@ In addition to declarative schema validation, you can programmatically mark fiel
 // @errors: 18046
 /// file: src/routes/shop/data.remote.js
 // @filename: ambient.d.ts
-declare module '$lib/server/database' {
+declare module '#lib/server/database' {
 	export function buy(qty: number): Promise<void>
 }
 // @filename: index.js
@@ -576,7 +576,7 @@ declare module '$lib/server/database' {
 import * as v from 'valibot';
 import { invalid } from '@sveltejs/kit';
 import { form } from '$app/server';
-import * as db from '$lib/server/database';
+import * as db from '#lib/server/database';
 
 export const buyHotcakes = form(
 	v.object({
@@ -739,11 +739,11 @@ The example above uses [`redirect(...)`](@sveltejs-kit#redirect), which sends th
 ```ts
 /// file: src/routes/blog/data.remote.js
 // @filename: ambient.d.ts
-declare module '$lib/server/database' {
+declare module '#lib/server/database' {
 	export function sql(strings: TemplateStringsArray, ...values: any[]): Promise<any[]>;
 }
 
-declare module '$lib/server/auth' {
+declare module '#lib/server/auth' {
 	interface User {
 		name: string;
 	}
@@ -757,8 +757,8 @@ declare module '$lib/server/auth' {
 import * as v from 'valibot';
 import { error, redirect } from '@sveltejs/kit';
 import { query, form } from '$app/server';
-import * as db from '$lib/server/database';
-import * as auth from '$lib/server/auth';
+import * as db from '#lib/server/database';
+import * as auth from '#lib/server/auth';
 
 export const getPosts = query(async () => { /* ... */ });
 
@@ -806,7 +806,7 @@ We can customize what happens when the form is submitted with the `enhance` meth
 <!--- file: src/routes/blog/new/+page.svelte --->
 <script>
 	import { createPost } from '../data.remote';
-	import { showToast } from '$lib/toast';
+	import { showToast } from '#lib/toast';
 </script>
 
 <h1>Create a new post</h1>
@@ -864,7 +864,7 @@ To accomplish this, add a field to your schema for the button value, and use `as
 ```svelte
 <!--- file: src/routes/login/+page.svelte --->
 <script>
-	import { loginOrRegister } from '$lib/auth';
+	import { loginOrRegister } from '#lib/auth';
 </script>
 
 <form {...loginOrRegister}>
@@ -886,7 +886,7 @@ To accomplish this, add a field to your schema for the button value, and use `as
 In your form handler, you can check which button was clicked:
 
 ```js
-/// file: $lib/auth.js
+/// file: #lib/auth.js
 import * as v from 'valibot';
 import { form } from '$app/server';
 
@@ -917,14 +917,14 @@ As with `query` and `form`, if the function accepts an argument, it should be [v
 ```ts
 /// file: likes.remote.js
 // @filename: ambient.d.ts
-declare module '$lib/server/database' {
+declare module '#lib/server/database' {
 	export function sql(strings: TemplateStringsArray, ...values: any[]): Promise<any[]>;
 }
 // @filename: index.js
 // ---cut---
 import * as v from 'valibot';
 import { query, command } from '$app/server';
-import * as db from '$lib/server/database';
+import * as db from '#lib/server/database';
 
 export const getLikes = query(v.string(), async (id) => {
 	const [row] = await db.sql`
@@ -951,7 +951,7 @@ Now simply call `addLike`, from (for example) an event handler:
 <!--- file: +page.svelte --->
 <script>
 	import { getLikes, addLike } from './likes.remote';
-	import { showToast } from '$lib/toast';
+	import { showToast } from '#lib/toast';
 
 	let { item } = $props();
 </script>
@@ -1132,13 +1132,13 @@ The `prerender` function is similar to `query`, except that it will be invoked a
 ```js
 /// file: src/routes/blog/data.remote.js
 // @filename: ambient.d.ts
-declare module '$lib/server/database' {
+declare module '#lib/server/database' {
 	export function sql(strings: TemplateStringsArray, ...values: any[]): Promise<any[]>;
 }
 // @filename: index.js
 // ---cut---
 import { prerender } from '$app/server';
-import * as db from '$lib/server/database';
+import * as db from '#lib/server/database';
 
 export const getPosts = prerender(async () => {
 	const posts = await db.sql`
@@ -1163,7 +1163,7 @@ As with queries, prerender functions can accept an argument, which should be [va
 ```js
 /// file: src/routes/blog/data.remote.js
 // @filename: ambient.d.ts
-declare module '$lib/server/database' {
+declare module '#lib/server/database' {
 	export function sql(strings: TemplateStringsArray, ...values: any[]): Promise<any[]>;
 }
 // @filename: index.js
@@ -1171,7 +1171,7 @@ declare module '$lib/server/database' {
 import * as v from 'valibot';
 import { error } from '@sveltejs/kit';
 import { prerender } from '$app/server';
-import * as db from '$lib/server/database';
+import * as db from '#lib/server/database';
 
 export const getPosts = prerender(async () => { /* ... */ });
 
@@ -1272,14 +1272,14 @@ interface User {
 	avatar: string;
 }
 
-declare module '$lib/server/database' {
+declare module '#lib/server/database' {
 	export function findUser(sessionId: string | undefined): Promise<User | null>;
 }
 
 // @filename: index.js
 // ---cut---
 import { getRequestEvent, query } from '$app/server';
-import { findUser } from '$lib/server/database';
+import { findUser } from '#lib/server/database';
 
 export const getProfile = query(async () => {
 	const user = await getUser();

--- a/documentation/docs/20-core-concepts/70-environment-variables.md
+++ b/documentation/docs/20-core-concepts/70-environment-variables.md
@@ -167,7 +167,7 @@ Because this variable is `static`, the `<DebugOverlay>` component shown here wil
 ```svelte
 <script>
 	import { SHOW_DEBUG_OVERLAY } from '$app/env/public';
-	import DebugOverlay from '$lib/components/DebugOverlay.svelte';
+	import DebugOverlay from '#lib/components/DebugOverlay.svelte';
 </script>
 
 {#if SHOW_DEBUG_OVERLAY}

--- a/documentation/docs/25-build-and-deploy/10-building-your-app.md
+++ b/documentation/docs/25-build-and-deploy/10-building-your-app.md
@@ -14,7 +14,7 @@ SvelteKit will load your `+page/layout(.server).js` files (and all files they im
 
 ```js
 +++import { building } from '$app/env';+++
-import { initialiseDatabase } from '$lib/server/database';
+import { initialiseDatabase } from '#lib/server/database';
 
 +++if (!building) {+++
 	initialiseDatabase();

--- a/documentation/docs/30-advanced/10-advanced-routing.md
+++ b/documentation/docs/30-advanced/10-advanced-routing.md
@@ -289,7 +289,7 @@ Not all use cases are suited for layout grouping, nor should you feel compelled 
 ```svelte
 <!--- file: src/routes/nested/route/+layout@.svelte --->
 <script>
-	import ReusableLayout from '$lib/ReusableLayout.svelte';
+	import ReusableLayout from '#lib/ReusableLayout.svelte';
 	let { data, children } = $props();
 </script>
 
@@ -301,12 +301,12 @@ Not all use cases are suited for layout grouping, nor should you feel compelled 
 ```js
 /// file: src/routes/nested/route/+layout.js
 // @filename: ambient.d.ts
-declare module "$lib/reusable-load-function" {
+declare module "#lib/reusable-load-function" {
 	export function reusableLoad(event: import('@sveltejs/kit').LoadEvent): Promise<Record<string, any>>;
 }
 // @filename: index.js
 // ---cut---
-import { reusableLoad } from '$lib/reusable-load-function';
+import { reusableLoad } from '#lib/reusable-load-function';
 
 /** @type {import('./$types').PageLoad} */
 export function load(event) {

--- a/documentation/docs/30-advanced/20-hooks.md
+++ b/documentation/docs/30-advanced/20-hooks.md
@@ -283,7 +283,7 @@ This function runs once, when the server is created or the app starts in the bro
 ```js
 // @errors: 2307
 /// file: src/hooks.server.js
-import * as db from '$lib/server/database';
+import * as db from '#lib/server/database';
 
 /** @type {import('@sveltejs/kit').ServerInit} */
 export async function init() {
@@ -356,7 +356,7 @@ This is a collection of _transporters_, which allow you to pass custom types —
 ```js
 // @errors: 2307
 /// file: src/hooks.js
-import { Vector } from '$lib/math';
+import { Vector } from '#lib/math';
 
 /** @type {import('@sveltejs/kit').Transport} */
 export const transport = {

--- a/documentation/docs/30-advanced/25-errors.md
+++ b/documentation/docs/30-advanced/25-errors.md
@@ -17,14 +17,14 @@ An _expected_ error is one created with the [`error`](@sveltejs-kit#error) helpe
 ```js
 /// file: src/routes/blog/[slug]/+page.server.js
 // @filename: ambient.d.ts
-declare module '$lib/server/database' {
+declare module '#lib/server/database' {
 	export function getPost(slug: string): Promise<{ title: string, content: string } | undefined>
 }
 
 // @filename: index.js
 // ---cut---
 import { error } from '@sveltejs/kit';
-import * as db from '$lib/server/database';
+import * as db from '#lib/server/database';
 
 /** @type {import('./$types').PageServerLoad} */
 export async function load({ params }) {

--- a/documentation/docs/30-advanced/50-server-only-modules.md
+++ b/documentation/docs/30-advanced/50-server-only-modules.md
@@ -16,8 +16,8 @@ The [`$app/server`]($app-server) module, which contains a [`read`]($app-server#r
 
 You can make your own modules server-only in two ways:
 
-- For single modules, add `.server` to the filename, e.g. `secrets.server.js`. This works for _any_ file in the project directory, including within `$lib`.
-- Directories named `server` under `$lib`, at any depth, mark _all_ code within as server-only, e.g. `$lib/server/config.js` or `$lib/data/server/user/profile.js`.
+- For single modules, add `.server` to the filename, e.g. `secrets.server.js`. This works for _any_ file in the project directory, including within `#lib`.
+- Directories named `server` under `#lib`, at any depth, mark _all_ code within as server-only, e.g. `#lib/server/config.js` or `#lib/data/server/user/profile.js`.
 
 ## How it works
 
@@ -25,14 +25,14 @@ Any time you have public-facing code that imports server-only code (whether dire
 
 ```js
 // @errors: 7005
-/// file: $lib/server/secrets.js
+/// file: #lib/server/secrets.js
 export const atlantisCoordinates = [/* redacted */];
 ```
 
 ```js
 // @errors: 2307 7006 7005
 /// file: src/routes/utils.js
-export { atlantisCoordinates } from '$lib/server/secrets.js';
+export { atlantisCoordinates } from '#lib/server/secrets.js';
 
 export const add = (a, b) => a + b;
 ```
@@ -47,11 +47,11 @@ export const add = (a, b) => a + b;
 ...SvelteKit will error:
 
 ```
-Cannot import $lib/server/secrets.ts into code that runs in the browser, as this could leak sensitive information.
+Cannot import #lib/server/secrets.ts into code that runs in the browser, as this could leak sensitive information.
 
  src/routes/+page.svelte imports
   src/routes/utils.js imports
-   $lib/server/secrets.ts
+   #lib/server/secrets.ts
 
 If you're only using the import as a type, change it to `import type`.
 ```

--- a/documentation/docs/30-advanced/50-server-only-modules.md
+++ b/documentation/docs/30-advanced/50-server-only-modules.md
@@ -19,7 +19,7 @@ You can make your own modules server-only in two ways:
 - For single modules, add `.server` to the filename, e.g. `secrets.server.js`. This works for _any_ file in the project directory.
 - Directories named `server` anywhere in your project (except inside `src/routes` or the assets directory) mark _all_ code within as server-only, e.g. `src/lib/server/config.js` or `src/lib/data/server/user/profile.js`. (In SvelteKit 2, this only applied to the `src/lib` folder.)
 
-> [!NOTE] Modules outside your working directory and those inside `node_modules` (e.g. packages from npm) are _not_ subject to these rules. If you want to publish a package and want to mark a module as server-only, add `import '$app/server'` to the top of that file.
+> [!NOTE] Modules outside your working directory and those inside `node_modules` (e.g. packages from npm) are _not_ subject to these rules. If you want to publish a package with a server-only module, add `import '$app/server'` to the top of that file.
 
 ## How it works
 

--- a/documentation/docs/30-advanced/50-server-only-modules.md
+++ b/documentation/docs/30-advanced/50-server-only-modules.md
@@ -17,7 +17,9 @@ The [`$app/server`]($app-server) module, which contains a [`read`]($app-server#r
 You can make your own modules server-only in two ways:
 
 - For single modules, add `.server` to the filename, e.g. `secrets.server.js`. This works for _any_ file in the project directory.
-- Directories named `server` anywhere in your project (except inside `src/routes` or the assets directory) mark _all_ code within as server-only, e.g. `src/lib/server/config.js` or `src/lib/data/server/user/profile.js`.
+- Directories named `server` anywhere in your project (except inside `src/routes` or the assets directory) mark _all_ code within as server-only, e.g. `src/lib/server/config.js` or `src/lib/data/server/user/profile.js`. (In SvelteKit 2, this only applied to the `src/lib` folder.)
+
+> [!NOTE] Modules outside your working directory and those inside `node_modules` (e.g. packages from npm) are _not_ subject to these rules. If you want to publish a package and want to mark a module as server-only, add `import '$app/server'` to the top of that file.
 
 ## How it works
 

--- a/documentation/docs/30-advanced/50-server-only-modules.md
+++ b/documentation/docs/30-advanced/50-server-only-modules.md
@@ -16,8 +16,8 @@ The [`$app/server`]($app-server) module, which contains a [`read`]($app-server#r
 
 You can make your own modules server-only in two ways:
 
-- For single modules, add `.server` to the filename, e.g. `secrets.server.js`. This works for _any_ file in the project directory, including within `#lib`.
-- Directories named `server` under `#lib`, at any depth, mark _all_ code within as server-only, e.g. `#lib/server/config.js` or `#lib/data/server/user/profile.js`.
+- For single modules, add `.server` to the filename, e.g. `secrets.server.js`. This works for _any_ file in the project directory.
+- Directories named `server` anywhere in your project (except inside `src/routes` or the assets directory) mark _all_ code within as server-only, e.g. `src/lib/server/config.js` or `src/lib/data/server/user/profile.js`.
 
 ## How it works
 

--- a/documentation/docs/30-advanced/68-observability.md
+++ b/documentation/docs/30-advanced/68-observability.md
@@ -40,17 +40,17 @@ export default defineConfig({
 SvelteKit provides access to the `root` span and the `current` span on the request event. The root span is the one associated with your root `handle` function, and the current span could be associated with `handle`, `load`, a form action, or a remote function, depending on the context. You can annotate these spans with any attributes you wish to record:
 
 ```js
-/// file: $lib/authenticate.ts
+/// file: #lib/authenticate.ts
 
 // @filename: ambient.d.ts
-declare module '$lib/auth-core' {
+declare module '#lib/auth-core' {
 	export function getAuthenticatedUser(): Promise<{ id: string }>
 }
 
 // @filename: index.js
 // ---cut---
 import { getRequestEvent } from '$app/server';
-import { getAuthenticatedUser } from '$lib/auth-core';
+import { getAuthenticatedUser } from '#lib/auth-core';
 
 async function authenticate() {
 	const user = await getAuthenticatedUser();

--- a/documentation/docs/40-best-practices/07-images.md
+++ b/documentation/docs/40-best-practices/07-images.md
@@ -16,7 +16,7 @@ Doing this manually is tedious. There are a variety of techniques you can use, d
 
 ```svelte
 <script>
-	import logo from '$lib/assets/logo.png';
+	import logo from '#lib/assets/logo.png';
 </script>
 
 <img alt="The project logo" src={logo} />

--- a/documentation/docs/60-appendix/40-migrating.md
+++ b/documentation/docs/60-appendix/40-migrating.md
@@ -89,7 +89,7 @@ The `goto`, `prefetch` and `prefetchRoutes` imports from `@sapper/app` should be
 
 The `stores` import from `@sapper/app` should be replaced — see the [Stores](migrating#Pages-and-layouts-Stores) section below.
 
-Any files you previously imported from directories in `src/node_modules` will need to be replaced with [`$lib`]($lib) imports.
+Any files you previously imported from directories in `src/node_modules` will need to be replaced with [`#lib`]($lib) imports.
 
 ### Preload
 

--- a/documentation/docs/98-reference/26-$lib.md
+++ b/documentation/docs/98-reference/26-$lib.md
@@ -1,8 +1,21 @@
 ---
-title: $lib
+title: '#lib'
 ---
 
-SvelteKit automatically makes files under `src/lib` available using the `$lib` import alias.
+When scaffolding a new SvelteKit project through the [`sv` CLI](/docs/cli/overview), it automatically creates a `#lib` import alias for your `src/lib` directory, by adding the following to your `package.json`:
+
+```json
+{
+	"imports": {
+		"#lib": "./src/lib/index.js",
+		"#lib/*": "./src/lib/*"
+	}
+}
+```
+
+The `#` prefix leverages Node's built-in [subpath imports](https://nodejs.org/api/packages.html#subpath-imports) feature, which reserves `#` for package-internal aliases. Vite and TypeScript both resolve these natively.
+
+> [!NOTE] Previously, this alias was `$lib` and was automatically configured by SvelteKit. It is now `#lib` and must be declared in your `package.json` `imports` field. `import { foo } from '$lib/foo.js'` becomes `import { foo } from '#lib/foo.js'`.
 
 ```svelte
 <!--- file: src/lib/Component.svelte --->
@@ -12,7 +25,7 @@ A reusable component
 ```svelte
 <!--- file: src/routes/+page.svelte --->
 <script>
-	import Component from '$lib/Component.svelte';
+	import Component from '#lib/Component.svelte';
 </script>
 
 <Component />

--- a/documentation/docs/98-reference/26-$lib.md
+++ b/documentation/docs/98-reference/26-$lib.md
@@ -15,7 +15,8 @@ When scaffolding a new SvelteKit project through the [`sv` CLI](/docs/cli/overvi
 
 The `#` prefix leverages Node's built-in [subpath imports](https://nodejs.org/api/packages.html#subpath-imports) feature, which reserves `#` for package-internal aliases. Vite and TypeScript both resolve these natively.
 
-> [!NOTE] Previously, this alias was `$lib` and was automatically configured by SvelteKit. It is now `#lib` and must be declared in your `package.json` `imports` field. `import { foo } from '$lib/foo.js'` becomes `import { foo } from '#lib/foo.js'`.
+> [!LEGACY]
+> Previously, this alias was `$lib` and was automatically configured by SvelteKit. It is now `#lib` and must be declared in your `package.json` `imports` field. `import { foo } from '$lib/foo.js'` becomes `import { foo } from '#lib/foo.js'`.
 
 ```svelte
 <!--- file: src/lib/Component.svelte --->

--- a/documentation/docs/98-reference/54-types.md
+++ b/documentation/docs/98-reference/54-types.md
@@ -194,14 +194,6 @@ Others are required for SvelteKit to work properly, and should also be left unto
 
 Use the [`typescript.config` setting](configuration#typescript) of the SvelteKit plugin in `vite.config.js` to extend or modify the generated `tsconfig.json`.
 
-## #lib
-
-This is a simple alias to `src/lib`, configured via the [`imports`](https://nodejs.org/api/packages.html#subpath-imports) field in your `package.json`. It allows you to access common components and utility modules without `../../../../` nonsense.
-
-### #lib/server
-
-A subdirectory of `#lib`. SvelteKit will prevent you from importing any modules in `#lib/server` into client-side code. See [server-only modules](server-only-modules).
-
 ## app.d.ts
 
 The `app.d.ts` file is home to the ambient types of your apps, i.e. types that are available without explicitly importing them.

--- a/documentation/docs/98-reference/54-types.md
+++ b/documentation/docs/98-reference/54-types.md
@@ -132,8 +132,8 @@ The generated `.svelte-kit/tsconfig.json` file contains a mixture of options. So
 {
 	"compilerOptions": {
 		"paths": {
-			"$lib": ["../src/lib"],
-			"$lib/*": ["../src/lib/*"]
+			"#lib": ["../src/lib/index.js"],
+			"#lib/*": ["../src/lib/*"]
 		},
 		"rootDirs": ["..", "./types"]
 	},
@@ -194,13 +194,13 @@ Others are required for SvelteKit to work properly, and should also be left unto
 
 Use the [`typescript.config` setting](configuration#typescript) of the SvelteKit plugin in `vite.config.js` to extend or modify the generated `tsconfig.json`.
 
-## $lib
+## #lib
 
-This is a simple alias to `src/lib`. It allows you to access common components and utility modules without `../../../../` nonsense.
+This is a simple alias to `src/lib`, configured via the [`imports`](https://nodejs.org/api/packages.html#subpath-imports) field in your `package.json`. It allows you to access common components and utility modules without `../../../../` nonsense.
 
-### $lib/server
+### #lib/server
 
-A subdirectory of `$lib`. SvelteKit will prevent you from importing any modules in `$lib/server` into client-side code. See [server-only modules](server-only-modules).
+A subdirectory of `#lib`. SvelteKit will prevent you from importing any modules in `#lib/server` into client-side code. See [server-only modules](server-only-modules).
 
 ## app.d.ts
 

--- a/packages/adapter-cloudflare/utils.spec.js
+++ b/packages/adapter-cloudflare/utils.spec.js
@@ -251,7 +251,6 @@ describe('_routes.json', () => {
 								server: 'src/hooks.server.js',
 								universal: 'src/hooks.js'
 							},
-							lib: 'src/lib',
 							params: 'src/params',
 							routes: 'src/routes',
 							serviceWorker: 'src/service-worker.js',
@@ -330,7 +329,6 @@ describe('_routes.json', () => {
 								server: 'src/hooks.server.js',
 								universal: 'src/hooks.js'
 							},
-							lib: 'src/lib',
 							params: 'src/params',
 							routes: 'src/routes',
 							serviceWorker: 'src/service-worker.js',

--- a/packages/enhanced-img/test/Input.svelte
+++ b/packages/enhanced-img/test/Input.svelte
@@ -39,7 +39,7 @@
 	alt="event handler test"
 />
 
-<enhanced:img src="$lib/dev.png" alt="alias test" />
+<enhanced:img src="#lib/dev.png" alt="alias test" />
 
 <enhanced:img src="/src/dev.png" alt="absolute path test" />
 

--- a/packages/enhanced-img/types/index.d.ts
+++ b/packages/enhanced-img/types/index.d.ts
@@ -11,13 +11,13 @@ export type EnhancedImgAttributes = Omit<HTMLImgAttributes, 'src'> & {
 	 * for use with `<enhanced:img>`, the `src` must be a `Picture` object created with `?enhanced`, rather than a string:
 	 *
 	 * ```js
-	 * import hero from '$lib/assets/hero.jpg?enhanced';
+	 * import hero from '#lib/assets/hero.jpg?enhanced';
 	 * ```
 	 *
 	 * Note that this object is created automatically if you use `<enhanced:img>` directly:
 	 *
 	 * ```svelte
-	 * <enhanced:img src="$lib/assets/hero.jpg" alt="..." />
+	 * <enhanced:img src="#lib/assets/hero.jpg" alt="..." />
 	 * ```
 	 */
 	src: Picture;
@@ -31,14 +31,14 @@ declare module 'svelte/elements' {
 			 * If the `src` is a string, it will be treated as an asset import relative to the current module:
 			 *
 			 * ```svelte
-			 * <enhanced:img src="$lib/assets/hero.jpg" alt="..." />
+			 * <enhanced:img src="#lib/assets/hero.jpg" alt="..." />
 			 * ```
 			 *
 			 * When [dynamically choosing an image](https://svelte.dev/docs/kit/images#sveltejs-enhanced-img-Dynamically-choosing-an-image)
 			 * (i.e. `src={...}`) it must be a `Picture` object created with `?enhanced`:
 			 *
 			 * ```js
-			 * import hero from '$lib/assets/hero.jpg?enhanced';
+			 * import hero from '#lib/assets/hero.jpg?enhanced';
 			 * ```
 			 */
 			src: string | Picture;

--- a/packages/kit/src/core/config/index.js
+++ b/packages/kit/src/core/config/index.js
@@ -191,7 +191,6 @@ export function validate_config(config) {
 		files.hooks.client ??= path.join(files.src, 'hooks.client');
 		files.hooks.server ??= path.join(files.src, 'hooks.server');
 		files.hooks.universal ??= path.join(files.src, 'hooks');
-		files.lib ??= path.join(files.src, 'lib');
 		files.params ??= path.join(files.src, 'params');
 		files.routes ??= path.join(files.src, 'routes');
 		files.serviceWorker ??= path.join(files.src, 'service-worker');

--- a/packages/kit/src/core/config/index.js
+++ b/packages/kit/src/core/config/index.js
@@ -161,7 +161,7 @@ export function process_config(config, cwd) {
 			config.kit.files.hooks.client = path.resolve(cwd, config.kit.files.hooks.client);
 			config.kit.files.hooks.server = path.resolve(cwd, config.kit.files.hooks.server);
 			config.kit.files.hooks.universal = path.resolve(cwd, config.kit.files.hooks.universal);
-		} else {
+		} else if (key !== 'lib' /* TODO remove when we remove the `lib` option altogether */) {
 			// @ts-expect-error
 			config.kit.files[key] = path.resolve(cwd, config.kit.files[key]);
 		}

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -81,7 +81,6 @@ const get_defaults = (prefix = '') => ({
 				server: join(prefix, 'src/hooks.server'),
 				universal: join(prefix, 'src/hooks')
 			},
-			lib: join(prefix, 'src/lib'),
 			params: join(prefix, 'src/params'),
 			routes: join(prefix, 'src/routes'),
 			serviceWorker: join(prefix, 'src/service-worker'),

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -140,7 +140,6 @@ export const validate_kit_options = object({
 			server: string(null),
 			universal: string(null)
 		}),
-		lib: string(null),
 		params: string(null),
 		routes: string(null),
 		serviceWorker: string(null),

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -140,6 +140,10 @@ export const validate_kit_options = object({
 			server: string(null),
 			universal: string(null)
 		}),
+		lib: removed(
+			(keypath) =>
+				`\`${keypath}\` has been removed. Use #lib instead of $lib: https://svelte.dev/docs/kit/$lib`
+		),
 		params: string(null),
 		routes: string(null),
 		serviceWorker: string(null),

--- a/packages/kit/src/core/sync/write_tsconfig.js
+++ b/packages/kit/src/core/sync/write_tsconfig.js
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { styleText } from 'node:util';
 import { posixify } from '../../utils/os.js';
+import { read_package_imports, normalize_import_value } from '../../utils/imports.js';
 import { write_if_changed } from './utils.js';
 
 /**
@@ -65,7 +66,7 @@ export function get_tsconfig(kit, cwd) {
 		config_relative('vite.config.js'),
 		config_relative('vite.config.ts')
 	]);
-	const src_includes = [kit.files.routes, kit.files.lib, kit.files.src].filter((dir) => {
+	const src_includes = [kit.files.routes, kit.files.src].filter((dir) => {
 		const relative = path.relative(kit.files.src, dir);
 		return !relative || relative.startsWith('..');
 	});
@@ -198,36 +199,7 @@ const alias_regex = /^(.+?)(\/\*)?$/;
 const value_regex = /^(.*?)((\/\*)|(\.\w+))?$/;
 
 /**
- * @param {string} cwd
- * @returns {Record<string, string | Record<string, string>> | undefined}
- */
-function read_package_imports(cwd) {
-	const pkg_path = path.resolve(cwd, 'package.json');
-	if (fs.existsSync(pkg_path)) {
-		try {
-			return JSON.parse(fs.readFileSync(pkg_path, 'utf-8')).imports;
-		} catch {
-			// malformed package.json — ignore, the user will see other errors
-		}
-	}
-}
-
-/**
- * @param {string | Record<string, string>} value
- * @returns {string | null}
- */
-function normalize_import_value(value) {
-	if (typeof value === 'string') {
-		return value.replace(/^\.\//, '');
-	}
-	if (value && typeof value === 'object' && typeof value.default === 'string') {
-		return value.default.replace(/^\.\//, '');
-	}
-	return null;
-}
-
-/**
- * Generates tsconfig path aliases from kit's aliases.
+ * Generates tsconfig path aliases from kit's aliases and the package.json `imports` field.
  * Related to vite alias creation.
  *
  * @param {import('types').ValidatedKitConfig} config
@@ -245,15 +217,15 @@ function get_tsconfig_paths(config, cwd) {
 
 	const alias = { ...config.alias };
 
+	// Add all `#`-prefixed imports from package.json as path aliases
 	const imports = read_package_imports(cwd);
 	if (imports) {
-		const lib = normalize_import_value(imports['#lib']);
-		if (lib) {
-			alias['#lib'] = lib;
-		}
-		const lib_star = normalize_import_value(imports['#lib/*']);
-		if (lib_star) {
-			alias['#lib/*'] = lib_star;
+		for (const [key, raw_value] of Object.entries(imports)) {
+			if (!key.startsWith('#')) continue;
+			const value = normalize_import_value(raw_value);
+			if (value) {
+				alias[key] = value;
+			}
 		}
 	}
 

--- a/packages/kit/src/core/sync/write_tsconfig.js
+++ b/packages/kit/src/core/sync/write_tsconfig.js
@@ -198,6 +198,35 @@ const alias_regex = /^(.+?)(\/\*)?$/;
 const value_regex = /^(.*?)((\/\*)|(\.\w+))?$/;
 
 /**
+ * @param {string} cwd
+ * @returns {Record<string, string | Record<string, string>> | undefined}
+ */
+function read_package_imports(cwd) {
+	const pkg_path = path.resolve(cwd, 'package.json');
+	if (fs.existsSync(pkg_path)) {
+		try {
+			return JSON.parse(fs.readFileSync(pkg_path, 'utf-8')).imports;
+		} catch {
+			// malformed package.json — ignore, the user will see other errors
+		}
+	}
+}
+
+/**
+ * @param {string | Record<string, string>} value
+ * @returns {string | null}
+ */
+function normalize_import_value(value) {
+	if (typeof value === 'string') {
+		return value.replace(/^\.\//, '');
+	}
+	if (value && typeof value === 'object' && typeof value.default === 'string') {
+		return value.default.replace(/^\.\//, '');
+	}
+	return null;
+}
+
+/**
  * Generates tsconfig path aliases from kit's aliases.
  * Related to vite alias creation.
  *
@@ -215,8 +244,17 @@ function get_tsconfig_paths(config, cwd) {
 	};
 
 	const alias = { ...config.alias };
-	if (fs.existsSync(project_relative(cwd, config.files.lib))) {
-		alias['$lib'] = project_relative(cwd, config.files.lib);
+
+	const imports = read_package_imports(cwd);
+	if (imports) {
+		const lib = normalize_import_value(imports['#lib']);
+		if (lib) {
+			alias['#lib'] = lib;
+		}
+		const lib_star = normalize_import_value(imports['#lib/*']);
+		if (lib_star) {
+			alias['#lib/*'] = lib_star;
+		}
 	}
 
 	/** @type {Record<string, string[]>} */

--- a/packages/kit/src/core/sync/write_tsconfig.spec.js
+++ b/packages/kit/src/core/sync/write_tsconfig.spec.js
@@ -15,10 +15,11 @@ test('Creates tsconfig path aliases from kit.alias', () => {
 		}
 	});
 
-	const { compilerOptions } = get_tsconfig(kit, '.');
+	// Use a cwd without a package.json so no `#`-prefixed imports are picked up
+	const { compilerOptions } = get_tsconfig(kit, import.meta.dirname);
 
-	// #lib isn't part of the outcome because the package.json at the test cwd
-	// doesn't have a #lib entry in its imports field
+	// No `#`-prefixed path aliases because the package.json at the test cwd
+	// doesn't have an `imports` field
 	expect(compilerOptions.paths).toEqual({
 		'$app/types': ['./types/index.d.ts'],
 		simpleKey: ['../simple/value'],
@@ -28,6 +29,19 @@ test('Creates tsconfig path aliases from kit.alias', () => {
 		keyToFile: ['../path/to/file.ts'],
 		$routes: ['./types/src/routes'],
 		'$routes/*': ['./types/src/routes/*']
+	});
+});
+
+test('Creates tsconfig path aliases from package.json import map', () => {
+	const { kit } = validate_config({});
+	const { compilerOptions } = get_tsconfig(kit, import.meta.dirname + '/write_tsconfig_test');
+
+	// No `#`-prefixed path aliases because the package.json at the test cwd
+	// doesn't have an `imports` field
+	expect(compilerOptions.paths).toEqual({
+		'$app/types': ['./types/index.d.ts'],
+		'#lib': ['../src/lib'],
+		'#lib/*': ['../src/lib/*']
 	});
 });
 
@@ -70,7 +84,7 @@ test('Creates tsconfig include from kit.files', () => {
 	const { kit } = validate_config({
 		kit: {
 			files: {
-				lib: 'app'
+				routes: 'app'
 			}
 		}
 	});

--- a/packages/kit/src/core/sync/write_tsconfig.spec.js
+++ b/packages/kit/src/core/sync/write_tsconfig.spec.js
@@ -17,8 +17,8 @@ test('Creates tsconfig path aliases from kit.alias', () => {
 
 	const { compilerOptions } = get_tsconfig(kit, '.');
 
-	// $lib isn't part of the outcome because there's a "path exists"
-	// check in the implementation
+	// #lib isn't part of the outcome because the package.json at the test cwd
+	// doesn't have a #lib entry in its imports field
 	expect(compilerOptions.paths).toEqual({
 		'$app/types': ['./types/index.d.ts'],
 		simpleKey: ['../simple/value'],

--- a/packages/kit/src/core/sync/write_tsconfig_test/package.json
+++ b/packages/kit/src/core/sync/write_tsconfig_test/package.json
@@ -1,0 +1,7 @@
+{
+	"private": true,
+	"imports": {
+		"#lib": "./src/lib",
+		"#lib/*": "./src/lib/*"
+	}
+}

--- a/packages/kit/src/exports/index.js
+++ b/packages/kit/src/exports/index.js
@@ -234,7 +234,7 @@ export function isActionFailure(e) {
  * ```ts
  * import { invalid } from '@sveltejs/kit';
  * import { form } from '$app/server';
- * import { tryLogin } from '$lib/server/auth';
+ * import { tryLogin } from '#lib/server/auth';
  * import * as v from 'valibot';
  *
  * export const login = form(

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -551,12 +551,6 @@ export interface KitConfig {
 			universal?: string;
 		};
 		/**
-		 * Your app's internal library, accessible throughout the codebase as `#lib` (configured via the `imports` field in your `package.json`).
-		 * @deprecated this feature is still supported, but it's generally recommended to use [monorepos](https://levelup.video/tutorials/monorepos-with-pnpm) instead
-		 * @default "src/lib"
-		 */
-		lib?: string;
-		/**
 		 * A directory containing [parameter matchers](https://svelte.dev/docs/kit/advanced-routing#Matching).
 		 * @deprecated this feature is still supported, but it's generally recommended to use [monorepos](https://levelup.video/tutorials/monorepos-with-pnpm) instead
 		 * @default "src/params"

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -551,7 +551,7 @@ export interface KitConfig {
 			universal?: string;
 		};
 		/**
-		 * Your app's internal library, accessible throughout the codebase as `$lib`.
+		 * Your app's internal library, accessible throughout the codebase as `#lib` (configured via the `imports` field in your `package.json`).
 		 * @deprecated this feature is still supported, but it's generally recommended to use [monorepos](https://levelup.video/tutorials/monorepos-with-pnpm) instead
 		 * @default "src/lib"
 		 */

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -97,7 +97,6 @@ const enforced_config = {
 	resolve: {
 		alias: {
 			$app: true,
-			$lib: true,
 			'$service-worker': true
 		}
 	}
@@ -678,7 +677,7 @@ function kit({ svelte_config }) {
 
 	/**
 	 * Ensures that client-side code can't accidentally import server-side code,
-	 * whether in `*.server.js` files, `$app/server`, `$lib/server`, or `$app/env/private`
+	 * whether in `*.server.js` files, `$app/server`, `#lib/server`, or `$app/env/private`
 	 * @type {Plugin}
 	 */
 	const plugin_guard = {
@@ -740,7 +739,7 @@ function kit({ svelte_config }) {
 				const is_server_only =
 					normalized === '$app/env/private' ||
 					normalized === '$app/server' ||
-					(normalized.startsWith('$lib/') && server_only_directory_pattern.test(id)) ||
+					(normalized.startsWith('#lib/') && server_only_directory_pattern.test(id)) ||
 					(is_internal && server_only_module_pattern.test(id));
 
 				if (!is_server_only) return;

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -43,6 +43,7 @@ import analyse from '../../core/postbuild/analyse.js';
 import { s } from '../../utils/misc.js';
 import { hash } from '../../utils/hash.js';
 import { dedent } from '../../core/sync/utils.js';
+import { get_import_aliases, get_hash_import_keys } from '../../utils/imports.js';
 import {
 	app_env_private,
 	app_server,
@@ -302,10 +303,14 @@ function kit({ svelte_config }) {
 
 	/** @type {string} */
 	let normalized_cwd;
-	/** @type {string} */
-	let normalized_lib;
+	/** @type {Array<{ alias: string, path: string }>} */
+	let normalized_aliases;
 	/** @type {string} */
 	let normalized_node_modules;
+	/** @type {string} */
+	let normalized_routes;
+	/** @type {string} */
+	let normalized_assets;
 	/**
 	 * A map showing which features (such as `$app/server:read`) are defined
 	 * in which chunks, so that we can later determine which routes use which features
@@ -351,11 +356,21 @@ function kit({ svelte_config }) {
 				vite = await import_peer('vite', root);
 
 				normalized_cwd = vite.normalizePath(root);
-				normalized_lib = vite.normalizePath(kit.files.lib);
+				normalized_aliases = get_import_aliases(root, vite.normalizePath.bind(vite));
 				normalized_node_modules = vite.normalizePath(path.resolve(root, 'node_modules'));
+				normalized_routes = vite.normalizePath(path.resolve(root, kit.files.routes));
+				normalized_assets = vite.normalizePath(path.resolve(root, kit.files.assets));
+
+				// Add `#`-prefixed import keys to the enforced config so users are warned
+				// if they try to set them in their Vite config's resolve.alias
+				const enforced_alias = /** @type {Record<string, true>} */ (
+					/** @type {any} */ (enforced_config.resolve).alias
+				);
+				for (const key of get_hash_import_keys(root)) {
+					enforced_alias[key] = true;
+				}
 
 				const allow = new Set([
-					kit.files.lib,
 					kit.files.routes,
 					kit.files.src,
 					kit.outDir,
@@ -370,6 +385,11 @@ function kit({ svelte_config }) {
 					// see https://vite.dev/guide/api-javascript#searchforworkspaceroot
 					path.resolve(vite.searchForWorkspaceRoot(process.cwd()), 'node_modules')
 				]);
+
+				// Add directories from `#`-prefixed package.json imports to the allow list
+				for (const { path: alias_path } of normalized_aliases) {
+					allow.add(alias_path);
+				}
 
 				// We can only add directories to the allow list, so we find out
 				// if there's a client hooks file and pass its directory
@@ -677,7 +697,7 @@ function kit({ svelte_config }) {
 
 	/**
 	 * Ensures that client-side code can't accidentally import server-side code,
-	 * whether in `*.server.js` files, `$app/server`, `#lib/server`, or `$app/env/private`
+	 * whether in `*.server.js` files, `$app/server`, any `/server/` directory, or `$app/env/private`
 	 * @type {Plugin}
 	 */
 	const plugin_guard = {
@@ -703,7 +723,7 @@ function kit({ svelte_config }) {
 					const resolved = await this.resolve(id, importer, { ...options, skipSelf: true });
 
 					if (resolved) {
-						const normalized = normalize_id(resolved.id, normalized_lib, normalized_cwd);
+						const normalized = normalize_id(resolved.id, normalized_aliases, normalized_cwd);
 
 						let importers = import_map.get(normalized);
 
@@ -712,7 +732,7 @@ function kit({ svelte_config }) {
 							import_map.set(normalized, importers);
 						}
 
-						importers.add(normalize_id(importer, normalized_lib, normalized_cwd));
+						importers.add(normalize_id(importer, normalized_aliases, normalized_cwd));
 					}
 				}
 			}
@@ -734,12 +754,19 @@ function kit({ svelte_config }) {
 				const is_internal =
 					id.startsWith(normalized_cwd) && !id.startsWith(normalized_node_modules);
 
-				const normalized = normalize_id(id, normalized_lib, normalized_cwd);
+				const normalized = normalize_id(id, normalized_aliases, normalized_cwd);
+
+				// server-only directories: any file in a `/server/` folder inside the cwd,
+				// except those inside the routes or assets directories
+				const is_in_routes = id.startsWith(normalized_routes + '/');
+				const is_in_assets = id.startsWith(normalized_assets + '/');
+				const is_server_only_directory =
+					is_internal && !is_in_routes && !is_in_assets && server_only_directory_pattern.test(id);
 
 				const is_server_only =
 					normalized === '$app/env/private' ||
 					normalized === '$app/server' ||
-					(normalized.startsWith('#lib/') && server_only_directory_pattern.test(id)) ||
+					is_server_only_directory ||
 					(is_internal && server_only_module_pattern.test(id));
 
 				if (!is_server_only) return;
@@ -862,7 +889,7 @@ function kit({ svelte_config }) {
 		},
 
 		async transform(code, id) {
-			const normalized = normalize_id(id, normalized_lib, normalized_cwd);
+			const normalized = normalize_id(id, normalized_aliases, normalized_cwd);
 			if (!svelte_config.kit.moduleExtensions.some((ext) => normalized.endsWith(`.remote${ext}`))) {
 				return;
 			}
@@ -1083,7 +1110,7 @@ function kit({ svelte_config }) {
 					throw new Error(
 						`Cannot import ${normalize_id(
 							id,
-							normalized_lib,
+							normalized_aliases,
 							normalized_cwd
 						)} into service-worker code. Only the modules $service-worker and $app/env/public are available in service workers.`
 					);
@@ -1177,9 +1204,12 @@ function kit({ svelte_config }) {
 					);
 				}
 
-				const normalized_cwd = vite.normalizePath(vite_config.root);
-				const normalized_lib = vite.normalizePath(kit.files.lib);
-				const relative = normalize_id(id, normalized_lib, normalized_cwd);
+				const sw_normalized_cwd = vite.normalizePath(vite_config.root);
+				const sw_normalized_aliases = get_import_aliases(
+					vite_config.root,
+					vite.normalizePath.bind(vite)
+				);
+				const relative = normalize_id(id, sw_normalized_aliases, sw_normalized_cwd);
 				const stripped = strip_virtual_prefix(relative);
 				throw new Error(
 					`Cannot import ${stripped} into service-worker code. Only the modules $service-worker and $app/env/public are available in service workers.`

--- a/packages/kit/src/exports/vite/utils.js
+++ b/packages/kit/src/exports/vite/utils.js
@@ -21,11 +21,7 @@ import {
  */
 export function get_config_aliases(config, root) {
 	/** @type {import('vite').Alias[]} */
-	const alias = [
-		// For now, we handle `$lib` specially here rather than make it a default value for
-		// `config.alias` since it has special meaning for packaging, etc.
-		{ find: '$lib', replacement: posixify(config.files.lib) }
-	];
+	const alias = [];
 
 	for (let [key, value] of Object.entries(config.alias)) {
 		value = posixify(value);
@@ -127,7 +123,7 @@ export function normalize_id(id, lib, cwd) {
 	id = id.replace(query_pattern, '');
 
 	if (id.startsWith(lib)) {
-		id = id.replace(lib, '$lib');
+		id = id.replace(lib, '#lib');
 	}
 
 	if (id.startsWith(cwd)) {

--- a/packages/kit/src/exports/vite/utils.js
+++ b/packages/kit/src/exports/vite/utils.js
@@ -114,16 +114,20 @@ export function not_found(req, res, base) {
 const query_pattern = /\?.*$/s;
 
 /**
- * Removes cwd/lib path from the start of the id
+ * Removes cwd path from the start of the id and replaces any `#`-prefixed
+ * import alias target paths with their alias names.
  * @param {string} id
- * @param {string} lib
+ * @param {Array<{ alias: string, path: string }>} aliases — sorted by path length descending
  * @param {string} cwd
  */
-export function normalize_id(id, lib, cwd) {
+export function normalize_id(id, aliases, cwd) {
 	id = id.replace(query_pattern, '');
 
-	if (id.startsWith(lib)) {
-		id = id.replace(lib, '#lib');
+	for (const { alias, path } of aliases) {
+		if (id === path || id.startsWith(path + '/')) {
+			id = id.replace(path, alias);
+			break;
+		}
 	}
 
 	if (id.startsWith(cwd)) {

--- a/packages/kit/src/exports/vite/utils.spec.js
+++ b/packages/kit/src/exports/vite/utils.spec.js
@@ -30,7 +30,6 @@ test('transform kit.alias to resolve.alias', () => {
 	});
 
 	expect(transformed).toEqual([
-		{ find: '$lib', replacement: 'src/lib' },
 		{ find: 'simpleKey', replacement: 'simple/value' },
 		{ find: /^key$/.toString(), replacement: 'value' },
 		{ find: /^key\/(.+)$/.toString(), replacement: 'value/$1' },

--- a/packages/kit/src/types/synthetic/$lib.md
+++ b/packages/kit/src/types/synthetic/$lib.md
@@ -4,4 +4,4 @@ This is a simple alias to `src/lib`, configured via the [`imports`](https://node
 
 ### `#lib/server`
 
-A subdirectory of `#lib`. SvelteKit 2 prevented you from importing any modules in `#lib/server` into client-side code. In SvelteKit 3 _all_ files within your project in a `server` folder (except the routes and assets folder) are treated as server-only. Also see [server-only modules](https://svelte.dev/docs/kit/server-only-modules).
+A subdirectory of `#lib`. SvelteKit 2 prevented you from importing any modules in `#lib/server` into client-side code. In SvelteKit 3 _all_ files within your project in a `server` folder (except the routes and assets folder) are treated as [server-only modules](https://svelte.dev/docs/kit/server-only-modules).

--- a/packages/kit/src/types/synthetic/$lib.md
+++ b/packages/kit/src/types/synthetic/$lib.md
@@ -1,7 +1,0 @@
-This is a simple alias to `src/lib`, configured via the [`imports`](https://nodejs.org/api/packages.html#subpath-imports) field in your `package.json`. It allows you to access common components and utility modules without `../../../../` nonsense.
-
-> [!NOTE] Previously this alias was `$lib` and was configured via `kit.files.lib`. It is now `#lib` and must be declared in your `package.json` `imports` field.
-
-### `#lib/server`
-
-A subdirectory of `#lib`. SvelteKit 2 prevented you from importing any modules in `#lib/server` into client-side code. In SvelteKit 3 _all_ files within your project in a `server` folder (except the routes and assets folder) are treated as [server-only modules](https://svelte.dev/docs/kit/server-only-modules).

--- a/packages/kit/src/types/synthetic/$lib.md
+++ b/packages/kit/src/types/synthetic/$lib.md
@@ -1,7 +1,7 @@
-This is a simple alias to `src/lib`, or whatever directory is specified as [`config.files.lib`](https://svelte.dev/docs/kit/configuration#files). It allows you to access common components and utility modules without `../../../../` nonsense. The alias is configured via the [`imports`](https://nodejs.org/api/packages.html#subpath-imports) field in your `package.json`.
+This is a simple alias to `src/lib`, configured via the [`imports`](https://nodejs.org/api/packages.html#subpath-imports) field in your `package.json`. It allows you to access common components and utility modules without `../../../../` nonsense.
 
-> [!NOTE] Previously this alias was `$lib` and was automatically configured by SvelteKit. It is now `#lib` and must be declared in your `package.json` `imports` field.
+> [!NOTE] Previously this alias was `$lib` and was configured via `kit.files.lib`. It is now `#lib` and must be declared in your `package.json` `imports` field.
 
 ### `#lib/server`
 
-A subdirectory of `#lib`. SvelteKit will prevent you from importing any modules in `#lib/server` into client-side code. See [server-only modules](https://svelte.dev/docs/kit/server-only-modules).
+A subdirectory of `#lib`. SvelteKit 2 prevented you from importing any modules in `#lib/server` into client-side code. In SvelteKit 3 _all_ files within your project in a `server` folder (except the routes and assets folder) are treated as server-only. Also see [server-only modules](https://svelte.dev/docs/kit/server-only-modules).

--- a/packages/kit/src/types/synthetic/$lib.md
+++ b/packages/kit/src/types/synthetic/$lib.md
@@ -1,5 +1,7 @@
-This is a simple alias to `src/lib`, or whatever directory is specified as [`config.files.lib`](https://svelte.dev/docs/kit/configuration#files). It allows you to access common components and utility modules without `../../../../` nonsense.
+This is a simple alias to `src/lib`, or whatever directory is specified as [`config.files.lib`](https://svelte.dev/docs/kit/configuration#files). It allows you to access common components and utility modules without `../../../../` nonsense. The alias is configured via the [`imports`](https://nodejs.org/api/packages.html#subpath-imports) field in your `package.json`.
 
-### `$lib/server`
+> [!NOTE] Previously this alias was `$lib` and was automatically configured by SvelteKit. It is now `#lib` and must be declared in your `package.json` `imports` field.
 
-A subdirectory of `$lib`. SvelteKit will prevent you from importing any modules in `$lib/server` into client-side code. See [server-only modules](https://svelte.dev/docs/kit/server-only-modules).
+### `#lib/server`
+
+A subdirectory of `#lib`. SvelteKit will prevent you from importing any modules in `#lib/server` into client-side code. See [server-only modules](https://svelte.dev/docs/kit/server-only-modules).

--- a/packages/kit/src/utils/imports.js
+++ b/packages/kit/src/utils/imports.js
@@ -1,0 +1,83 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Reads the `imports` field from the package.json at the given directory.
+ * @param {string} cwd
+ * @returns {Record<string, string | Record<string, string>> | undefined}
+ */
+export function read_package_imports(cwd) {
+	const pkg_path = path.resolve(cwd, 'package.json');
+	if (fs.existsSync(pkg_path)) {
+		try {
+			return JSON.parse(fs.readFileSync(pkg_path, 'utf-8')).imports;
+		} catch {
+			// malformed package.json — ignore, the user will see other errors
+		}
+	}
+}
+
+/**
+ * Normalizes an import value to a string path, handling both string values
+ * and conditional export objects (using the `default` key).
+ * @param {string | Record<string, string>} value
+ * @returns {string | null}
+ */
+export function normalize_import_value(value) {
+	if (typeof value === 'string') {
+		return value.replace(/^\.\//, '');
+	}
+	if (value && typeof value === 'object' && typeof value.default === 'string') {
+		return value.default.replace(/^\.\//, '');
+	}
+	return null;
+}
+
+/**
+ * Returns the `#`-prefixed import keys from the package.json `imports` field.
+ * @param {string} cwd
+ * @returns {string[]}
+ */
+export function get_hash_import_keys(cwd) {
+	const imports = read_package_imports(cwd);
+	if (!imports) return [];
+	return Object.keys(imports).filter((key) => key.startsWith('#'));
+}
+
+/**
+ * Computes alias entries for `normalize_id` from the package.json `imports` field.
+ * Each entry maps a `#xx` alias to its absolute target path. Entries are sorted
+ * by path length descending so that longer/more-specific paths are matched first.
+ *
+ * @param {string} root
+ * @param {(p: string) => string} [normalize] - optional path normalizer (e.g. `vite.normalizePath`)
+ * @returns {Array<{ alias: string, path: string }>}
+ */
+export function get_import_aliases(root, normalize) {
+	const imports = read_package_imports(root);
+	if (!imports) return [];
+
+	/** @type {Array<{ alias: string, path: string }>} */
+	const aliases = [];
+
+	for (const [key, raw_value] of Object.entries(imports)) {
+		if (!key.startsWith('#')) continue;
+
+		const value = normalize_import_value(raw_value);
+		if (!value) continue;
+
+		// For `#xx/*` imports, the target directory is the value without `/*`
+		// For `#xx` imports, the target is the file itself
+		const target = value.endsWith('/*') ? value.slice(0, -2) : value;
+		if (target.includes('*')) continue; // not sure if this is even allowed in Node, anyway it's too niche/complex to support here
+		const abs = path.resolve(root, target);
+		const alias = key.endsWith('/*') ? key.slice(0, -2) : key;
+
+		aliases.push({ alias, path: normalize ? normalize(abs) : abs });
+	}
+
+	// Sort by path length descending so longer/more-specific paths match first
+	aliases.sort((a, b) => b.path.length - a.path.length);
+
+	return aliases;
+}

--- a/packages/kit/test/apps/async/package.json
+++ b/packages/kit/test/apps/async/package.json
@@ -22,5 +22,9 @@
 		"typescript": "catalog:",
 		"valibot": "catalog:",
 		"vite": "catalog:"
+	},
+	"imports": {
+		"#lib": "./src/lib/index.js",
+		"#lib/*": "./src/lib/*"
 	}
 }

--- a/packages/kit/test/apps/async/src/hooks.js
+++ b/packages/kit/test/apps/async/src/hooks.js
@@ -1,4 +1,4 @@
-import { Foo } from '$lib';
+import { Foo } from '#lib';
 
 /** @type {import("@sveltejs/kit").Transport} */
 export const transport = {

--- a/packages/kit/test/apps/async/src/routes/remote/transport/data.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/transport/data.remote.ts
@@ -1,4 +1,4 @@
 import { query } from '$app/server';
-import { Foo } from '$lib';
+import { Foo } from '#lib';
 
 export const greeting = query(() => new Foo('hello from remote function'));

--- a/packages/kit/test/apps/basics/package.json
+++ b/packages/kit/test/apps/basics/package.json
@@ -34,5 +34,9 @@
 		"vite": "catalog:",
 		"vitest": "catalog:"
 	},
+	"imports": {
+		"#lib": "./src/lib/index.js",
+		"#lib/*": "./src/lib/*"
+	},
 	"type": "module"
 }

--- a/packages/kit/test/apps/basics/src/routes/serialization-stream/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/serialization-stream/+page.server.js
@@ -1,4 +1,4 @@
-import { Foo } from '$lib';
+import { Foo } from '#lib';
 
 export const load = () => {
 	return {

--- a/packages/kit/test/apps/dev-only/package.json
+++ b/packages/kit/test/apps/dev-only/package.json
@@ -28,5 +28,8 @@
 		"typescript": "catalog:",
 		"vite": "catalog:"
 	},
+	"imports": {
+		"#lib/*": "./src/lib/*"
+	},
 	"type": "module"
 }

--- a/packages/kit/test/apps/dev-only/src/routes/illegal-imports/server-only-folder/path-top-level/+page.svelte
+++ b/packages/kit/test/apps/dev-only/src/routes/illegal-imports/server-only-folder/path-top-level/+page.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { should_explode } from '$lib/server/blah/private.js';
+	import { should_explode } from '#lib/server/blah/private.js';
 </script>
 
 <p>{should_explode}</p>

--- a/packages/kit/test/apps/dev-only/test/test.js
+++ b/packages/kit/test/apps/dev-only/test/test.js
@@ -56,10 +56,10 @@ If you're only using the import as a type, change it to \`import type\`.`);
 			wait_for_started: false
 		});
 		expect(await page.textContent('.message-body'))
-			.toBe(`Cannot import $lib/nested/server/private.js into code that runs in the browser, as this could leak sensitive information.
+			.toBe(`Cannot import #lib/nested/server/private.js into code that runs in the browser, as this could leak sensitive information.
 
  src/routes/illegal-imports/server-only-folder/relative-nested/+page.svelte imports
-  $lib/nested/server/private.js
+  #lib/nested/server/private.js
 
 If you're only using the import as a type, change it to \`import type\`.`);
 	});
@@ -71,10 +71,10 @@ If you're only using the import as a type, change it to \`import type\`.`);
 			wait_for_started: false
 		});
 		expect(await page.textContent('.message-body'))
-			.toBe(`Cannot import $lib/server/blah/private.js into code that runs in the browser, as this could leak sensitive information.
+			.toBe(`Cannot import #lib/server/blah/private.js into code that runs in the browser, as this could leak sensitive information.
 
  src/routes/illegal-imports/server-only-folder/path-top-level/+page.svelte imports
-  $lib/server/blah/private.js
+  #lib/server/blah/private.js
 
 If you're only using the import as a type, change it to \`import type\`.`);
 	});

--- a/packages/kit/test/apps/options-2/package.json
+++ b/packages/kit/test/apps/options-2/package.json
@@ -22,5 +22,9 @@
 		"valibot": "catalog:",
 		"vite": "catalog:"
 	},
+	"imports": {
+		"#lib": "./src/lib/index.js",
+		"#lib/*": "./src/lib/*"
+	},
 	"type": "module"
 }

--- a/packages/kit/test/apps/options-2/src/hooks.js
+++ b/packages/kit/test/apps/options-2/src/hooks.js
@@ -1,4 +1,4 @@
-import { Foo } from '$lib';
+import { Foo } from '#lib';
 
 /** @type {import("@sveltejs/kit").Transport} */
 export const transport = {

--- a/packages/kit/test/apps/options-2/src/routes/serialization-stream/+page.server.js
+++ b/packages/kit/test/apps/options-2/src/routes/serialization-stream/+page.server.js
@@ -1,4 +1,4 @@
-import { Foo } from '$lib';
+import { Foo } from '#lib';
 
 export const load = () => {
 	return {

--- a/packages/kit/test/apps/options-3/package.json
+++ b/packages/kit/test/apps/options-3/package.json
@@ -19,5 +19,9 @@
 		"typescript": "catalog:",
 		"vite": "catalog:"
 	},
+	"imports": {
+		"#lib": "./src/lib/index.js",
+		"#lib/*": "./src/lib/*"
+	},
 	"type": "module"
 }

--- a/packages/kit/test/apps/options-3/src/hooks.js
+++ b/packages/kit/test/apps/options-3/src/hooks.js
@@ -1,4 +1,4 @@
-import { Foo } from '$lib';
+import { Foo } from '#lib';
 
 /** @type {import("@sveltejs/kit").Transport} */
 export const transport = {

--- a/packages/kit/test/apps/options-3/src/routes/serialization-stream/+page.server.js
+++ b/packages/kit/test/apps/options-3/src/routes/serialization-stream/+page.server.js
@@ -1,4 +1,4 @@
-import { Foo } from '$lib';
+import { Foo } from '#lib';
 
 export const load = () => {
 	return {

--- a/packages/kit/test/apps/options/package.json
+++ b/packages/kit/test/apps/options/package.json
@@ -28,5 +28,8 @@
 		"vite": "catalog:",
 		"vitest": "catalog:"
 	},
+	"imports": {
+		"#lib/*": "./source/components/*"
+	},
 	"type": "module"
 }

--- a/packages/kit/test/apps/options/source/pages/+page.svelte
+++ b/packages/kit/test/apps/options/source/pages/+page.svelte
@@ -1,5 +1,5 @@
 <script>
-	import Message from '$lib/Message.svelte';
+	import Message from '#lib/Message.svelte';
 </script>
 
 <h2>We're on index.svelte</h2>

--- a/packages/kit/test/apps/options/source/pages/base/+page.svelte
+++ b/packages/kit/test/apps/options/source/pages/base/+page.svelte
@@ -1,5 +1,5 @@
 <script>
-	import SvelteLogo from '$lib/SvelteLogo.svelte';
+	import SvelteLogo from '#lib/SvelteLogo.svelte';
 
 	/** @type {import('./$types').PageData} */
 	export let data;

--- a/packages/kit/test/apps/options/source/pages/base/[slug]/+page.svelte
+++ b/packages/kit/test/apps/options/source/pages/base/[slug]/+page.svelte
@@ -1,6 +1,6 @@
 <script>
 	import { page } from '$app/state';
-	import SvelteLogo from '$lib/SvelteLogo.svelte';
+	import SvelteLogo from '#lib/SvelteLogo.svelte';
 </script>
 
 <SvelteLogo />

--- a/packages/kit/test/apps/options/source/pages/inline-style/+page.svelte
+++ b/packages/kit/test/apps/options/source/pages/inline-style/+page.svelte
@@ -1,5 +1,5 @@
 <script>
-	import SharedCSS from '$lib/SharedCSS.svelte';
+	import SharedCSS from '#lib/SharedCSS.svelte';
 	// @ts-ignore this is a vite font import so it has no side-effect types
 	import '@fontsource/libre-barcode-128-text';
 </script>

--- a/packages/kit/test/apps/options/vite.custom.config.js
+++ b/packages/kit/test/apps/options/vite.custom.config.js
@@ -28,7 +28,6 @@ const config = {
 			files: {
 				src: 'source',
 				assets: 'public',
-				lib: 'source/components',
 				routes: 'source/pages',
 				appTemplate: 'source/template.html',
 				hooks: {

--- a/packages/kit/test/apps/prerendered-app-error-pages/jsconfig.json
+++ b/packages/kit/test/apps/prerendered-app-error-pages/jsconfig.json
@@ -11,7 +11,7 @@
 		"moduleResolution": "bundler"
 	}
 	// Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias
-	// except $lib which is handled by https://svelte.dev/docs/kit/configuration#files
+	// except #lib which is handled by the package.json imports field
 	//
 	// If you want to overwrite includes/excludes, make sure to copy over the relevant includes/excludes
 	// from the referenced tsconfig.json - TypeScript does not merge them in

--- a/packages/kit/test/build-errors/apps/server-only-folder-dynamic-import/package.json
+++ b/packages/kit/test/build-errors/apps/server-only-folder-dynamic-import/package.json
@@ -18,5 +18,8 @@
 		"typescript": "catalog:",
 		"vite": "catalog:"
 	},
+	"imports": {
+		"#lib/*": "./src/lib/*"
+	},
 	"type": "module"
 }

--- a/packages/kit/test/build-errors/apps/server-only-folder-dynamic-import/src/routes/+page.svelte
+++ b/packages/kit/test/build-errors/apps/server-only-folder-dynamic-import/src/routes/+page.svelte
@@ -1,5 +1,5 @@
 <script>
-	const mod = import('$lib/blah/server/something/private.js');
+	const mod = import('#lib/blah/server/something/private.js');
 </script>
 
 {#await mod then resolved}

--- a/packages/kit/test/build-errors/apps/server-only-folder/package.json
+++ b/packages/kit/test/build-errors/apps/server-only-folder/package.json
@@ -18,5 +18,8 @@
 		"typescript": "catalog:",
 		"vite": "catalog:"
 	},
+	"imports": {
+		"#lib/*": "./src/lib/*"
+	},
 	"type": "module"
 }

--- a/packages/kit/test/build-errors/apps/server-only-folder/src/routes/+page.svelte
+++ b/packages/kit/test/build-errors/apps/server-only-folder/src/routes/+page.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { should_explode } from '$lib/blah/server/something/private.js';
+	import { should_explode } from '#lib/blah/server/something/private.js';
 </script>
 
 <p>{should_explode}</p>

--- a/packages/kit/test/build-errors/apps/server-only-module-dynamic-import/package.json
+++ b/packages/kit/test/build-errors/apps/server-only-module-dynamic-import/package.json
@@ -18,5 +18,8 @@
 		"typescript": "catalog:",
 		"vite": "catalog:"
 	},
+	"imports": {
+		"#lib/*": "./src/lib/*"
+	},
 	"type": "module"
 }

--- a/packages/kit/test/build-errors/apps/server-only-module-dynamic-import/src/routes/+page.svelte
+++ b/packages/kit/test/build-errors/apps/server-only-module-dynamic-import/src/routes/+page.svelte
@@ -1,5 +1,5 @@
 <script>
-	const mod = import('$lib/test.server.js');
+	const mod = import('#lib/test.server.js');
 </script>
 
 {#await mod then resolved}

--- a/packages/kit/test/build-errors/apps/server-only-module/package.json
+++ b/packages/kit/test/build-errors/apps/server-only-module/package.json
@@ -18,5 +18,8 @@
 		"typescript": "catalog:",
 		"vite": "catalog:"
 	},
+	"imports": {
+		"#lib/*": "./src/lib/*"
+	},
 	"type": "module"
 }

--- a/packages/kit/test/build-errors/apps/server-only-module/src/routes/+page.svelte
+++ b/packages/kit/test/build-errors/apps/server-only-module/src/routes/+page.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { should_explode } from '$lib/test.server.js';
+	import { should_explode } from '#lib/test.server.js';
 </script>
 
 <p>{should_explode}</p>

--- a/packages/kit/test/build-errors/apps/server-only-shared/package.json
+++ b/packages/kit/test/build-errors/apps/server-only-shared/package.json
@@ -18,5 +18,8 @@
 		"typescript": "catalog:",
 		"vite": "catalog:"
 	},
+	"imports": {
+		"#lib/*": "./src/lib/*"
+	},
 	"type": "module"
 }

--- a/packages/kit/test/build-errors/apps/server-only-shared/src/routes/+page.server.js
+++ b/packages/kit/test/build-errors/apps/server-only-shared/src/routes/+page.server.js
@@ -1,4 +1,4 @@
-import { secret } from '$lib/secret.server.js';
+import { secret } from '#lib/secret.server.js';
 
 // This valid server-side import exercises the "shared" import scenario:
 // the module is imported by both client and server code, so the guard's

--- a/packages/kit/test/build-errors/apps/server-only-shared/src/routes/+page.svelte
+++ b/packages/kit/test/build-errors/apps/server-only-shared/src/routes/+page.svelte
@@ -3,7 +3,7 @@
 	// The guard must still detect this client-side import and report
 	// "Cannot import ... into the browser" rather than following the
 	// server branch and throwing "An impossible situation occurred".
-	import { secret } from '$lib/secret.server.js';
+	import { secret } from '#lib/secret.server.js';
 </script>
 
 <p>{secret}</p>

--- a/packages/kit/test/build-errors/server-only.spec.js
+++ b/packages/kit/test/build-errors/server-only.spec.js
@@ -9,7 +9,7 @@ const timeout = 60_000;
 /** @type {Record<string, any>} */
 const env = { ...process.env, TEST: false };
 
-test('$lib/*.server.* is not statically importable from the client', { timeout }, () => {
+test('#lib/*.server.* is not statically importable from the client', { timeout }, () => {
 	assert.throws(
 		() =>
 			execSync('pnpm build', {
@@ -18,11 +18,11 @@ test('$lib/*.server.* is not statically importable from the client', { timeout }
 				timeout,
 				env
 			}),
-		/.*Cannot import \$lib\/test.server.js into code that runs in the browser.*/gs
+		/.*Cannot import #lib\/test.server.js into code that runs in the browser.*/gs
 	);
 });
 
-test('$lib/*.server.* is not dynamically importable from the client', { timeout }, () => {
+test('#lib/*.server.* is not dynamically importable from the client', { timeout }, () => {
 	assert.throws(
 		() =>
 			execSync('pnpm build', {
@@ -31,11 +31,11 @@ test('$lib/*.server.* is not dynamically importable from the client', { timeout 
 				timeout,
 				env
 			}),
-		/.*Cannot import \$lib\/test.server.js into code that runs in the browser.*/gs
+		/.*Cannot import #lib\/test.server.js into code that runs in the browser.*/gs
 	);
 });
 
-test('$lib/**/server/* is not statically importable from the client', { timeout }, () => {
+test('#lib/**/server/* is not statically importable from the client', { timeout }, () => {
 	assert.throws(
 		() =>
 			execSync('pnpm build', {
@@ -44,11 +44,11 @@ test('$lib/**/server/* is not statically importable from the client', { timeout 
 				timeout,
 				env
 			}),
-		/.*Cannot import \$lib\/blah\/server\/something\/private.js into code that runs in the browser.*/gs
+		/.*Cannot import #lib\/blah\/server\/something\/private.js into code that runs in the browser.*/gs
 	);
 });
 
-test('$lib/**/server/* is not dynamically importable from the client', { timeout }, () => {
+test('#lib/**/server/* is not dynamically importable from the client', { timeout }, () => {
 	assert.throws(
 		() =>
 			execSync('pnpm build', {
@@ -57,7 +57,7 @@ test('$lib/**/server/* is not dynamically importable from the client', { timeout
 				timeout,
 				env
 			}),
-		/.*Cannot import \$lib\/blah\/server\/something\/private.js into code that runs in the browser.*/gs
+		/.*Cannot import #lib\/blah\/server\/something\/private.js into code that runs in the browser.*/gs
 	);
 });
 
@@ -77,7 +77,7 @@ test(
 					timeout,
 					env
 				}),
-			/.*Cannot import \$lib\/secret.server.js into code that runs in the browser.*/gs
+			/.*Cannot import #lib\/secret.server.js into code that runs in the browser.*/gs
 		);
 	}
 );

--- a/packages/kit/test/build-errors/syntax-error.spec.js
+++ b/packages/kit/test/build-errors/syntax-error.spec.js
@@ -4,7 +4,7 @@ import path from 'node:path';
 
 const timeout = 60_000;
 
-test('$lib/*.server.* is not statically importable from the client', { timeout }, () => {
+test('#lib/*.server.* is not statically importable from the client', { timeout }, () => {
 	try {
 		execSync('pnpm build', {
 			cwd: path.join(import.meta.dirname, 'apps/syntax-error'),

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -524,7 +524,7 @@ declare module '@sveltejs/kit' {
 				universal?: string;
 			};
 			/**
-			 * Your app's internal library, accessible throughout the codebase as `$lib`.
+			 * Your app's internal library, accessible throughout the codebase as `#lib`.
 			 * @deprecated this feature is still supported, but it's generally recommended to use [monorepos](https://levelup.video/tutorials/monorepos-with-pnpm) instead
 			 * @default "src/lib"
 			 */
@@ -3045,7 +3045,7 @@ declare module '@sveltejs/kit' {
 	 * ```ts
 	 * import { invalid } from '@sveltejs/kit';
 	 * import { form } from '$app/server';
-	 * import { tryLogin } from '$lib/server/auth';
+	 * import { tryLogin } from '#lib/server/auth';
 	 * import * as v from 'valibot';
 	 *
 	 * export const login = form(

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -524,12 +524,6 @@ declare module '@sveltejs/kit' {
 				universal?: string;
 			};
 			/**
-			 * Your app's internal library, accessible throughout the codebase as `#lib`.
-			 * @deprecated this feature is still supported, but it's generally recommended to use [monorepos](https://levelup.video/tutorials/monorepos-with-pnpm) instead
-			 * @default "src/lib"
-			 */
-			lib?: string;
-			/**
 			 * A directory containing [parameter matchers](https://svelte.dev/docs/kit/advanced-routing#Matching).
 			 * @deprecated this feature is still supported, but it's generally recommended to use [monorepos](https://levelup.video/tutorials/monorepos-with-pnpm) instead
 			 * @default "src/params"

--- a/packages/package/src/index.js
+++ b/packages/package/src/index.js
@@ -218,6 +218,7 @@ function normalize_options(options) {
 	const tsconfig = options.tsconfig ? path.resolve(options.cwd, options.tsconfig) : undefined;
 
 	const alias = {
+		// We use #lib in SvelteKit 3+ but for backwards compat we still resolve $lib
 		$lib: path.resolve(options.cwd, options.config.kit?.files?.lib ?? 'src/lib'),
 		...(options.config.kit?.alias ?? {})
 	};

--- a/packages/package/src/index.js
+++ b/packages/package/src/index.js
@@ -217,11 +217,40 @@ function normalize_options(options) {
 	const extensions = options.config.extensions ?? ['.svelte'];
 	const tsconfig = options.tsconfig ? path.resolve(options.cwd, options.tsconfig) : undefined;
 
-	const alias = {
-		// We use #lib in SvelteKit 3+ but for backwards compat we still resolve $lib
-		$lib: path.resolve(options.cwd, options.config.kit?.files?.lib ?? 'src/lib'),
-		...(options.config.kit?.alias ?? {})
-	};
+	/** @type {Record<string, string>} */
+	const alias = { ...(options.config.kit?.alias ?? {}) };
+
+	// Read `#`-prefixed imports from package.json and add them as aliases
+	const pkg_path = path.resolve(options.cwd, 'package.json');
+	if (fs.existsSync(pkg_path)) {
+		try {
+			const imports = JSON.parse(fs.readFileSync(pkg_path, 'utf-8')).imports;
+			if (imports) {
+				// Add `/*` entries first (as trailing-slash keys for prefix matching)
+				for (const [key, raw_value] of Object.entries(imports)) {
+					if (key.startsWith('#') && key.endsWith('/*')) {
+						const value = normalize_import_value(raw_value);
+						if (value) {
+							// Strip the trailing /* from the value — it's a wildcard, not a literal path
+							const dir = value.endsWith('/*') ? value.slice(0, -2) : value;
+							alias[key.slice(0, -2) + '/'] = path.resolve(options.cwd, dir);
+						}
+					}
+				}
+				// Then add exact entries (for exact import matching)
+				for (const [key, raw_value] of Object.entries(imports)) {
+					if (key.startsWith('#') && !key.endsWith('/*')) {
+						const value = normalize_import_value(raw_value);
+						if (value) {
+							alias[key] = path.resolve(options.cwd, value);
+						}
+					}
+				}
+			}
+		} catch {
+			// malformed package.json — ignore
+		}
+	}
 
 	return {
 		input,
@@ -232,6 +261,20 @@ function normalize_options(options) {
 		alias,
 		tsconfig
 	};
+}
+
+/**
+ * @param {string | Record<string, string>} value
+ * @returns {string | null}
+ */
+function normalize_import_value(value) {
+	if (typeof value === 'string') {
+		return value.replace(/^\.\//, '');
+	}
+	if (value && typeof value === 'object' && typeof value.default === 'string') {
+		return value.default.replace(/^\.\//, '');
+	}
+	return null;
 }
 
 /**

--- a/packages/package/src/types.d.ts
+++ b/packages/package/src/types.d.ts
@@ -11,7 +11,9 @@ export interface Options {
 		extensions?: string[];
 		kit?: {
 			alias?: Record<string, string>;
+			/** @deprecated SvelteKit 2 had this, which we still support */
 			files?: {
+				/** @deprecated SvelteKit 2 had this, which we still support */
 				lib?: string;
 			};
 			outDir?: string;

--- a/packages/package/test/errors/no-lib-folder/tsconfig.json
+++ b/packages/package/test/errors/no-lib-folder/tsconfig.json
@@ -1,9 +1,6 @@
 {
 	"compilerOptions": {
-		"checkJs": true,
-		"paths": {
-			"$lib/*": ["./src/lib/*"]
-		}
+		"checkJs": true
 	},
 	"include": ["src/**/*.d.ts", "src/**/*.js", "src/**/*.svelte"]
 }

--- a/packages/package/test/fixtures/svelte-kit/package.json
+++ b/packages/package/test/fixtures/svelte-kit/package.json
@@ -7,6 +7,9 @@
 	"peerDependencies": {
 		"svelte": "^4.0.0"
 	},
+	"imports": {
+		"#lib/*": "./src/kitlib/*"
+	},
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",

--- a/packages/package/test/fixtures/svelte-kit/vite.config.js
+++ b/packages/package/test/fixtures/svelte-kit/vite.config.js
@@ -2,11 +2,5 @@ import { defineConfig } from 'vite';
 import { sveltekit } from '@sveltejs/kit/vite';
 
 export default defineConfig({
-	plugins: [
-		sveltekit({
-			files: {
-				lib: 'src/kitlib'
-			}
-		})
-	]
+	plugins: [sveltekit()]
 });

--- a/packages/package/test/fixtures/typescript-ts-extension-rewrites/package.json
+++ b/packages/package/test/fixtures/typescript-ts-extension-rewrites/package.json
@@ -7,6 +7,9 @@
 	"peerDependencies": {
 		"svelte": "^5.0.0"
 	},
+	"imports": {
+		"#lib/*": "./src/lib/*"
+	},
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",

--- a/packages/package/test/fixtures/typescript-ts-extension-rewrites/src/lib/Demo.svelte
+++ b/packages/package/test/fixtures/typescript-ts-extension-rewrites/src/lib/Demo.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { helper } from '$lib/helper.ts';
+	import { helper } from '#lib/helper.ts';
 	import { helper2 } from './helper2.ts';
 </script>
 

--- a/packages/package/test/fixtures/typescript-ts-extension-rewrites/src/lib/index.ts
+++ b/packages/package/test/fixtures/typescript-ts-extension-rewrites/src/lib/index.ts
@@ -1,3 +1,3 @@
-import { helper } from '$lib/helper.ts';
+import { helper } from '#lib/helper.ts';
 import { helper2 } from './helper2.ts';
 export { helper, helper2 };

--- a/packages/package/test/index.spec.js
+++ b/packages/package/test/index.spec.js
@@ -94,7 +94,7 @@ for (const dir of fs.readdirSync(join(import.meta.dirname, 'errors'))) {
 		const config = await load_config();
 		process.chdir(original_cwd);
 
-		const input = resolve(cwd, config.kit?.files?.lib ?? 'src/lib');
+		const input = resolve(cwd, 'src/lib');
 
 		try {
 			await build({ cwd, input, output, types: true, config, preserve_output: false });
@@ -164,8 +164,9 @@ test('create package with SvelteComponentTyped for backwards compatibility', asy
 	await test_make_package('svelte-3-types');
 });
 
-test('SvelteKit interop', async () => {
-	await test_make_package('svelte-kit');
+test('Custom lib folder with #lib import', async () => {
+	const cwd = join(import.meta.dirname, 'fixtures', 'svelte-kit');
+	await test_make_package('svelte-kit', { input: resolve(cwd, 'src/kitlib') });
 });
 
 test('create package with declaration map', async () => {


### PR DESCRIPTION
closes #16182

The `$lib` alias is removed from SvelteKit. You can always get it back by configuring an alias via the kit config: `alias: { '$lib': 'src/lib' }`. The node-native import map takes its place instead: After configuring it in your package.json (`"imports": { "#lib": "./src/lib/index.js", "#lib/*": "./src/lib/*" }`) you import from `#lib` instead of from `$lib`.

Implementation-wise this had a few consequences:
- all `#` paths are now transformed into tsconfig path aliases in our generated tsconfig. This preserves the extension-less imports that many probably like/expect. svelte-package will still get the appropriate TS errors of having to type the extension if `moduleResolution: 'nodenext'` is set.
- when normalizing the path in our vite plugin (which is mainly done for surfacing nicer errors) we now take into account the whole import map, instead of just `$lib`
- the `files.lib` config is removed
- because svelte-package used/recommended it, we now also transform import map paths into relative paths (e.g. when you do `import '#lib/foo.js` from within `src/lib/bar/baz.js` it becomes `import '../foo.js'`). This is because we don't touch the `package.json` and that file contains the dev-time file resolutions (`#lib -> src/lib`) instead of the dist (would have to be `#lib -> dist` to be correct after publishing)
- adjusted a whole bunch of tests and docs - hopefully got them all right
