### PR TITLE
fix preserve search parameters in remote form actions

### DIFF
--- a/.changeset/tidy-remote-form-search.md
+++ b/.changeset/tidy-remote-form-search.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: preserve the current URL search parameters when submitting a remote form without JavaScript

--- a/packages/kit/src/runtime/app/server/remote/form.js
+++ b/packages/kit/src/runtime/app/server/remote/form.js
@@ -146,7 +146,15 @@ export function form(validate_or_fn, maybe_fn) {
 		Object.defineProperty(instance, '__', { value: __ });
 
 		Object.defineProperty(instance, 'action', {
-			get: () => `?/remote=${__.key ? `${__.id}/${encodeURIComponent(__.key)}` : __.id}`,
+			get: () => {
+				const search = new URLSearchParams(get_request_store().event.url.search);
+				search.delete('/remote');
+
+				const query = search.toString();
+				const action_id = __.key ? `${__.id}/${encodeURIComponent(__.key)}` : __.id;
+
+				return `?${query ? `${query}&` : ''}/remote=${action_id}`;
+			},
 			enumerable: true
 		});
 

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -70,14 +70,28 @@ export function form(id) {
 	function create_instance(key) {
 		const action_id_without_key = id;
 		const action_id = id + (key != undefined ? `/${JSON.stringify(key)}` : '');
+		const action = '/remote=' + encodeURIComponent(action_id);
+
+		/** @type {string} */
+		let cached_search = '';
+		/** @type {string} */
+		let cached_query = '';
 
 		/** @returns {string} */
 		function get_action() {
-			const search = new URLSearchParams(page.url.search);
-			search.delete('/remote');
+			if (page.url.search !== cached_search) {
+				cached_search = page.url.search;
 
-			const query = search.toString();
-			return `?${query ? `${query}&` : ''}/remote=${encodeURIComponent(action_id)}`;
+				if (page.url.search) {
+					const params = new URLSearchParams(page.url.search);
+					params.delete('/remote');
+					cached_query = params.toString();
+				} else {
+					cached_query = '';
+				}
+			}
+
+			return `?${cached_query && `${cached_query}&`}${action}`;
 		}
 
 		// the output of a non-enhanced submission that resulted in this page —

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -11,6 +11,7 @@ import {
 	handle_error,
 	refreshAll
 } from '../client.js';
+import { page } from '../state.svelte.js';
 import { tick } from 'svelte';
 import { categorize_updates, remote_request } from './shared.svelte.js';
 import { createAttachmentKey } from 'svelte/attachments';
@@ -69,7 +70,15 @@ export function form(id) {
 	function create_instance(key) {
 		const action_id_without_key = id;
 		const action_id = id + (key != undefined ? `/${JSON.stringify(key)}` : '');
-		const action = '?/remote=' + encodeURIComponent(action_id);
+
+		/** @returns {string} */
+		function get_action() {
+			const search = new URLSearchParams(page.url.search);
+			search.delete('/remote');
+
+			const query = search.toString();
+			return `?${query ? `${query}&` : ''}/remote=${encodeURIComponent(action_id)}`;
+		}
 
 		// the output of a non-enhanced submission that resulted in this page —
 		// consume it so the form's state survives hydration (form outputs are
@@ -355,7 +364,10 @@ export function form(id) {
 		const instance = {};
 
 		instance.method = 'POST';
-		instance.action = action;
+		Object.defineProperty(instance, 'action', {
+			get: get_action,
+			enumerable: true
+		});
 
 		instance[createAttachmentKey()] = (/** @type {HTMLFormElement} */ form) => {
 			if (element) {

--- a/packages/kit/test/apps/async/src/routes/remote/form/[test_name]/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/[test_name]/+page.svelte
@@ -20,6 +20,8 @@
 
 <hr />
 
+<a href="?existing=value&later=updated">update URL query</a>
+
 <form data-unscoped {...set_message}>
 	{#if set_message.fields.message.issues()}
 		<p>{set_message.fields.message.issues()?.[0].message}</p>

--- a/packages/kit/test/apps/async/test/test.js
+++ b/packages/kit/test/apps/async/test/test.js
@@ -159,7 +159,7 @@ test.describe('remote functions', () => {
 	});
 
 	test('form works', async ({ page, javaScriptEnabled }) => {
-		await page.goto(`/remote/form/basic-${javaScriptEnabled}`);
+		await page.goto(`/remote/form/basic-${javaScriptEnabled}?existing=value`);
 
 		if (javaScriptEnabled) {
 			await expect(page.getByText('message.current:')).toHaveText('message.current: initial');
@@ -169,8 +169,22 @@ test.describe('remote functions', () => {
 			'set_message.submitted: false'
 		);
 
+		const form = page.locator('[data-unscoped]');
+		await expect(form).toHaveAttribute('action', /^\?existing=value&\/remote=/);
+
+		if (javaScriptEnabled) {
+			await test.step('updates the form action when the URL query changes', async () => {
+				await page.getByRole('link', { name: 'update URL query' }).click();
+				await expect(page).toHaveURL((url) => url.searchParams.get('later') === 'updated');
+				await expect(form).toHaveAttribute('action', /later=updated&\/remote=/);
+			});
+		}
+
 		await page.fill('[data-unscoped] input', 'hello');
 		await page.getByText('set message').click();
+		await test.step('preserves URL query', async () => {
+			await expect(page).toHaveURL((url) => url.searchParams.get('existing') === 'value');
+		});
 
 		if (javaScriptEnabled) {
 			await expect(page.getByText('set_message.pending:')).toHaveText('set_message.pending: 1');


### PR DESCRIPTION
closes #16363

Remote form actions were generated as `?/remote=...`, so a native form submission replaced the page's existing query string. Generate the action from the current search parameters instead, then set the internal `/remote` parameter.

This keeps user-visible parameters such as pagination when JavaScript is disabled, and keeps the client-generated action aligned with the server-generated one.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

Additional validation:
- `pnpm --dir packages/kit/test/apps/async exec playwright test test.js --grep 'form works'` (Chromium with and without JavaScript)
- `pnpm -F @sveltejs/kit prepublishOnly`

### Changesets
- [x] Added a patch changeset for `@sveltejs/kit`.

### Edits
- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
