### PR TITLE
perf: match only unpaired surrogates when escaping HTML

### DIFF
--- a/.changeset/eight-lions-argue.md
+++ b/.changeset/eight-lions-argue.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+perf: match only unpaired surrogates when escaping HTML

--- a/packages/kit/src/utils/escape.js
+++ b/packages/kit/src/utils/escape.js
@@ -21,24 +21,12 @@ const escape_html_dict = {
 	'<': '&lt;'
 };
 
-const surrogates = // high surrogate without paired low surrogate
-	'[\\ud800-\\udbff](?![\\udc00-\\udfff])|' +
-	// a valid surrogate pair, the only match with 2 code units
-	// we match it so that we can match unpaired low surrogates in the same pass
-	// TODO: use lookbehind assertions once they are widely supported: (?<![\ud800-udbff])[\udc00-\udfff]
-	'[\\ud800-\\udbff][\\udc00-\\udfff]|' +
-	// unpaired low surrogate (see previous match)
-	'[\\udc00-\\udfff]';
+// `\p{Surrogate}` only matches unpaired surrogates with the `u` flag (a pair is one code point)
+/** @param {Record<string, string>} dict */
+const escape_regex = (dict) => new RegExp(`[${Object.keys(dict).join('')}]|\\p{Surrogate}`, 'gu');
 
-const escape_html_attr_regex = new RegExp(
-	`[${Object.keys(escape_html_attr_dict).join('')}]|` + surrogates,
-	'g'
-);
-
-const escape_html_regex = new RegExp(
-	`[${Object.keys(escape_html_dict).join('')}]|` + surrogates,
-	'g'
-);
+const escape_html_attr_regex = escape_regex(escape_html_attr_dict);
+const escape_html_regex = escape_regex(escape_html_dict);
 
 /**
  * Escapes unpaired surrogates (which are allowed in js strings but invalid in HTML) and
@@ -51,14 +39,10 @@ const escape_html_regex = new RegExp(
  */
 export function escape_html(str, is_attr) {
 	const dict = is_attr ? escape_html_attr_dict : escape_html_dict;
-	const escaped_str = str.replace(is_attr ? escape_html_attr_regex : escape_html_regex, (match) => {
-		if (match.length === 2) {
-			// valid surrogate pair
-			return match;
-		}
-
-		return dict[match] ?? `&#${match.charCodeAt(0)};`;
-	});
+	const escaped_str = str.replace(
+		is_attr ? escape_html_attr_regex : escape_html_regex,
+		(match) => dict[match] ?? `&#${match.charCodeAt(0)};`
+	);
 
 	return escaped_str;
 }


### PR DESCRIPTION
Resolves the TODO in `escape.js` from #4024, which planned to simplify the surrogate pattern with lookbehind assertions once widely supported. Lookbehind has been safe everywhere relevant since Safari 16.4, but `\p{Surrogate}` with the `u` flag is simpler still and supported even longer (ES2018). Under the `u` flag a valid surrogate pair forms a single astral code point, so `\p{Surrogate}` matches only unpaired surrogates and the pattern's other two branches disappear, including the branch that existed only to match valid pairs so the replace callback could return them unchanged.

That branch is also why this is a perf change rather than a cleanup. Every valid pair in rendered content currently invokes the replace callback just to pass through. With the new pattern pairs never match, so `escape_html` measures about 2x faster on emoji-heavy content in a quick microbench, with plain ASCII at parity.

Output is unchanged. I diffed the old and new implementations over 200k fuzzed strings built from surrogate halves, dict characters and astral pairs, plus curated edge cases, in both modes, all byte-identical. `escape.spec.js` passes as-is.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
