### PR TITLE
chore: don't reference `manifest._.server_assets` in Cloudflare adapter

### DIFF
--- a/packages/adapter-cloudflare/src/worker.js
+++ b/packages/adapter-cloudflare/src/worker.js
@@ -70,10 +70,7 @@ export default {
 		const filename = stripped_pathname.slice(base_path.length + 1);
 		if (filename) {
 			is_static_asset =
-				manifest.assets.has(filename) ||
-				manifest.assets.has(filename + '/index.html') ||
-				filename in manifest._.server_assets ||
-				filename + '/index.html' in manifest._.server_assets;
+				manifest.assets.has(filename) || manifest.assets.has(filename + '/index.html');
 		}
 
 		let location = pathname.at(-1) === '/' ? stripped_pathname : pathname + '/';


### PR DESCRIPTION
This was added in https://github.com/sveltejs/kit/pull/12113 but I'm quite confident it's just wrong. `server_assets` — files that are imported by server-only code — go in the `immutable` directory just like assets that are imported by client code, and so satisfy the `pathname.startsWith(immutable)` check. It shouldn't be a factor in `is_static_asset`, which refers exclusively to the contents of `static` along with the generated service worker.

Making this change saves us from adding `@ts-expect-error` comments or coming up with a pointless API, per https://github.com/sveltejs/kit/pull/16377#issuecomment-4998388302

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
