### PR TITLE
fix: incomplete URL scheme check code scanning alert

### DIFF
--- a/.changeset/eighty-cups-jam.md
+++ b/.changeset/eighty-cups-jam.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: treat `data:` protocol URLs as external for redirect

--- a/packages/kit/src/exports/url.js
+++ b/packages/kit/src/exports/url.js
@@ -22,14 +22,14 @@ export function is_external_location(location) {
 	}
 }
 
+const javascript_protocols = new Set(['javascript:', 'data:']);
+
 /**
  * @param {string} location
  */
 function is_javascript_location(location) {
 	try {
-		return ['javascript:', 'data:', 'vbscript:'].includes(
-			new URL(location, REDIRECT_BASE).protocol
-		);
+		return javascript_protocols.has(new URL(location, REDIRECT_BASE).protocol);
 	} catch {
 		return false;
 	}

--- a/packages/kit/src/exports/url.js
+++ b/packages/kit/src/exports/url.js
@@ -27,7 +27,9 @@ export function is_external_location(location) {
  */
 function is_javascript_location(location) {
 	try {
-		return new URL(location, REDIRECT_BASE).protocol === 'javascript:';
+		return ['javascript:', 'data:', 'vbscript:'].includes(
+			new URL(location, REDIRECT_BASE).protocol
+		);
 	} catch {
 		return false;
 	}
@@ -56,7 +58,7 @@ export function validate_redirect_location(location, options) {
 			throw new Error(
 				DEV
 					? `Cannot redirect to ${JSON.stringify(location)} with \`{ external: true }\`. ` +
-							'The `:javascript` protocol must be explicitly listed in the `external` allowlist'
+							'The `javascript:`, `data:`, and `vbscript:` protocols must be explicitly listed in the `external` allowlist'
 					: 'Cannot redirect to external URL unless explicitly allowed'
 			);
 		}

--- a/packages/kit/src/exports/url.js
+++ b/packages/kit/src/exports/url.js
@@ -58,7 +58,7 @@ export function validate_redirect_location(location, options) {
 			throw new Error(
 				DEV
 					? `Cannot redirect to ${JSON.stringify(location)} with \`{ external: true }\`. ` +
-							'The `javascript:`, `data:`, and `vbscript:` protocols must be explicitly listed in the `external` allowlist'
+							'The `javascript:` and `data:` protocols must be explicitly listed in the `external` allowlist'
 					: 'Cannot redirect to external URL unless explicitly allowed'
 			);
 		}


### PR DESCRIPTION
fix for [https://github.com/sveltejs/kit/security/code-scanning/33](https://github.com/sveltejs/kit/security/code-scanning/33)

We don't care about the `vbscript:` protocol since that only works on internet explorer. I've also tested running it on Safari/Firefox/Chrome and it's not recognised.

`data:` on the other hand does allow running some arbitrary javascript:
```
data:text/html,%3Cscript%3Ealert%28%27hi%27%29%3B%3C%2Fscript%3E
```
> An HTML document with <script>alert('hi');</script> that executes a JavaScript alert. Note that the closing script tag is required.

Taken from https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Schemes/data#datatexthtml3cscript3ealert2827hi27293b3c2fscript3e