### PR TITLE
chore: don't persist git credentials on read-only checkouts

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/node-setup
       # check prod dependencies as these would affect users
       - run: pnpm audit --prod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/node-setup
       - run: pnpm run lint
       - run: cd packages/kit && pnpm prepublishOnly && { [ "`git status --porcelain=v1`" == "" ] || (echo "Generated types have changed — please run prepublishOnly locally and commit the changes after you have reviewed them"; git diff; exit 1); }
@@ -69,6 +71,8 @@ jobs:
     steps:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/node-setup
         with:
           node-version: ${{ matrix.node-version }}
@@ -132,6 +136,8 @@ jobs:
     steps:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/node-setup
         with:
           node-version: ${{ matrix.node-version }}
@@ -163,6 +169,8 @@ jobs:
     steps:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/node-setup
       - run: pnpm playwright install chromium --no-shell
       - run: pnpm run sync-all
@@ -192,6 +200,8 @@ jobs:
     steps:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/node-setup
         with:
           node-version: ${{ matrix.node-version }}
@@ -218,6 +228,8 @@ jobs:
         node-version: [22, 24]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/node-setup
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/platform-tests-netlify.yml
+++ b/.github/workflows/platform-tests-netlify.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.sha || github.sha }}
+          persist-credentials: false
 
       - uses: ./.github/actions/netlify-deploy
         id: deploy
@@ -57,6 +58,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.sha || github.sha }}
+          persist-credentials: false
 
       - uses: ./.github/actions/netlify-deploy
         id: deploy
@@ -81,6 +83,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.sha || github.sha }}
+          persist-credentials: false
 
       - uses: ./.github/actions/netlify-deploy
         id: deploy
@@ -105,6 +108,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.sha || github.sha }}
+          persist-credentials: false
 
       - uses: ./.github/actions/netlify-deploy
         id: deploy

--- a/.github/workflows/platform-tests-node.yml
+++ b/.github/workflows/platform-tests-node.yml
@@ -41,6 +41,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.sha || github.sha }}
+          persist-credentials: false
 
       - uses: ./.github/actions/node-setup
         with:

--- a/.github/workflows/platform-tests-vercel.yml
+++ b/.github/workflows/platform-tests-vercel.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.sha || github.sha }}
+          persist-credentials: false
 
       - uses: ./.github/actions/vercel-deploy
         id: deploy


### PR DESCRIPTION
Adds `persist-credentials: false` to the 13 read-only checkouts in `ci.yml`, `audit.yml` and the platform test workflows, so the workflow token is no longer written into `.git/config` where every later step can read it. None of these jobs run an authenticated git operation after checkout. #16248 already covered the release workflow.

In #15876's review, ghostdevv [suggested these exact additions](https://github.com/sveltejs/kit/pull/15876#discussion_r3285737624) and elliott [planned to check on them in a follow-up](https://github.com/sveltejs/kit/pull/15876#discussion_r3312742207). This does the mechanical half of that so it doesn't get lost. If it makes more sense folded into a bigger hardening pass, feel free to close this one.

With this change, zizmor's `artipacked` audit flags only `autofix-lint.yml`, which keeps its credentials because it pushes a commit. The `secrets: inherit` part of #15529 is deliberately left untouched.

Addresses the `persist-credentials` half of #15529.
