### PR TITLE
fix: don't report empty environment variables as missing

### DIFF
--- a/.changeset/env-empty-string.md
+++ b/.changeset/env-empty-string.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: don't report empty environment variables as missing

--- a/packages/kit/src/exports/internal/env.js
+++ b/packages/kit/src/exports/internal/env.js
@@ -27,7 +27,7 @@ export function validate(variables, value, name, issues) {
 	const validator = config.schema;
 
 	if (!validator) {
-		if (!value) issues[name] = [MISSING];
+		if (value === undefined) issues[name] = [MISSING];
 		return value;
 	}
 

--- a/packages/kit/src/exports/internal/env.spec.js
+++ b/packages/kit/src/exports/internal/env.spec.js
@@ -1,0 +1,19 @@
+import { assert, test } from 'vitest';
+import { validate } from './env.js';
+
+test('reports a variable without a validator as missing when it is undefined', () => {
+	/** @type {Record<string, import('@standard-schema/spec').StandardSchemaV1.Issue[]>} */
+	const issues = {};
+	validate({}, undefined, 'FOO', issues);
+
+	assert.ok(issues.FOO);
+});
+
+test('accepts an empty string for a variable without a validator', () => {
+	/** @type {Record<string, import('@standard-schema/spec').StandardSchemaV1.Issue[]>} */
+	const issues = {};
+	const value = validate({}, '', 'FOO', issues);
+
+	assert.equal(value, '');
+	assert.deepEqual(issues, {});
+});

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -2457,7 +2457,7 @@ export interface EnvVarConfig<T> {
 	 * The validator can output any value — not necessarily a string — but public, non-static values must be
 	 * serializable by [devalue](https://github.com/sveltejs/devalue) so that they can be sent to the browser.
 	 *
-	 * If omitted, the value must be a non-empty string.
+	 * If omitted, the value must be set, but may be an empty string.
 	 */
 	schema?: StandardSchemaV1<string | undefined, T>;
 	/**

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2414,7 +2414,7 @@ declare module '@sveltejs/kit' {
 		 * The validator can output any value — not necessarily a string — but public, non-static values must be
 		 * serializable by [devalue](https://github.com/sveltejs/devalue) so that they can be sent to the browser.
 		 *
-		 * If omitted, the value must be a non-empty string.
+		 * If omitted, the value must be set, but may be an empty string.
 		 */
 		schema?: StandardSchemaV1<string | undefined, T>;
 		/**


### PR DESCRIPTION
As requested in [#16195](https://github.com/sveltejs/kit/issues/16195#issuecomment-5009795012), the missing-value check in `validate` is now `value === undefined`, so an empty string counts as set. Also updates the `EnvVarConfig.schema` JSDoc, which documented the old check, and adds a spec for `validate` whose empty-string test fails without the fix.

Function validators will be a separate PR.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
