### PR TITLE
fix: avoid resolving to client code when bundled with Wrangler

### DIFF
--- a/.changeset/jolly-adults-wave.md
+++ b/.changeset/jolly-adults-wave.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: avoid client-side code being bundled by Cloudflare Wrangler

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -92,14 +92,17 @@
 	},
 	"imports": {
 		"#app/paths": {
+			"workerd": "./src/runtime/app/paths/server.js",
 			"browser": "./src/runtime/app/paths/client.js",
 			"default": "./src/runtime/app/paths/server.js"
 		},
 		"#app/env/public": {
+			"workerd": "./src/runtime/app/env/public/server.js",
 			"browser": "./src/runtime/app/env/public/client.js",
 			"default": "./src/runtime/app/env/public/server.js"
 		},
 		"#internal": {
+			"workerd": "./src/exports/internal/server/index.js",
 			"browser": "./src/exports/internal/client.js",
 			"default": "./src/exports/internal/server/index.js"
 		}


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/16361

This PR adds the Cloudflare Workers-specific condition `workerd` to the imports list in `package.json` so that Wrangler stops resolving to the `browser` condition which exposes client-side code.

It's a quick fix that isn't needed if we land https://github.com/sveltejs/kit/pull/15627 which simply removes the `browser` condition added by the Cloudflare Vite plugin for the build. Once we use Cloudflare's Vite plugin, the builds get deployed unbundled so we don't have to worry about Wrangler rebundling with the `browser` condition like we do now.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
