### PR TITLE
chore: strip internal types

### DIFF
--- a/packages/adapter-cloudflare/src/worker.js
+++ b/packages/adapter-cloudflare/src/worker.js
@@ -72,9 +72,7 @@ export default {
 			is_static_asset =
 				manifest.assets.has(filename) ||
 				manifest.assets.has(filename + '/index.html') ||
-				// @ts-expect-error _ property exists on manifest but not part of public types
 				filename in manifest._.server_assets ||
-				// @ts-expect-error _ property exists on manifest but not part of public types
 				filename + '/index.html' in manifest._.server_assets;
 		}
 

--- a/packages/adapter-cloudflare/src/worker.js
+++ b/packages/adapter-cloudflare/src/worker.js
@@ -72,7 +72,9 @@ export default {
 			is_static_asset =
 				manifest.assets.has(filename) ||
 				manifest.assets.has(filename + '/index.html') ||
+				// @ts-expect-error _ property exists on manifest but not part of public types
 				filename in manifest._.server_assets ||
+				// @ts-expect-error _ property exists on manifest but not part of public types
 				filename + '/index.html' in manifest._.server_assets;
 		}
 

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -34,7 +34,7 @@
 		"@sveltejs/vite-plugin-svelte": "catalog:",
 		"@types/connect": "catalog:",
 		"@types/node": "catalog:",
-		"dts-buddy": "^0.8.1",
+		"dts-buddy": "^0.8.2",
 		"jsdom": "catalog:",
 		"rolldown": "catalog:",
 		"svelte": "catalog:",

