### PR TITLE
docs: clarify which hooks run during server route resolution

### DIFF
--- a/.changeset/lemon-poems-refuse.md
+++ b/.changeset/lemon-poems-refuse.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+chore: clarify which hooks run during server route resolution

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -833,8 +833,10 @@ export interface KitConfig {
 		 * This has several advantages:
 		 * - The client does not need to load the routing manifest upfront, which can lead to faster initial page loads
 		 * - The list of routes is hidden from public view
-		 * - The server has an opportunity to intercept each navigation (for example through a middleware), enabling (for example) A/B testing opaque to SvelteKit
-
+		 * - The server has an opportunity to intercept each navigation (for example through middleware in front of SvelteKit, such as a reverse proxy or your platform's edge functions), enabling (for example) A/B testing opaque to SvelteKit
+		 *
+		 * Route resolution requests do not run the `handle` hook. They do run the `reroute` hook, which is the way to intercept them within SvelteKit itself.
+		 *
 		 * The drawback is that for unvisited paths, resolution will take slightly longer (though this is mitigated by [preloading](https://svelte.dev/docs/kit/link-options#data-sveltekit-preload-data)).
 		 *
 		 * > [!NOTE] When using server-side route resolution and prerendering, the resolution is prerendered along with the route itself.

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -835,7 +835,7 @@ export interface KitConfig {
 		 * - The list of routes is hidden from public view
 		 * - The server has an opportunity to intercept each navigation (for example through middleware in front of SvelteKit, such as a reverse proxy or your platform's edge functions), enabling (for example) A/B testing opaque to SvelteKit
 		 *
-		 * Route resolution requests do not run the `handle` hook. They do run the `reroute` hook, which is the way to intercept them within SvelteKit itself.
+		 * Route resolution requests are answered as soon as the route has been looked up, before the `handle` hook is invoked. To intercept them within SvelteKit itself, use the `reroute` hook, which runs for these requests too.
 		 *
 		 * The drawback is that for unvisited paths, resolution will take slightly longer (though this is mitigated by [preloading](https://svelte.dev/docs/kit/link-options#data-sveltekit-preload-data)).
 		 *

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -807,7 +807,7 @@ declare module '@sveltejs/kit' {
 			 * - The list of routes is hidden from public view
 			 * - The server has an opportunity to intercept each navigation (for example through middleware in front of SvelteKit, such as a reverse proxy or your platform's edge functions), enabling (for example) A/B testing opaque to SvelteKit
 			 *
-			 * Route resolution requests do not run the `handle` hook. They do run the `reroute` hook, which is the way to intercept them within SvelteKit itself.
+			 * Route resolution requests are answered as soon as the route has been looked up, before the `handle` hook is invoked. To intercept them within SvelteKit itself, use the `reroute` hook, which runs for these requests too.
 			 *
 			 * The drawback is that for unvisited paths, resolution will take slightly longer (though this is mitigated by [preloading](https://svelte.dev/docs/kit/link-options#data-sveltekit-preload-data)).
 			 *

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -805,8 +805,10 @@ declare module '@sveltejs/kit' {
 			 * This has several advantages:
 			 * - The client does not need to load the routing manifest upfront, which can lead to faster initial page loads
 			 * - The list of routes is hidden from public view
-			 * - The server has an opportunity to intercept each navigation (for example through a middleware), enabling (for example) A/B testing opaque to SvelteKit
-
+			 * - The server has an opportunity to intercept each navigation (for example through middleware in front of SvelteKit, such as a reverse proxy or your platform's edge functions), enabling (for example) A/B testing opaque to SvelteKit
+			 *
+			 * Route resolution requests do not run the `handle` hook. They do run the `reroute` hook, which is the way to intercept them within SvelteKit itself.
+			 *
 			 * The drawback is that for unvisited paths, resolution will take slightly longer (though this is mitigated by [preloading](https://svelte.dev/docs/kit/link-options#data-sveltekit-preload-data)).
 			 *
 			 * > [!NOTE] When using server-side route resolution and prerendering, the resolution is prerendered along with the route itself.


### PR DESCRIPTION
closes #14896

The `router.resolution` docs say the server "has an opportunity to intercept each navigation (for example through a middleware)". #14896 read that as "the `handle` hook runs", which it does not. Route resolution requests are answered as soon as the route has been looked up ([respond.js#L323-L324](https://github.com/sveltejs/kit/blob/1406668dbc9c18928dabeff9d15ec756d6d455b3/packages/kit/src/runtime/server/respond.js#L323-L324)), before `handle` is invoked and after `reroute` has run ([respond.js#L249](https://github.com/sveltejs/kit/blob/1406668dbc9c18928dabeff9d15ec756d6d455b3/packages/kit/src/runtime/server/respond.js#L249)). Verified empirically in dev and in preview after a production build, details in https://github.com/sveltejs/kit/issues/14896#issuecomment-5006799473. The wording dates to #13379, which introduced server-side route resolution.

The new sentence is scoped to the route lookup rather than stating a blanket "handle never runs", because there is one path where it does. A pathname that fails to decode falls through to normal request handling ([respond.js#L272-L277](https://github.com/sveltejs/kit/blob/1406668dbc9c18928dabeff9d15ec756d6d455b3/packages/kit/src/runtime/server/respond.js#L272-L277)), deliberate behavior from #15744 so that malformed URLs render the default error page. In production `GET /%c0/__route.js` therefore reaches `handle` with pathname `/%c0` before being rejected with a 400. Dev masks this because the dev middleware rejects malformed URIs earlier, which #15744 also notes.

Two changes to the option's JSDoc. "Middleware" now says what it refers to, and a sentence states which hooks run for resolution requests. `types/index.d.ts` regenerated.

Note on sequencing, #16396 also touches `public.d.ts` (different lines) and regenerates `types/index.d.ts`; whichever merges second needs a trivial rebase and regeneration.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
