### PR TITLE
breaking: universal node config takes precedence over server

### DIFF
--- a/.changeset/nice-mammals-move.md
+++ b/.changeset/nice-mammals-move.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': major
+---
+
+breaking: `config` exported from a server route file takes precedence over a universal one

--- a/.changeset/nice-mammals-move.md
+++ b/.changeset/nice-mammals-move.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': major
 ---
 
-breaking: `config` exported from a server route file takes precedence over a universal one
+breaking: `config` exported from a universal route file takes precedence over a server one

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -58,7 +58,7 @@ export interface Adapter {
 		 * Test support for `read` from `$app/server`.
 		 * @param details.config The merged adapter-specific route config exported from the route with `export const config`
 		 */
-		read?: (details: { config: any; route: { id: string } }) => boolean;
+		read?: (details: { config: Record<string, any>; route: { id: string } }) => boolean;
 
 		/**
 		 * Test support for `instrumentation.server.js`. To pass, the adapter must support running `instrumentation.server.js` prior to the application code.

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -394,7 +394,7 @@ export interface ServerErrorNode {
 }
 
 export interface ServerMetadataRoute {
-	config: any;
+	config: Record<string, any>;
 	api: {
 		methods: Array<HttpMethod | '*'>;
 	};
@@ -426,7 +426,7 @@ export interface UniversalNode {
 	ssr?: boolean;
 	csr?: boolean;
 	trailingSlash?: TrailingSlash;
-	config?: any;
+	config?: Record<string, any>;
 	entries?: PrerenderEntryGenerator;
 }
 
@@ -437,7 +437,7 @@ export interface ServerNode {
 	csr?: boolean;
 	trailingSlash?: TrailingSlash;
 	actions?: Actions;
-	config?: any;
+	config?: Record<string, any>;
 	entries?: PrerenderEntryGenerator;
 }
 
@@ -511,7 +511,7 @@ export type RemotePrerenderInputsGenerator<Input = any> = () => MaybePromise<Inp
 export type SSREndpoint = Partial<Record<HttpMethod, RequestHandler>> & {
 	prerender?: PrerenderOption;
 	trailingSlash?: TrailingSlash;
-	config?: any;
+	config?: Record<string, any>;
 	entries?: PrerenderEntryGenerator;
 	fallback?: RequestHandler;
 };
@@ -560,7 +560,7 @@ export interface SSRState {
 	 */
 	before_handle?: (
 		event: RequestEvent,
-		config: any,
+		config: Record<string, any>,
 		prerender: PrerenderOption,
 		handle: () => Promise<Response>
 	) => Promise<Response>;

--- a/packages/kit/src/utils/features.js
+++ b/packages/kit/src/utils/features.js
@@ -1,6 +1,6 @@
 /**
  * @param {string} route_id
- * @param {Record<string, unknown>} config
+ * @param {Record<string, any>} config
  * @param {string} feature
  * @param {import('@sveltejs/kit').Adapter | undefined} adapter
  */

--- a/packages/kit/src/utils/features.js
+++ b/packages/kit/src/utils/features.js
@@ -1,6 +1,6 @@
 /**
  * @param {string} route_id
- * @param {any} config
+ * @param {Record<string, unknown>} config
  * @param {string} feature
  * @param {import('@sveltejs/kit').Adapter | undefined} adapter
  */

--- a/packages/kit/src/utils/page_nodes.js
+++ b/packages/kit/src/utils/page_nodes.js
@@ -69,7 +69,7 @@ export class PageNodes {
 	}
 
 	get_config() {
-		/** @type {any} */
+		/** @type {Record<string, any>} */
 		let current = {};
 
 		for (const node of this.data) {
@@ -77,13 +77,11 @@ export class PageNodes {
 
 			current = {
 				...current,
-				// TODO: should we override the server config value with the universal value similar to other page options?
-				...node?.universal?.config,
-				...node?.server?.config
+				...node?.server?.config,
+				...node?.universal?.config
 			};
 		}
 
-		// TODO 3.0 always return `current`? then we can get rid of `?? {}` in other places
 		return Object.keys(current).length ? current : undefined;
 	}
 

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -32,7 +32,7 @@ declare module '@sveltejs/kit' {
 			 * Test support for `read` from `$app/server`.
 			 * @param details.config The merged adapter-specific route config exported from the route with `export const config`
 			 */
-			read?: (details: { config: any; route: { id: string } }) => boolean;
+			read?: (details: { config: Record<string, any>; route: { id: string } }) => boolean;
 
 			/**
 			 * Test support for `instrumentation.server.js`. To pass, the adapter must support running `instrumentation.server.js` prior to the application code.


### PR DESCRIPTION
This PR resolves two TODOs surrounding page node configs:
1. Verified that we should return `undefined` if there are no page `config` keys
2. Standardised the `+page.server.js` exports taking precedence over the `+page.js` ones (this matches how we resolve all the other page options)