### PR TITLE
perf: reuse fresh root layout server data instead of refetching it when rendering the error page

### DIFF
--- a/.changeset/fresh-dogs-smile.md
+++ b/.changeset/fresh-dogs-smile.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+perf: reuse fresh root layout server data instead of refetching it when rendering the error page

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1428,7 +1428,8 @@ async function load_root_error_page({ error, url, route }) {
 
 		if (default_layout_has_server_load) {
 			const previous = current.branch[0];
-			const route_changed = current.route ? route.id !== current.route.id : false;
+			// current.route is null after an error-page render, so a missing route counts as changed
+			const route_changed = !current.route || route.id !== current.route.id;
 			const url_changed = current.url ? get_page_key(url) !== get_page_key(current.url) : false;
 			const search_params_changed = diff_search_params(current.url, url);
 

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1457,8 +1457,6 @@ async function load_root_error_page({ error, url, route }) {
 
 					server_data_node = server_data.nodes[0] ?? null;
 				} catch (e) {
-					// at this point we have no choice but to fall back to the server, if it wouldn't
-					// bring us right back here, turning this into an endless loop.
 					// if __data.json returned 404, the route doesn't exist — don't reload or we loop
 					if (
 						!(e instanceof HttpError && e.status === 404) &&

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1427,28 +1427,45 @@ async function load_root_error_page({ error, url, route }) {
 		const default_layout_has_server_load = app.server_loads[0] === 0;
 
 		if (default_layout_has_server_load) {
-			// TODO post-https://github.com/sveltejs/kit/discussions/6124 we can use
-			// existing root layout data
-			try {
-				const server_data = await load_data(url, [true]);
+			const previous = current.branch[0];
+			const route_changed = current.route ? route.id !== current.route.id : false;
+			const url_changed = current.url ? get_page_key(url) !== get_page_key(current.url) : false;
+			const search_params_changed = diff_search_params(current.url, url);
 
-				if (
-					server_data.type !== 'data' ||
-					(server_data.nodes[0] && server_data.nodes[0].type !== 'data')
-				) {
-					throw 0;
-				}
+			if (
+				previous?.server &&
+				!has_changed(
+					false,
+					route_changed,
+					url_changed,
+					search_params_changed,
+					previous.server.uses,
+					params
+				)
+			) {
+				server_data_node = previous.server;
+			} else {
+				try {
+					const server_data = await load_data(url, [true]);
 
-				server_data_node = server_data.nodes[0] ?? null;
-			} catch (e) {
-				// at this point we have no choice but to fall back to the server, if it wouldn't
-				// bring us right back here, turning this into an endless loop.
-				// if __data.json returned 404, the route doesn't exist — don't reload or we loop
-				if (
-					!(e instanceof HttpError && e.status === 404) &&
-					(url.origin !== origin || url.pathname !== location.pathname || hydrated)
-				) {
-					return await native_navigation(url);
+					if (
+						server_data.type !== 'data' ||
+						(server_data.nodes[0] && server_data.nodes[0].type !== 'data')
+					) {
+						throw 0;
+					}
+
+					server_data_node = server_data.nodes[0] ?? null;
+				} catch (e) {
+					// at this point we have no choice but to fall back to the server, if it wouldn't
+					// bring us right back here, turning this into an endless loop.
+					// if __data.json returned 404, the route doesn't exist — don't reload or we loop
+					if (
+						!(e instanceof HttpError && e.status === 404) &&
+						(url.origin !== origin || url.pathname !== location.pathname || hydrated)
+					) {
+						return await native_navigation(url);
+					}
 				}
 			}
 		}

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -372,13 +372,16 @@ test.describe('Load', () => {
 	test('reuses root layout server data when rendering the error page', async ({ page, app }) => {
 		await page.goto('/');
 
-		/** @type {string[]} */
-		const urls = [];
-		page.on('request', (request) => urls.push(request.url()));
-		await app.goto('/this-route-does-not-exist');
+		let data_requests = 0;
+		await page.route('**/__data.json*', (route) => {
+			data_requests += 1;
+			return route.fulfill({ status: 500, body: 'nope' });
+		});
 
-		expect(await page.textContent('h1')).toBe('404');
-		expect(urls.some((url) => url.includes('__data.json'))).toBe(false);
+		await app.goto('/serialization-basic');
+
+		expect(await page.textContent('#message')).toContain('Internal Error');
+		expect(data_requests).toBe(1);
 	});
 });
 

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -368,6 +368,18 @@ test.describe('Load', () => {
 			expect(pathnames).not.toContain('/load/no-server-load/b/__data.json');
 		});
 	}
+
+	test('reuses root layout server data when rendering the error page', async ({ page, app }) => {
+		await page.goto('/');
+
+		/** @type {string[]} */
+		const urls = [];
+		page.on('request', (request) => urls.push(request.url()));
+		await app.goto('/this-route-does-not-exist');
+
+		expect(await page.textContent('h1')).toBe('404');
+		expect(urls.some((url) => url.includes('__data.json'))).toBe(false);
+	});
 });
 
 test.describe('SPA mode / no SSR', () => {


### PR DESCRIPTION
`load_root_error_page` has carried this TODO since 2022:

```js
// TODO post-https://github.com/sveltejs/kit/discussions/6124 we can use
// existing root layout data
```

It was written in #6056, and #6174 resolved the discussion it waits on that same month by giving every app a canonical root layout. That PR removed the discussion's sibling TODO elsewhere in client.js but kept this one, so it was left as standing work rather than forgotten. The precondition has been met for four years, so this implements it and deletes the comment.

The error page now reuses `current.branch[0].server` when it is still fresh instead of fetching `__data.json` again. Freshness is the same `has_changed` check normal navigations use to skip valid server nodes, so a root layout load that tracked `url`, `route`, a param or a `depends` key still refetches, and `invalidate` still forces a fetch. An empty `current.branch` (SPA-mode initial load, hydration failure) takes the fetch path unchanged. A reused node's load does not run at all, so its side effects (logging, session refresh) skip that render, the same way they already do when navigations skip valid nodes.

Navigations to unknown routes full-reload by design (`server_fallback`), so the reuse fires where client state is intact, when a navigation's own `__data.json` request fails or a redirect loops. Today that failure is answered by refetching `__data.json` on the connection that just failed, then a full page reload. With the reuse the error page renders immediately with root layout data intact. The `ssr = false` initial load has nothing to reuse and stays a fetch, which is the server-side case #16376 addresses.

The new test intercepts `__data.json` with a 500 during a client-side navigation and asserts the error page renders with exactly one data request. On `version-3` the second request fires and the fallback reload tears the page down.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.

