### PR TITLE
chore: fix Renovate parsing of pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -91,6 +91,6 @@ catalogs:
   # vite-beta:
   #   vite: ^9.0.0-beta.0
   #   '@sveltejs/vite-plugin-svelte': ^7.0.0
-overrides:
+overrides: {}
   # ci script replaces all overrides with the vite-xxx or node-xx catalogs above.
   # if you want to introduce an override, make sure to add it to all of them too


### PR DESCRIPTION
`pnpm-workspace.yaml` ends with an `overrides` key holding only comments, which YAML parses as `null`. pnpm ignores that, but Renovate's schema rejects it ("expected record, received null") and discards the whole file, so the `catalog:` entries are invisible to it. That is the "Failed to parse pnpm-workspace.yaml file" warning in #3256, and the reason catalog deps stopped getting update PRs after #15597 in March. `{}` passes the schema (verified against [schema.ts#L53-L67](https://github.com/renovatebot/renovate/blob/8e6a7fc2e660/lib/modules/manager/npm/schema.ts#L53-L67)), and the CI yq step overwrites the key either way.

After this merges the non-major group also needs its "recreate" checkbox ticked on #3256, since Renovate suppresses the group while #16180 stays closed.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
