### PR TITLE
perf: skip running plugin completely

### DIFF
--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -710,7 +710,8 @@ function kit({ svelte_config }) {
 		enforce: 'pre',
 
 		applyToEnvironment(environment) {
-			return environment.name !== 'serviceWorker';
+			// the import map is only read for client-side violations in `load`, so skip other environments
+			return environment.config.consumer === 'client' && environment.name !== 'serviceWorker';
 		},
 
 		resolveId: {
@@ -721,9 +722,6 @@ function kit({ svelte_config }) {
 			// 	include(importerId(/.+/))
 			// ]),
 			async handler(id, importer, options) {
-				// the import map is only read for client-side violations in `load`, so skip other environments
-				if (this.environment.config.consumer !== 'client') return;
-
 				if (importer && !importer.endsWith('index.html')) {
 					const resolved = await this.resolve(id, importer, { ...options, skipSelf: true });
 
@@ -753,8 +751,6 @@ function kit({ svelte_config }) {
 				]
 			},
 			handler(id) {
-				if (this.environment.config.consumer !== 'client') return;
-
 				// skip .server.js files outside the cwd or in node_modules, as the filename might not mean 'server-only module' in this context
 				const is_internal =
 					id.startsWith(normalized_cwd) && !id.startsWith(normalized_node_modules);


### PR DESCRIPTION
follow up to https://github.com/sveltejs/kit/pull/16383

Using `applyToEnvironment` is better here as the plugin isn't needed in the server environment if we're already using an `if (...)` guard to opt out early