--- a/packages/kit/scripts/generate-dts.js
+++ b/packages/kit/scripts/generate-dts.js
@@ -16,7 +16,10 @@ await createBundle({
 		'$app/state': 'src/runtime/app/state/index.js'
 	},
 	include: ['src'],
-	exclude: ['**/test/**', '**/fixtures/**', '**/*.spec.js']
+	exclude: ['**/test/**', '**/fixtures/**', '**/*.spec.js'],
+	compilerOptions: {
+		stripInternal: true
+	}
 });
 
 // dts-buddy doesn't inline imports of module declaration in ambient-private.d.ts but also doesn't include them, resulting in broken types - guard against that

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -6,7 +6,6 @@ declare module '@sveltejs/kit' {
 	import type { StandardSchemaV1 } from '@standard-schema/spec';
 	import type { Plugin } from 'vite';
 	import type { RouteId as AppRouteId, LayoutParams as AppLayoutParams, ResolvedPathname } from '$app/types';
-	import type { Component } from 'svelte';
 	// @ts-ignore this is an optional peer dependency so could be missing. Written like this so dts-buddy preserves the ts-ignore
 	type Span = import('@opentelemetry/api').Span;
 
@@ -1747,19 +1746,6 @@ declare module '@sveltejs/kit' {
 		/** Static files from `config.files.assets` and the service worker (if any). */
 		assets: Set<string>;
 		mimeTypes: Record<string, string>;
-
-		/** @internal private fields */
-		_: {
-			client: BuildData['client'];
-			nodes: SSRNodeLoader[];
-			/** hashed filename -> import to that file */
-			remotes: Record<string, () => Promise<{ default: Record<string, any> }>>;
-			routes: SSRRoute[];
-			prerendered_routes: Set<string>;
-			matchers: () => Promise<Record<string, ParamMatcher>>;
-			/** A `[file]: size` map of all assets imported by server code. */
-			server_assets: Record<string, number>;
-		};
 	}
 
 	/**
@@ -2693,9 +2679,6 @@ declare module '@sveltejs/kit' {
 		rest: boolean;
 	}
 
-	/** @default 'never' */
-	type TrailingSlash = 'never' | 'always' | 'ignore';
-
 	type DeepPartial<T> = T extends Record<PropertyKey, unknown> | unknown[]
 		? {
 				[K in keyof T]?: T[K] extends Record<PropertyKey, unknown> | unknown[]
@@ -2705,87 +2688,6 @@ declare module '@sveltejs/kit' {
 		: T | undefined;
 
 	type IsAny<T> = 0 extends 1 & T ? true : false;
-	interface Asset {
-		file: string;
-		size: number;
-		type: string | null;
-	}
-
-	interface BuildData {
-		app_dir: string;
-		app_path: string;
-		manifest_data: ManifestData;
-		out_dir: string;
-		service_worker: string | null;
-		client: {
-			/** Path to the client entry point. */
-			start: string;
-			/** Path to the generated `app.js` file that contains the client manifest. Only set in case of `bundleStrategy === 'split'`. */
-			app?: string;
-			/** JS files that the client entry point relies on. */
-			imports: string[];
-			/**
-			 * JS files that represent the entry points of the layouts/pages.
-			 * An entry is undefined if the layout/page has no component or universal file (i.e. only has a `.server.js` file).
-			 * Only set in case of `router.resolution === 'server'`.
-			 */
-			nodes?: Array<string | undefined>;
-			/**
-			 * CSS files referenced in the entry points of the layouts/pages.
-			 * An entry is undefined if the layout/page has no component or universal file (i.e. only has a `.server.js` file) or if has no CSS.
-			 * Only set in case of `router.resolution === 'server'`.
-			 */
-			css?: Array<string[] | undefined>;
-			/**
-			 * Contains the client route manifest in a form suitable for the server which is used for server-side route resolution.
-			 * Notably, it contains all routes, regardless of whether they are prerendered or not (those are missing in the optimized server route manifest).
-			 * Only set in case of `router.resolution === 'server'`.
-			 */
-			routes?: SSRClientRoute[];
-			stylesheets: string[];
-			fonts: string[];
-			/**
-			 * Whether the client uses public dynamic env vars — `$env/dynamic/public` or `$app/env/public`.
-			 */
-			uses_env_dynamic_public: boolean;
-			/** Only set in case of `bundleStrategy === 'inline'`. */
-			inline?: {
-				script: string;
-				style: string | undefined;
-			};
-		} | null;
-		server_manifest: import('vite').Manifest;
-	}
-
-	interface ManifestData {
-		/** Static files from `config.files.assets`. */
-		assets: Asset[];
-		hooks: {
-			client: string | null;
-			server: string | null;
-			universal: string | null;
-		};
-		nodes: PageNode[];
-		routes: RouteData[];
-		params: string | null;
-	}
-
-	interface PageNode {
-		depth: number;
-		/** The `+page/layout.svelte`. */
-		component?: string; // TODO supply default component if it's missing (bit of an edge case)
-		/** The `+page/layout.js/.ts`. */
-		universal?: string;
-		/** The `+page/layout.server.js/ts`. */
-		server?: string;
-		parent_id?: string;
-		parent?: PageNode;
-		/** Filled with the pages that reference this layout (if this is a layout). */
-		child_pages?: PageNode[];
-		/** The final page options for a node if it was statically analysable */
-		page_options?: PageOptions | null;
-	}
-
 	type RecursiveRequired<T> = {
 		// Recursive implementation of TypeScript's Required utility type.
 		// Will recursively continue until it reaches a primitive or Function
@@ -2794,135 +2696,6 @@ declare module '@sveltejs/kit' {
 			? RecursiveRequired<T[K]> // recursively continue through.
 			: T[K]; // Use the exact type for everything else
 	};
-
-	interface RouteParam {
-		name: string;
-		matcher: string;
-		optional: boolean;
-		rest: boolean;
-		chained: boolean;
-	}
-
-	/**
-	 * Represents a route segment in the app. It can either be an intermediate node
-	 * with only layout/error pages, or a leaf, at which point either `page` and `leaf`
-	 * or `endpoint` is set.
-	 */
-	interface RouteData {
-		id: string;
-		parent: RouteData | null;
-
-		segment: string;
-		pattern: RegExp;
-		params: RouteParam[];
-
-		layout: PageNode | null;
-		error: PageNode | null;
-		leaf: PageNode | null;
-
-		page: {
-			layouts: Array<number | undefined>;
-			errors: Array<number | undefined>;
-			leaf: number;
-		} | null;
-
-		endpoint: {
-			file: string;
-			/** The final page options for the endpoint if it was statically analysable */
-			page_options: PageOptions | null;
-		} | null;
-	}
-
-	type SSRComponentLoader = () => Promise<Component>;
-
-	interface UniversalNode {
-		/** Is `null` in case static analysis succeeds but the node is ssr=false */
-		load?: Load;
-		prerender?: PrerenderOption;
-		ssr?: boolean;
-		csr?: boolean;
-		trailingSlash?: TrailingSlash;
-		config?: any;
-		entries?: PrerenderEntryGenerator;
-	}
-
-	interface ServerNode {
-		load?: ServerLoad;
-		prerender?: PrerenderOption;
-		ssr?: boolean;
-		csr?: boolean;
-		trailingSlash?: TrailingSlash;
-		actions?: Actions;
-		config?: any;
-		entries?: PrerenderEntryGenerator;
-	}
-
-	interface SSRNode {
-		/** index into the `nodes` array in the generated `client/app.js`. */
-		index: number;
-		/** external JS files that are loaded on the client. `imports[0]` is the entry point (e.g. `client/nodes/0.js`) */
-		imports: string[];
-		/** external CSS files that are loaded on the client */
-		stylesheets: string[];
-		/** external font files that are loaded on the client */
-		fonts: string[];
-
-		universal_id?: string;
-		server_id?: string;
-
-		/**
-		 * During development, all styles are inlined for the page to avoid FOUC.
-		 * But in production, this stores styles that are below the inline threshold.
-		 * It returns a Promise during development because Vite needs to load the
-		 * modules on demand. But in production, the contents have been precomputed
-		 * during the build, so it can return synchronously.
-		 */
-		inline_styles?(): MaybePromise<
-			Record<string, string | ((assets: string, base: string) => string)>
-		>;
-		/** Svelte component */
-		component?: SSRComponentLoader;
-		/** +page.js or +layout.js */
-		universal?: UniversalNode;
-		/** +page.server.js, +layout.server.js, or +server.js */
-		server?: ServerNode;
-	}
-
-	type SSRNodeLoader = () => Promise<SSRNode>;
-
-	interface PageNodeIndexes {
-		errors: Array<number | undefined>;
-		layouts: Array<number | undefined>;
-		leaf: number;
-	}
-
-	type PrerenderEntryGenerator = () => MaybePromise<Array<Record<string, string>>>;
-
-	type SSREndpoint = Partial<Record<HttpMethod, RequestHandler>> & {
-		prerender?: PrerenderOption;
-		trailingSlash?: TrailingSlash;
-		config?: any;
-		entries?: PrerenderEntryGenerator;
-		fallback?: RequestHandler;
-	};
-
-	interface SSRRoute {
-		id: string;
-		pattern: RegExp;
-		params: RouteParam[];
-		page: PageNodeIndexes | null;
-		endpoint: (() => Promise<SSREndpoint>) | null;
-		endpoint_id?: string;
-	}
-
-	interface SSRClientRoute {
-		id: string;
-		pattern: RegExp;
-		params: RouteParam[];
-		errors: Array<number | undefined>;
-		layouts: Array<[has_server_load: boolean, node_id: number] | undefined>;
-		leaf: [has_server_load: boolean, node_id: number];
-	}
 
 	type ValidatedConfig = Omit<Config, 'kit'> & {
 		kit: ValidatedKitConfig;
@@ -3084,19 +2857,7 @@ declare module '@sveltejs/kit' {
 		wasNormalized: boolean;
 		denormalize: (url?: string | URL) => URL;
 	};
-	type ValidPageOption = (typeof valid_page_options_array)[number];
-
-	type PageOptions = Partial<{
-		[K in ValidPageOption]: K extends 'ssr' | 'csr'
-			? boolean
-			: K extends 'prerender'
-				? PrerenderOption
-				: K extends 'trailingSlash'
-					? TrailingSlash
-					: any;
-	}>;
 	export const VERSION: string;
-	const valid_page_options_array: readonly ["ssr", "prerender", "csr", "trailingSlash", "config", "entries", "load"];
 
 	export {};
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -567,8 +567,8 @@ importers:
         specifier: 'catalog:'
         version: 22.19.19
       dts-buddy:
-        specifier: ^0.8.1
-        version: 0.8.1(typescript@6.0.3)
+        specifier: ^0.8.2
+        version: 0.8.2(typescript@6.0.3)
       jsdom:
         specifier: 'catalog:'
         version: 29.1.1
@@ -3116,8 +3116,8 @@ packages:
   dropcss@1.0.16:
     resolution: {integrity: sha512-QgA6BUh2SoBYE/dSuMmeGhNdoGtGewt3Rn66xKyXoGNyjrKRXf163wuM+xeQ83p87l/3ALoB6Il1dgKyGS5pEw==}
 
-  dts-buddy@0.8.1:
-    resolution: {integrity: sha512-bJ+/wrJxcZwhuaB3IopMcCp0heZ55gRiyd3tKG5GhKm1EKLhaPzk3NyLcuOACyYoTMF1sVKbKU72gh1U276DUQ==}
+  dts-buddy@0.8.2:
+    resolution: {integrity: sha512-JwMQPNGhHwXBv9p0Uu5sKGO0EKb15CQbYZ7z4CvCFPX3MyosvhkGDyse6pAGpbtu4txPK3FoxoHy7MLBbEwQug==}
     hasBin: true
     peerDependencies:
       typescript: ^5.0.4 || ^6.0.0
@@ -5717,7 +5717,7 @@ snapshots:
 
   dropcss@1.0.16: {}
 
-  dts-buddy@0.8.1(typescript@6.0.3):
+  dts-buddy@0.8.2(typescript@6.0.3):
     dependencies:
       '@jridgewell/source-map': 0.3.6
       '@jridgewell/sourcemap-codec': 1.5.5


### PR DESCRIPTION
no user-observable effect (unless someone was using the private `manifest._` property, in which case no sympathy) so no changeset