### PR TITLE
perf: skip import graph collection outside client environments

### DIFF
--- a/.changeset/olive-boxes-tan.md
+++ b/.changeset/olive-boxes-tan.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+perf: skip import graph collection outside client environments

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -684,6 +684,9 @@ function kit({ svelte_config, adapter }) {
 			// 	include(importerId(/.+/))
 			// ]),
 			async handler(id, importer, options) {
+				// the import map is only read for client-side violations in `load`, so skip other environments
+				if (this.environment.config.consumer !== 'client') return;
+
 				if (importer && !importer.endsWith('index.html')) {
 					const resolved = await this.resolve(id, importer, { ...options, skipSelf: true });
 


### PR DESCRIPTION
Addresses part of #15461

`vite-plugin-sveltekit-guard` builds its `import_map` in every environment, but the map is only read in the `load` hook, which bails for non-client consumers before touching it. On the svelte.dev build that makes 69% of the guard's `resolveId` calls (3,987 of 5,778) dead work, and the guard was the top entry in dominikg's `PLUGIN_TIMINGS` report in #13756. This adds the same consumer bail to `resolveId`.

The error chains from #14155 are unaffected because the client environment collects its own edges. Measured on the svelte.dev build with `3.0.0-next.6` and vite `8.0.16` (details in https://github.com/sveltejs/kit/issues/15461#issuecomment-4999014482), ssr-side hook time drops from ~296s cumulative to 23ms, the build succeeds, and a planted two-hop `$lib/server` violation still fails with the full chain. There is no new test because the behavior is meant to be unobservable and the exact chain assertions already exist in `test/apps/dev-only` (dev) and `test/build-errors/server-only.spec.js` (build), both green with this change.

History for reviewers. #15439 added hook filters everywhere except this hook, which is blocked on vitejs/vite#21956. #15543 proposed this skip plus a node_modules importer skip and was closed pending kit 3. The ssr half was not fixed by kit 3. The node_modules half is not implemented here because it is unsafe, a library can legitimately import `$app/server` and its violation chain has to walk node_modules edges.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
