### PR TITLE
fix: ignore path casing differences in Vite config override warning

### DIFF
--- a/.changeset/tidy-hoops-brake.md
+++ b/.changeset/tidy-hoops-brake.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: ignore path casing differences when warning about overridden Vite config on Windows

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -1682,11 +1682,7 @@ function find_overridden_config(config, resolved_config, enforced_config, path, 
 			const resolved = resolved_config[key];
 
 			if (enforced === true) {
-				// Normalize path separators before comparing to avoid false positives on Windows,
-				// where config values like `root` may use backslashes while SvelteKit uses forward slashes.
-				const a = typeof config[key] === 'string' ? posixify(config[key]) : config[key];
-				const b = typeof resolved === 'string' ? posixify(resolved) : resolved;
-				if (a !== b) {
+				if (comparable(config[key]) !== comparable(resolved)) {
 					out.push(path + key);
 				}
 			} else {
@@ -1695,6 +1691,17 @@ function find_overridden_config(config, resolved_config, enforced_config, path, 
 		}
 	}
 	return out;
+}
+
+/**
+ * Normalizes a config value for comparison, since Windows paths may use backslashes
+ * and differ in casing (e.g. the drive letter) depending on where they came from.
+ * @param {any} value
+ */
+function comparable(value) {
+	if (typeof value !== 'string') return value;
+	const normalized = posixify(value);
+	return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
 }
 
 /**


### PR DESCRIPTION
Fixes #16317, follow-up to #16037 which normalized separators for this warning but left the comparison case-sensitive. #16239 addressed the same casing issue with a per-key whitelist before it was closed alongside #16293.

During `svelte-check`, `@sveltejs/load-config` resolves the Vite config with an explicit `root` derived from directory traversal (`loadSvelteConfigFromVite` passes `{ root, configFile }` and chdirs first), so the config SvelteKit's plugin receives always contains `root`, and it gets compared against SvelteKit's `posixify(process.cwd())`. The two strings match exactly on Linux, which is why the warning only ever shows on Windows, where the two routes can disagree on casing (typically the drive letter) and #16037's slash normalization doesn't help. That matches #16317 still reproducing on 2.69.2 after #16293 was closed as unreproducible on non-Windows. Windows paths are case-insensitive, so the comparison now folds case on win32.

Traced by instrumenting `find_overridden_config`, Vite's `resolveConfig` and `runConfigHook` in a fresh kit 2.69.2 + svelte-check 4.7.3 app. Validated by injecting a case-only difference into that flow, where the current comparison prints the reported warning, the fixed one stays silent, and a genuine `appType` override still warns. The reporter has since confirmed the case-only difference on real Windows in https://github.com/sveltejs/kit/issues/16317#issuecomment-5027938691. Like #16037 there is no test, the function is internal and the behaviour platform-specific.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.

