### PR TITLE
feat: support function validators for environment variables

### DIFF
--- a/.changeset/env-empty-string.md
+++ b/.changeset/env-empty-string.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: don't report empty environment variables as missing

--- a/.changeset/env-function-validators.md
+++ b/.changeset/env-function-validators.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: support function validators for environment variables

--- a/documentation/docs/20-core-concepts/70-environment-variables.md
+++ b/documentation/docs/20-core-concepts/70-environment-variables.md
@@ -121,6 +121,23 @@ export const variables = defineEnvVars({
 });
 ```
 
+If you don't want to bring in a schema library, you can pass a function that returns the (possibly transformed) value, returns `undefined` if the value is invalid, or throws an error explaining the problem:
+
+```ts
+/// file: src/env.ts
+import { defineEnvVars } from '@sveltejs/kit/env';
+
+export const variables = defineEnvVars({
+	GOOGLE_ANALYTICS_ID: {
+		public: true,
+		schema: (value) => {
+			if (!value?.startsWith('G-')) return;
+			return value;
+		}
+	}
+});
+```
+
 If a value is invalid, the app will fail to start (or build). To opt out of one or the other, use [`building`]($app-env#building) from `$app/env` along with a validator that accepts an optional value:
 
 ```ts

--- a/documentation/docs/20-core-concepts/70-environment-variables.md
+++ b/documentation/docs/20-core-concepts/70-environment-variables.md
@@ -121,7 +121,7 @@ export const variables = defineEnvVars({
 });
 ```
 
-If you don't want to bring in a schema library, you can pass a function that returns the (possibly transformed) value, returns `undefined` if the value is invalid, or throws an error explaining the problem:
+If you don't want to bring in a schema library, you can pass a function that returns the (possibly transformed) value, or throws an error explaining the problem:
 
 ```ts
 /// file: src/env.ts
@@ -131,7 +131,7 @@ export const variables = defineEnvVars({
 	GOOGLE_ANALYTICS_ID: {
 		public: true,
 		schema: (value) => {
-			if (!value?.startsWith('G-')) return;
+			if (!value?.startsWith('G-')) throw new Error('expected a Google Analytics ID');
 			return value;
 		}
 	}

--- a/packages/kit/src/exports/env/index.js
+++ b/packages/kit/src/exports/env/index.js
@@ -1,12 +1,81 @@
-/** @import { EnvVarConfig } from '@sveltejs/kit' */
+/** @import { StandardSchemaV1 } from '@standard-schema/spec' */
+/** @import { DefinedEnvVars, EnvVarConfig } from '@sveltejs/kit' */
 
 /**
  * Utility for defining [environment variables](https://svelte.dev/docs/kit/environment-variables),
  * which are made available via `$app/env/public` and `$app/env/private`.
+ *
+ * @example
+ * ```js
+ * import { defineEnvVars } from '@sveltejs/kit/env';
+ * import * as v from 'valibot';
+ *
+ * export const variables = defineEnvVars({
+ * 	API_URL: {
+ * 		schema: v.pipe(v.string(), v.url())
+ * 	},
+ * 	PORT: {
+ * 		schema: (value) => {
+ * 			if (value === undefined) return 3000;
+ * 			const port = Number(value);
+ * 			if (!Number.isInteger(port)) return;
+ * 			return port;
+ * 		}
+ * 	}
+ * });
+ * ```
+ *
  * @template {Record<string, EnvVarConfig<any>>} T
  * @param {T} variables
- * @returns {T}
+ * @returns {DefinedEnvVars<T>}
  */
 export function defineEnvVars(variables) {
-	return variables;
+	/** @type {Record<string, EnvVarConfig<any>>} */
+	const normalized = {};
+
+	for (const [name, config] of Object.entries(variables)) {
+		// standard schemas can be callable (e.g. ArkType), so a function is only a validator if it isn't one
+		normalized[name] =
+			typeof config.schema === 'function' && !('~standard' in config.schema)
+				? { ...config, schema: normalize_env_schema(config.schema) }
+				: config;
+	}
+
+	return /** @type {DefinedEnvVars<T>} */ (normalized);
+}
+
+/**
+ * @param {(value: string | undefined) => any} fn
+ * @returns {StandardSchemaV1<string | undefined, any>}
+ */
+function normalize_env_schema(fn) {
+	return /** @type {StandardSchemaV1<string | undefined, any>} */ (
+		/** @type {unknown} */ ({
+			'~standard': {
+				validate(/** @type {unknown} */ value) {
+					let result;
+
+					try {
+						result = fn(/** @type {string | undefined} */ (value));
+					} catch (error) {
+						return {
+							issues: [
+								{
+									message: error instanceof Error ? error.message || 'Invalid value' : String(error)
+								}
+							]
+						};
+					}
+
+					if (result === undefined) {
+						return { issues: [{ message: 'Invalid value' }] };
+					}
+
+					if (result instanceof Promise) return result; // will be rejected upstream
+
+					return { value: result };
+				}
+			}
+		})
+	);
 }

--- a/packages/kit/src/exports/env/index.js
+++ b/packages/kit/src/exports/env/index.js
@@ -18,7 +18,7 @@
  * 		schema: (value) => {
  * 			if (value === undefined) return 3000;
  * 			const port = Number(value);
- * 			if (!Number.isInteger(port)) return;
+ * 			if (!Number.isInteger(port)) throw new Error('PORT must be an integer');
  * 			return port;
  * 		}
  * 	}
@@ -65,10 +65,6 @@ function normalize_env_schema(fn) {
 								}
 							]
 						};
