### PR TITLE
fix: posixify paths on Windows

### DIFF
--- a/.changeset/rare-lions-reply.md
+++ b/.changeset/rare-lions-reply.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+fix: correctly bundle entrypoints on Windows

--- a/.github/workflows/platform-tests-node.yml
+++ b/.github/workflows/platform-tests-node.yml
@@ -24,12 +24,20 @@ env:
 jobs:
   test-basic:
     if: github.repository == 'sveltejs/kit'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [22, 24]
+        include:
+          - node-version: 22
+            os: ubuntu-latest
+          - node-version: 24
+            os: ubuntu-latest
+          - node-version: 24
+            os: windows-latest
     environment: '@sveltejs/adapter-node platform tests'
     steps:
+      - run: git config --global core.autocrlf false
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.sha || github.sha }}

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -1,5 +1,4 @@
 import { readFileSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { rolldown } from 'rolldown';
 
@@ -45,10 +44,10 @@ export default function (opts = {}) {
 			// together with the app's server code. Bundling everything in a single
 			// pass means shared modules (e.g. `SvelteKitError` from `@sveltejs/kit`)
 			// aren't duplicated. See https://github.com/sveltejs/kit/issues/15755
-			const entries = `${tmp}/entries`;
+			const entries = posixify(`${tmp}/entries`);
 			builder.copy(files, entries);
 
-			const dir_id = join(entries, 'dir.js');
+			const dir_id = `${entries}/dir.js`;
 
 			writeFileSync(
 				`${server}/manifest.js`,
@@ -155,4 +154,9 @@ export default function (opts = {}) {
 			instrumentation: () => true
 		}
 	};
+}
+
+/** @param {string} str */
+function posixify(str) {
+	return str.replace(/\\/g, '/');
 }


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/16365

This PR posixifies the paths used with Rolldown's filters so that it works on Windows

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
