### PR TITLE
docs: explain how to skip later handlers in a sequence

### DIFF
--- a/packages/kit/src/exports/hooks/sequence.js
+++ b/packages/kit/src/exports/hooks/sequence.js
@@ -73,7 +73,7 @@ import {
  * first post-processing
  * ```
  *
- * A handler cannot prevent the rest of the sequence from running. To conditionally skip the work of later handlers while still rendering the page, set a flag on `event.locals` and check it in those handlers.
+ * Calling `resolve` invokes the next handler in the sequence (or SvelteKit itself, if it is the last one). To pass data between handlers, use `event.locals`.
  *
  * @param {...Handle} handlers The chain of `handle` functions
  * @returns {Handle}

--- a/packages/kit/src/exports/hooks/sequence.js
+++ b/packages/kit/src/exports/hooks/sequence.js
@@ -73,6 +73,8 @@ import {
  * first post-processing
  * ```
  *
+ * A handler cannot prevent the rest of the sequence from running. To conditionally skip the work of later handlers while still rendering the page, set a flag on `event.locals` and check it in those handlers.
+ *
  * @param {...Handle} handlers The chain of `handle` functions
  * @returns {Handle}
  */

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -3182,7 +3182,7 @@ declare module '@sveltejs/kit/hooks' {
 	 * first post-processing
 	 * ```
 	 *
-	 * A handler cannot prevent the rest of the sequence from running. To conditionally skip the work of later handlers while still rendering the page, set a flag on `event.locals` and check it in those handlers.
+	 * Calling `resolve` invokes the next handler in the sequence (or SvelteKit itself, if it is the last one). To pass data between handlers, use `event.locals`.
 	 *
 	 * @param handlers The chain of `handle` functions
 	 * */

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -3182,6 +3182,8 @@ declare module '@sveltejs/kit/hooks' {
 	 * first post-processing
 	 * ```
 	 *
+	 * A handler cannot prevent the rest of the sequence from running. To conditionally skip the work of later handlers while still rendering the page, set a flag on `event.locals` and check it in those handlers.
+	 *
 	 * @param handlers The chain of `handle` functions
 	 * */
 	export function sequence(...handlers: Handle[]): Handle;


### PR DESCRIPTION
Documents the `event.locals` flag pattern from https://github.com/sveltejs/kit/issues/16263#issuecomment-4908777495 in the `sequence` docs, since the same question also came up in #11850.

Closes #16263
