### PR TITLE
chore: reuse playwright cache for platform tests

### DIFF
--- a/.github/actions/platform-test/action.yml
+++ b/.github/actions/platform-test/action.yml
@@ -5,6 +5,10 @@ inputs:
   test-app-dir:
     description: 'Path to the test app directory'
     required: true
+  os:
+    description: 'Operating system'
+    required: true
+    default: 'ubuntu-latest'
   deployment-url:
     description: 'URL of the deployed preview to test against'
 
@@ -12,8 +16,9 @@ runs:
   using: 'composite'
   steps:
     - name: Install Playwright
-      shell: bash
-      run: pnpm playwright install chromium --no-shell
+      uses: ./.github/actions/playwright-setup
+      with:
+        os: ${{ inputs.os }}
 
     - name: Run Playwright tests
       shell: bash

--- a/.github/workflows/platform-tests-node.yml
+++ b/.github/workflows/platform-tests-node.yml
@@ -54,3 +54,4 @@ jobs:
       - uses: ./.github/actions/platform-test
         with:
           test-app-dir: packages/adapter-node/test/apps/basic
+          os: ${{ matrix.os }}


### PR DESCRIPTION
follow up to https://github.com/sveltejs/kit/pull/16387
I missed adding it to the platform tests