### PR TITLE
fix: warn if a plugin uses `transformIndexHtml`

### DIFF
--- a/.changeset/rich-poems-happen.md
+++ b/.changeset/rich-poems-happen.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: warn if there are plugins using `transformIndexHtml`

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -548,6 +548,24 @@ function kit({ svelte_config }) {
 		 */
 		configResolved(config) {
 			vite_config = config;
+
+			const unsupported_plugins = vite_config.plugins.filter((plugin) => plugin.transformIndexHtml);
+			if (unsupported_plugins.length) {
+				const verbose = vite_config.logLevel === 'info';
+				const log = logger({ verbose });
+
+				const list = unsupported_plugins
+					.map((plugin) => `  - ${plugin.name || 'missing plugin name'}`)
+					.join('\n');
+
+				log.warn(
+					dedent`
+						The following plugins may not work correctly because they use the \`transformIndexHtml\` hook which is not supported:
+
+						${list}
+					`
+				);
+			}
 		}
 	};
 
@@ -1905,7 +1923,7 @@ function kit({ svelte_config }) {
 						explicit_env_config
 					);
 				} else {
-					console.log(styleText(['bold', 'yellow'], '\nNo adapter specified'));
+					log.warn('\nNo adapter specified');
 
 					const link = styleText(['bold', 'cyan'], 'https://svelte.dev/docs/kit/adapters');
 					console.log(

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -555,7 +555,7 @@ function kit({ svelte_config }) {
 				const log = logger({ verbose });
 
 				const list = unsupported_plugins
-					.map((plugin) => `  - ${plugin.name || 'missing plugin name'}`)
+					.map((plugin) => `  - ${plugin.name || '(missing plugin name)'}`)
 					.join('\n');
 
 				log.warn(


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/12391

Not sure how to word the warning message so I'm open to suggestions

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