-					}
-
-					if (result === undefined) {
-						return { issues: [{ message: 'Invalid value' }] };
 					}
 
 					if (result instanceof Promise) return result; // will be rejected upstream

--- a/packages/kit/src/exports/internal/env.js
+++ b/packages/kit/src/exports/internal/env.js
@@ -27,7 +27,7 @@ export function validate(variables, value, name, issues) {
 	const validator = config.schema;
 
 	if (!validator) {
-		if (!value) issues[name] = [MISSING];
+		if (value === undefined) issues[name] = [MISSING];
 		return value;
 	}
 

--- a/packages/kit/src/exports/internal/env.js
+++ b/packages/kit/src/exports/internal/env.js
@@ -4,7 +4,7 @@
 import { stackless } from '../../utils/error.js';
 
 const MISSING = {
-	message: `Value is missing. If it is optional, add a Standard Schema validator declaring it as such.`
+	message: `Value is missing. If it is optional, add a validator declaring it as such.`
 };
 
 const BAD_VALIDATOR = {
@@ -24,7 +24,10 @@ const ASYNC_VALIDATOR = {
  */
 export function validate(variables, value, name, issues) {
 	const config = variables[name] ?? {};
-	const validator = config.schema;
+	// `defineEnvVars` normalizes function validators to standard schemas
+	const validator = /** @type {StandardSchemaV1<string | undefined, any> | undefined} */ (
+		config.schema
+	);
 
 	if (!validator) {
 		if (value === undefined) issues[name] = [MISSING];

--- a/packages/kit/src/exports/internal/env.spec.js
+++ b/packages/kit/src/exports/internal/env.spec.js
@@ -39,8 +39,9 @@ test('wraps function validators', () => {
 	assert.equal(validate(variables, '8080', 'PORT', issues), 8080);
 	assert.deepEqual(issues, {});
 
-	validate(variables, 'nope', 'PORT', issues);
-	assert.deepEqual(issues.PORT, [{ message: 'Invalid value' }]);
+	// returning undefined is valid, so a function validator can describe an optional variable
+	assert.equal(validate(variables, 'nope', 'PORT', issues), undefined);
+	assert.deepEqual(issues, {});
 
 	validate(variables, '', 'NAME', issues);
 	assert.deepEqual(issues.NAME, [{ message: 'NAME must not be empty' }]);

--- a/packages/kit/src/exports/internal/env.spec.js
+++ b/packages/kit/src/exports/internal/env.spec.js
@@ -1,4 +1,5 @@
 import { assert, test } from 'vitest';
+import { defineEnvVars } from '../env/index.js';
 import { validate } from './env.js';
 
 test('reports a variable without a validator as missing when it is undefined', () => {
@@ -15,5 +16,83 @@ test('accepts an empty string for a variable without a validator', () => {
 	const value = validate({}, '', 'FOO', issues);
 
 	assert.equal(value, '');
+	assert.deepEqual(issues, {});
+});
+
+test('wraps function validators', () => {
+	const variables = defineEnvVars({
+		PORT: {
+			schema: (value) => (value === undefined ? 3000 : Number(value) || undefined)
+		},
+		NAME: {
+			schema: (value) => {
+				if (value === '') throw new Error('NAME must not be empty');
+				return value;
+			}
+		}
+	});
+
+	/** @type {Record<string, import('@standard-schema/spec').StandardSchemaV1.Issue[]>} */
+	const issues = {};
+
+	assert.equal(validate(variables, undefined, 'PORT', issues), 3000);
+	assert.equal(validate(variables, '8080', 'PORT', issues), 8080);
+	assert.deepEqual(issues, {});
+
+	validate(variables, 'nope', 'PORT', issues);
+	assert.deepEqual(issues.PORT, [{ message: 'Invalid value' }]);
+
+	validate(variables, '', 'NAME', issues);
+	assert.deepEqual(issues.NAME, [{ message: 'NAME must not be empty' }]);
+});
+
+test('rejects async function validators', () => {
+	const variables = defineEnvVars({
+		FOO: { schema: async (value) => value }
+	});
+
+	/** @type {Record<string, import('@standard-schema/spec').StandardSchemaV1.Issue[]>} */
+	const issues = {};
+	validate(variables, 'x', 'FOO', issues);
+
+	assert.equal(issues.FOO[0].message, 'Variable uses an async validator, which is not supported');
+});
+
+test('passes standard schema configs through untouched', () => {
+	const config = {
+		/** @type {import('@standard-schema/spec').StandardSchemaV1<string | undefined, string>} */
+		schema: {
+			'~standard': {
+				version: 1,
+				vendor: 'test',
+				validate: (value) => ({ value: /** @type {string} */ (value) })
+			}
+		}
+	};
+
+	// standard schemas can be callable (e.g. ArkType)
+	const callable = {
+		schema:
+			/** @type {import('@standard-schema/spec').StandardSchemaV1<string | undefined, string>} */ (
+				/** @type {unknown} */ (
+					Object.assign(() => 'from-call', {
+						'~standard': {
+							version: 1,
+							vendor: 'test',
+							validate: () => ({ value: 'from-schema' })
+						}
+					})
+				)
+			)
+	};
+
+	const variables = defineEnvVars({ FOO: config, BAR: callable });
+
+	assert.equal(variables.FOO, config);
+	assert.equal(variables.BAR, callable);
+
+	/** @type {Record<string, import('@standard-schema/spec').StandardSchemaV1.Issue[]>} */
+	const issues = {};
+	assert.equal(validate(variables, 'x', 'BAR', issues), 'from-schema');
 	assert.deepEqual(issues, {});
 });

--- a/packages/kit/src/exports/internal/env.spec.js
+++ b/packages/kit/src/exports/internal/env.spec.js
@@ -1,0 +1,19 @@
+import { assert, test } from 'vitest';
+import { validate } from './env.js';
+
+test('reports a variable without a validator as missing when it is undefined', () => {
+	/** @type {Record<string, import('@standard-schema/spec').StandardSchemaV1.Issue[]>} */
+	const issues = {};
+	validate({}, undefined, 'FOO', issues);
+
+	assert.ok(issues.FOO);
+});
+
+test('accepts an empty string for a variable without a validator', () => {
+	/** @type {Record<string, import('@standard-schema/spec').StandardSchemaV1.Issue[]>} */
+	const issues = {};
+	const value = validate({}, '', 'FOO', issues);
+
+	assert.equal(value, '');
+	assert.deepEqual(issues, {});
+});

--- a/packages/kit/src/exports/internal/env.spec.js
+++ b/packages/kit/src/exports/internal/env.spec.js
@@ -49,7 +49,7 @@ test('wraps function validators', () => {
 
 test('rejects async function validators', () => {
 	const variables = defineEnvVars({
-		FOO: { schema: async (value) => value }
+		FOO: { schema: (value) => Promise.resolve(value) }
 	});
 
 	/** @type {Record<string, import('@standard-schema/spec').StandardSchemaV1.Issue[]>} */

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -2457,7 +2457,7 @@ export interface EnvVarConfig<T> {
 	 * The validator can output any value — not necessarily a string — but public, non-static values must be
 	 * serializable by [devalue](https://github.com/sveltejs/devalue) so that they can be sent to the browser.
 	 *
-	 * If omitted, the value must be a non-empty string.
+	 * If omitted, the value must be set, but may be an empty string.
 	 */
 	schema?: StandardSchemaV1<string | undefined, T>;
 	/**

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -2456,8 +2456,8 @@ export interface EnvVarConfig<T> {
 	static?: boolean;
 	/**
 	 * A [Standard Schema](https://standardschema.dev/) validator that is applied to the value when the app starts.
-	 * Alternatively, a function that returns the (possibly transformed) value, returns `undefined` if
-	 * the value is invalid, or throws an error explaining the problem.
+	 * Alternatively, a function that returns the (possibly transformed) value, or throws an error explaining
+	 * the problem. Returning `undefined` is valid, so a function can describe an optional variable.
 	 * The validator can output any value — not necessarily a string — but public, non-static values must be
 	 * serializable by [devalue](https://github.com/sveltejs/devalue) so that they can be sent to the browser.
 	 *

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -2454,16 +2454,35 @@ export interface EnvVarConfig<T> {
 	static?: boolean;
 	/**
 	 * A [Standard Schema](https://standardschema.dev/) validator that is applied to the value when the app starts.
+	 * Alternatively, a function that returns the (possibly transformed) value, returns `undefined` if
+	 * the value is invalid, or throws an error explaining the problem.
 	 * The validator can output any value — not necessarily a string — but public, non-static values must be
 	 * serializable by [devalue](https://github.com/sveltejs/devalue) so that they can be sent to the browser.
 	 *
 	 * If omitted, the value must be set, but may be an empty string.
 	 */
-	schema?: StandardSchemaV1<string | undefined, T>;
+	schema?: StandardSchemaV1<string | undefined, T> | ((value: string | undefined) => T | undefined);
 	/**
 	 * A description of the variable that will be used for inline documentation on hover.
 	 */
 	description?: string;
 }
+
+/**
+ * The return type of [`defineEnvVars`](https://svelte.dev/docs/kit/@sveltejs-kit-env#defineEnvVars).
+ */
+export type DefinedEnvVars<T extends Record<string, EnvVarConfig<any>>> = {
+	readonly [K in keyof T]: EnvVarEntry<T[K]>;
+};
+
+/**
+ * Normalizes an environment variable config's schema (standard schema or function) to standard schema.
+ */
+type EnvVarEntry<C extends EnvVarConfig<any>> =
+	C['schema'] extends StandardSchemaV1<any, any>
+		? C
+		: C['schema'] extends (value: any) => infer R
+			? Omit<C, 'schema'> & { schema: StandardSchemaV1<string | undefined, Exclude<R, undefined>> }
+			: C;
 
 export * from './index.js';

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -2484,7 +2484,7 @@ type EnvVarEntry<C extends EnvVarConfig<any>> =
 	C['schema'] extends StandardSchemaV1<any, any>
 		? C
 		: C['schema'] extends (value: any) => infer R
-			? Omit<C, 'schema'> & { schema: StandardSchemaV1<string | undefined, Exclude<R, undefined>> }
+			? Omit<C, 'schema'> & { schema: StandardSchemaV1<string | undefined, R> }
 			: C;
 
 export * from './index.js';

--- a/packages/kit/test/types/env.test.ts
+++ b/packages/kit/test/types/env.test.ts
@@ -29,12 +29,12 @@ const variables = defineEnvVars({
 });
 
 // function schemas are normalized to standard schemas, mirroring the generated env.d.ts types
-variables.PORT.schema satisfies StandardSchemaV1<string | undefined, number>;
+variables.PORT.schema satisfies StandardSchemaV1<string | undefined, number | undefined>;
 type PortOutput = StandardSchemaV1.InferOutput<typeof variables.PORT.schema>;
 
 3000 satisfies PortOutput;
 
-// @ts-expect-error `undefined` is excluded from the inferred output
+// returning `undefined` is valid, so it stays in the inferred output
 undefined satisfies PortOutput;
 
 // standard schema configs keep their type

--- a/packages/kit/test/types/env.test.ts
+++ b/packages/kit/test/types/env.test.ts
@@ -1,0 +1,47 @@
+import { defineEnvVars } from '@sveltejs/kit/env';
+import type { StandardSchemaV1 } from '@standard-schema/spec';
+
+const callable_schema = Object.assign((value: string | undefined) => String(value), {
+	'~standard': {
+		version: 1 as const,
+		vendor: 'test',
+		validate: (value: unknown) => ({ value: String(value) })
+	}
+});
+
+const variables = defineEnvVars({
+	PORT: {
+		schema: (value) => (value === undefined ? 3000 : Number(value) || undefined)
+	},
+	NAME: {
+		schema: {
+			'~standard': {
+				version: 1,
+				vendor: 'test',
+				validate: (value) => ({ value: String(value) })
+			}
+		}
+	},
+	CALLABLE: {
+		schema: callable_schema
+	},
+	PLAIN: {}
+});
+
+// function schemas are normalized to standard schemas, mirroring the generated env.d.ts types
+variables.PORT.schema satisfies StandardSchemaV1<string | undefined, number>;
+type PortOutput = StandardSchemaV1.InferOutput<typeof variables.PORT.schema>;
+
+3000 satisfies PortOutput;
+
+// @ts-expect-error `undefined` is excluded from the inferred output
+undefined satisfies PortOutput;
+
+// standard schema configs keep their type
+variables.NAME.schema satisfies StandardSchemaV1<string | undefined, string>;
+
+// callable standard schemas (e.g. ArkType) are not treated as function validators
+variables.CALLABLE.schema satisfies StandardSchemaV1<unknown, string>;
+variables.CALLABLE.schema satisfies (value: string | undefined) => string;
+
+void variables.PLAIN;

--- a/packages/kit/tsconfig.json
+++ b/packages/kit/tsconfig.json
@@ -8,6 +8,7 @@
 		"moduleResolution": "nodenext",
 		"paths": {
 			"@sveltejs/kit": ["./src/exports/public.d.ts"],
+			"@sveltejs/kit/env": ["./src/exports/env/index.js"],
 			"@sveltejs/kit/vite": ["./src/exports/vite/index.js"],
 			"@sveltejs/kit/node": ["./src/exports/node/index.js"],
 			"@sveltejs/kit/internal": ["./src/exports/internal/index.js"],

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2414,7 +2414,7 @@ declare module '@sveltejs/kit' {
 		 * The validator can output any value — not necessarily a string — but public, non-static values must be
 		 * serializable by [devalue](https://github.com/sveltejs/devalue) so that they can be sent to the browser.
 		 *
-		 * If omitted, the value must be a non-empty string.
+		 * If omitted, the value must be set, but may be an empty string.
 		 */
 		schema?: StandardSchemaV1<string | undefined, T>;
 		/**

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2413,8 +2413,8 @@ declare module '@sveltejs/kit' {
 		static?: boolean;
 		/**
 		 * A [Standard Schema](https://standardschema.dev/) validator that is applied to the value when the app starts.
-		 * Alternatively, a function that returns the (possibly transformed) value, returns `undefined` if
-		 * the value is invalid, or throws an error explaining the problem.
+		 * Alternatively, a function that returns the (possibly transformed) value, or throws an error explaining
+		 * the problem. Returning `undefined` is valid, so a function can describe an optional variable.
 		 * The validator can output any value — not necessarily a string — but public, non-static values must be
 		 * serializable by [devalue](https://github.com/sveltejs/devalue) so that they can be sent to the browser.
 		 *

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2441,7 +2441,7 @@ declare module '@sveltejs/kit' {
 		C['schema'] extends StandardSchemaV1<any, any>
 			? C
 			: C['schema'] extends (value: any) => infer R
-				? Omit<C, 'schema'> & { schema: StandardSchemaV1<string | undefined, Exclude<R, undefined>> }
+				? Omit<C, 'schema'> & { schema: StandardSchemaV1<string | undefined, R> }
 				: C;
 	interface AdapterEntry {
 		/**
@@ -2908,7 +2908,7 @@ declare module '@sveltejs/kit/env' {
 	 * 		schema: (value) => {
 	 * 			if (value === undefined) return 3000;
 	 * 			const port = Number(value);
-	 * 			if (!Number.isInteger(port)) return;
+	 * 			if (!Number.isInteger(port)) throw new Error('PORT must be an integer');
 	 * 			return port;
 	 * 		}
 	 * 	}

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2411,17 +2411,36 @@ declare module '@sveltejs/kit' {
 		static?: boolean;
 		/**
 		 * A [Standard Schema](https://standardschema.dev/) validator that is applied to the value when the app starts.
+		 * Alternatively, a function that returns the (possibly transformed) value, returns `undefined` if
+		 * the value is invalid, or throws an error explaining the problem.
 		 * The validator can output any value — not necessarily a string — but public, non-static values must be
 		 * serializable by [devalue](https://github.com/sveltejs/devalue) so that they can be sent to the browser.
 		 *
 		 * If omitted, the value must be set, but may be an empty string.
 		 */
-		schema?: StandardSchemaV1<string | undefined, T>;
+		schema?: StandardSchemaV1<string | undefined, T> | ((value: string | undefined) => T | undefined);
 		/**
 		 * A description of the variable that will be used for inline documentation on hover.
 		 */
 		description?: string;
 	}
+
+	/**
+	 * The return type of [`defineEnvVars`](https://svelte.dev/docs/kit/@sveltejs-kit-env#defineEnvVars).
+	 */
+	export type DefinedEnvVars<T extends Record<string, EnvVarConfig<any>>> = {
+		readonly [K in keyof T]: EnvVarEntry<T[K]>;
+	};
+
+	/**
+	 * Normalizes an environment variable config's schema (standard schema or function) to standard schema.
+	 */
+	type EnvVarEntry<C extends EnvVarConfig<any>> =
+		C['schema'] extends StandardSchemaV1<any, any>
+			? C
+			: C['schema'] extends (value: any) => infer R
+				? Omit<C, 'schema'> & { schema: StandardSchemaV1<string | undefined, Exclude<R, undefined>> }
+				: C;
 	interface AdapterEntry {
 		/**
 		 * A string that uniquely identifies an HTTP service (e.g. serverless function) and is used for deduplication.
@@ -2861,12 +2880,33 @@ declare module '@sveltejs/kit' {
 }
 
 declare module '@sveltejs/kit/env' {
-	import type { EnvVarConfig } from '@sveltejs/kit';
+	import type { EnvVarConfig, DefinedEnvVars } from '@sveltejs/kit';
 	/**
 	 * Utility for defining [environment variables](https://svelte.dev/docs/kit/environment-variables),
 	 * which are made available via `$app/env/public` and `$app/env/private`.
+	 *
+	 * @example
+	 * ```js
+	 * import { defineEnvVars } from '@sveltejs/kit/env';
+	 * import * as v from 'valibot';
+	 *
+	 * export const variables = defineEnvVars({
+	 * 	API_URL: {
+	 * 		schema: v.pipe(v.string(), v.url())
+	 * 	},
+	 * 	PORT: {
+	 * 		schema: (value) => {
+	 * 			if (value === undefined) return 3000;
+	 * 			const port = Number(value);
+	 * 			if (!Number.isInteger(port)) return;
+	 * 			return port;
+	 * 		}
+	 * 	}
+	 * });
+	 * ```
+	 *
 	 * */
-	export function defineEnvVars<T extends Record<string, EnvVarConfig<any>>>(variables: T): T;
+	export function defineEnvVars<T extends Record<string, EnvVarConfig<any>>>(variables: T): DefinedEnvVars<T>;
 
 	export {};
 }


### PR DESCRIPTION
As invited in [#16195](https://github.com/sveltejs/kit/issues/16195#issuecomment-5009795012), `defineEnvVars` now accepts a function in place of a Standard Schema. The contract mirrors `defineParams`: the function returns the (possibly transformed) value, or `undefined` if the value is invalid. It can also throw, in which case the error's message appears in the startup report, since a bare `undefined` can't carry one.

Throwing is the only rejection path, returning any value including `undefined` accepts it, so a function validator can describe an optional variable without a fallback.

`defineEnvVars` normalizes functions to standard schemas, so `validate` and the generated `env.d.ts` types are unchanged (the return type is mapped like `DefinedParams`). Also adds the `@sveltejs/kit/env` tsconfig paths entry that #16378 didn't need yet.

Built on top of #16401.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.

