### PR TITLE
fix: get build working

### DIFF
--- a/documentation/docs/30-advanced/10-advanced-routing.md
+++ b/documentation/docs/30-advanced/10-advanced-routing.md
@@ -74,6 +74,9 @@ Note that an optional route parameter cannot follow a rest parameter (`[...rest]
 A route like `src/routes/fruits/[page]` would match `/fruits/apple`, but it would also match `/fruits/rocketship`. We don't want that. You can ensure that route parameters are well-formed by adding a _matcher_ — which takes the parameter string (`"apple"` or `"rocketship"`) and returns `true` if it is valid — to your `src/params` directory...
 
 ```js
+// TODO: remove the ts error once kit 3 docs are main
+// ---cut---
+// @errors: 1360
 /// file: src/params/fruit.js
 /**
  * @param {string} param


### PR DESCRIPTION
quick fix to get kit 2 docs building although svelte.dev has kit 3 types installed