### PR TITLE
breaking: require Node 22.17

### DIFF
--- a/.changeset/thick-otters-decide.md
+++ b/.changeset/thick-otters-decide.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': major
+---
+
+breaking: require Node 22.17 or newer

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -147,6 +147,6 @@
 	},
 	"types": "types/index.d.ts",
 	"engines": {
-		"node": ">=22"
+		"node": ">=22.17"
 	}
 }

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -137,14 +137,8 @@ export function getRequest({ request, base, bodySizeLimit }) {
 	}
 
 	const controller = new AbortController();
-	// TODO: Whenever Node >=22.17 is the minimum supported version, we can do `if (request.readableAborted) controller.abort()` instead
-	// see https://github.com/nodejs/node/blob/5cf3c3e24c7257a0c6192ed8ef71efec8ddac22b/lib/internal/streams/readable.js#L1443-L1453
-	let errored = false;
-	let end_emitted = false;
-	request.once('error', () => (errored = true));
-	request.once('end', () => (end_emitted = true));
 	request.once('close', () => {
-		if ((errored || request.destroyed) && !end_emitted) {
+		if (request.readableAborted) {
 			controller.abort();
 		}
 	});


### PR DESCRIPTION
`packages/kit/src/exports/node/index.js` has carried a TODO from #14715 saying the manual errored/end_emitted tracking around request aborts can become `request.readableAborted` once Node >=22.17 is the minimum. The engines floor was set to >=22 by #12548 and can only move while 3.0 is unreleased, so this seems like the moment to decide. 22.17.0 was the June 2025 LTS release, which makes 22.0 to 22.16 unpatched minors. Flagged in the TODO inventory on #1247.

Only `@sveltejs/kit` moves to >=22.17 since the runtime TODO is the only thing that needs it, `package` and `enhanced-img` stay at >=22.

The request-abort test from #14715 passes with the simplified code (dev-only suite, 15 passed), along with the unit suite and typecheck.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
