### PR TITLE
fix: don't treat callable standard schemas as function param matchers

### DIFF
--- a/.changeset/callable-param-matchers.md
+++ b/.changeset/callable-param-matchers.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: don't treat callable standard schemas as function param matchers

--- a/packages/kit/src/exports/params.js
+++ b/packages/kit/src/exports/params.js
@@ -35,6 +35,15 @@ export function defineParams(definitions) {
  * @returns {import('@sveltejs/kit').ParamMatcher}
  */
 export function normalize_param_definition(definition) {
+	// standard schemas can be callable (e.g. ArkType), so this must be checked before the function case
+	if (
+		definition &&
+		(typeof definition === 'object' || typeof definition === 'function') &&
+		'~standard' in definition
+	) {
+		return definition;
+	}
+
 	if (typeof definition === 'function') {
 		return /** @type {import('@sveltejs/kit').ParamMatcher} */ (
 			/** @type {unknown} */ ({
@@ -53,10 +62,6 @@ export function normalize_param_definition(definition) {
 				}
 			})
 		);
-	}
-
-	if (definition && typeof definition === 'object' && '~standard' in definition) {
-		return definition;
 	}
 
 	throw new Error('Invalid param definition');

--- a/packages/kit/src/utils/params.spec.js
+++ b/packages/kit/src/utils/params.spec.js
@@ -72,3 +72,23 @@ test('normalize_param_definition propagates thrown errors', () => {
 
 	assert.throws(() => matcher['~standard'].validate('x'), /boom/);
 });
+
+test('normalize_param_definition passes callable standard schemas through untouched', () => {
+	// standard schemas can be callable (e.g. ArkType)
+	const callable = /** @type {import('@sveltejs/kit').ParamMatcher} */ (
+		/** @type {unknown} */ (
+			Object.assign(() => 'from-call', {
+				'~standard': {
+					version: 1,
+					vendor: 'test',
+					validate: () => ({ value: 'from-schema' })
+				}
+			})
+		)
+	);
+
+	const matcher = normalize_param_definition(callable);
+
+	assert.equal(matcher, callable);
+	assert.deepEqual(matcher['~standard'].validate('x'), { value: 'from-schema' });
+});


### PR DESCRIPTION
`normalize_param_definition` checks for a function before checking for `~standard`, but standard schemas can themselves be callable. ArkType's `type()` returns one, so it gets wrapped as a plain function matcher and its own validation never runs. The wrapper then treats whatever the call returns as the parsed value, and ArkType returns an `ArkErrors` instance rather than throwing:

```js
const matcher = normalize_param_definition(type('string.numeric'));
matcher['~standard'].validate('not-a-number');
// { value: ArkErrors } so the route matches, with an ArkErrors instance as the param
```

Checking `~standard` first fixes this, verified against arktype 2.x (invalid values now produce `issues`, so the route no longer matches). It also matches `ParamEntry` in `public.d.ts`, which has resolved callable schemas to the schema branch since #16189. Same discriminator fix as #16402.

The new test fails on `version-3`.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
