### PR TITLE
docs: add scroll management page

### DIFF
--- a/documentation/docs/30-advanced/66-scroll-management.md
+++ b/documentation/docs/30-advanced/66-scroll-management.md
@@ -36,6 +36,8 @@ Since only your app knows which element scrolls, you can manage the container yo
 </div>
 ```
 
-On every navigation, `capture` saves the container's scroll position against the outgoing history entry immediately before the page updates, and `afterNavigate` scrolls new pages to the top. On back and forward navigations, `restore` is called with the saved position after the `afterNavigate` callbacks have run, so the two don't conflict. Snapshots are persisted to `sessionStorage`, so the position also survives a reload.
+On every navigation, `capture` saves the container's scroll position against the outgoing history entry immediately before the page updates, and `afterNavigate` scrolls new pages to the top. On back and forward navigations, `restore` is called with the saved position after the `afterNavigate` callbacks have run, so the two don't conflict. Snapshots are persisted to `sessionStorage`, so the position also survives a reload. Links with a `#hash` keep working, since SvelteKit scrolls the targeted element into view within its container after the reset.
+
+Note that `afterNavigate` callbacks can't tell whether a navigation used [`data-sveltekit-noscroll`](link-options#data-sveltekit-noscroll) or `goto`'s `noScroll` option, so the container is also reset on those navigations.
 
 > [!NOTE] Passing [`behavior: 'instant'`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTo) makes the reset immediate even if the container has [`scroll-behavior: smooth`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior) in CSS, which would otherwise animate it on every navigation.

--- a/documentation/docs/30-advanced/66-scroll-management.md
+++ b/documentation/docs/30-advanced/66-scroll-management.md
@@ -2,7 +2,7 @@
 title: Scroll management
 ---
 
-When you navigate between pages, SvelteKit mirrors the browser's default behaviour: it scrolls to the top of the page (or to the element with a matching ID, if the link includes a `#hash`), and restores the previous scroll position when you navigate back or forward. You can opt out per link with [`data-sveltekit-noscroll`](link-options#data-sveltekit-noscroll) or per navigation with the `noScroll` option of [`goto`]($app-navigation#goto).
+When you navigate between pages, SvelteKit mirrors the browser's default behaviour: it scrolls to the top of the page (or to the element with a matching ID, if the link includes a `#hash`), and restores the previous scroll position when you navigate back or forward. You can opt out per link with [`data-sveltekit-reset="false"`](link-options#data-sveltekit-reset) or per navigation with `goto`'s [`reset: false`]($app-navigation#goto) option, both of which also skip the [focus reset](accessibility#Focus-management).
 
 This applies to the scroll position of the _document_. If your pages scroll inside a custom container instead — for example a layout where `<html>` and `<body>` have `overflow: hidden` and an inner element scrolls, as is common in mobile-style app shells — SvelteKit has no way of knowing which element it should scroll. The container will keep its scroll position when you navigate, and nothing will be restored when you go back.
 
@@ -38,6 +38,6 @@ Since only your app knows which element scrolls, you can manage the container yo
 
 On every navigation, `capture` saves the container's scroll position against the outgoing history entry immediately before the page updates, and `afterNavigate` scrolls new pages to the top. On back and forward navigations, `restore` is called with the saved position after the `afterNavigate` callbacks have run, so the two don't conflict. Snapshots are persisted to `sessionStorage`, so the position also survives a reload. Links with a `#hash` still end up at the targeted element.
 
-Note that `afterNavigate` callbacks can't tell whether a navigation used [`data-sveltekit-noscroll`](link-options#data-sveltekit-noscroll) or `goto`'s `noScroll` option, so the container is also reset on those navigations.
+Note that `afterNavigate` callbacks can't tell whether a navigation used [`data-sveltekit-reset="false"`](link-options#data-sveltekit-reset) or `goto`'s `reset: false`, so the container is also reset on those navigations.
 
 > [!NOTE] Passing [`behavior: 'instant'`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTo) makes the reset and the restore immediate even if the container has [`scroll-behavior: smooth`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior) in CSS, which would otherwise animate them.

--- a/documentation/docs/30-advanced/66-scroll-management.md
+++ b/documentation/docs/30-advanced/66-scroll-management.md
@@ -36,7 +36,7 @@ Since only your app knows which element scrolls, you can manage the container yo
 </div>
 ```
 
-On every navigation, `capture` saves the container's scroll position against the outgoing history entry immediately before the page updates, and `afterNavigate` scrolls new pages to the top. On back and forward navigations, `restore` is called with the saved position after the `afterNavigate` callbacks have run, so the two don't conflict. Snapshots are persisted to `sessionStorage`, so the position also survives a reload. Links with a `#hash` keep working, since SvelteKit scrolls the targeted element into view within its container after the reset.
+On every navigation, `capture` saves the container's scroll position against the outgoing history entry immediately before the page updates, and `afterNavigate` scrolls new pages to the top. On back and forward navigations, `restore` is called with the saved position after the `afterNavigate` callbacks have run, so the two don't conflict. Snapshots are persisted to `sessionStorage`, so the position also survives a reload. Links with a `#hash` still end up at the targeted element.
 
 Note that `afterNavigate` callbacks can't tell whether a navigation used [`data-sveltekit-noscroll`](link-options#data-sveltekit-noscroll) or `goto`'s `noScroll` option, so the container is also reset on those navigations.
 

--- a/documentation/docs/30-advanced/66-scroll-management.md
+++ b/documentation/docs/30-advanced/66-scroll-management.md
@@ -1,0 +1,41 @@
+---
+title: Scroll management
+---
+
+When you navigate between pages, SvelteKit mirrors the browser's default behaviour: it scrolls to the top of the page (or to the element with a matching ID, if the link includes a `#hash`), and restores the previous scroll position when you navigate back or forward. You can opt out per link with [`data-sveltekit-noscroll`](link-options#data-sveltekit-noscroll) or per navigation with the `noScroll` option of [`goto`]($app-navigation#goto).
+
+This applies to the scroll position of the _document_. If your pages scroll inside a custom container instead — for example a layout where `<html>` and `<body>` have `overflow: hidden` and an inner element scrolls, as is common in mobile-style app shells — SvelteKit has no way of knowing which element it should scroll. The container will keep its scroll position when you navigate, and nothing will be restored when you go back.
+
+Since only your app knows which element scrolls, you can manage the container yourself with [`afterNavigate`]($app-navigation#afterNavigate) and a [snapshot](snapshots) in the layout that owns it:
+
+```svelte
+<!--- file: src/routes/+layout.svelte --->
+<script>
+	import { afterNavigate } from '$app/navigation';
+
+	let { children } = $props();
+
+	/** @type {HTMLElement} */
+	let container;
+
+	/** @type {import('./$types').Snapshot<number>} */
+	export const snapshot = {
+		capture: () => container.scrollTop,
+		restore: (top) => (container.scrollTop = top)
+	};
+
+	afterNavigate((navigation) => {
+		if (navigation.type !== 'popstate') {
+			container.scrollTo({ top: 0, left: 0, behavior: 'instant' });
+		}
+	});
+</script>
+
+<div class="scroller" bind:this={container}>
+	{@render children()}
+</div>
+```
+
+On every navigation, `capture` saves the container's scroll position against the outgoing history entry immediately before the page updates, and `afterNavigate` scrolls new pages to the top. On back and forward navigations, `restore` is called with the saved position after the `afterNavigate` callbacks have run, so the two don't conflict. Snapshots are persisted to `sessionStorage`, so the position also survives a reload.
+
+> [!NOTE] Passing [`behavior: 'instant'`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTo) makes the reset immediate even if the container has [`scroll-behavior: smooth`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior) in CSS, which would otherwise animate it on every navigation.

--- a/documentation/docs/30-advanced/66-scroll-management.md
+++ b/documentation/docs/30-advanced/66-scroll-management.md
@@ -21,7 +21,7 @@ Since only your app knows which element scrolls, you can manage the container yo
 	/** @type {import('./$types').Snapshot<number>} */
 	export const snapshot = {
 		capture: () => container.scrollTop,
-		restore: (top) => (container.scrollTop = top)
+		restore: (top) => container.scrollTo({ top, behavior: 'instant' })
 	};
 
 	afterNavigate((navigation) => {
@@ -40,4 +40,4 @@ On every navigation, `capture` saves the container's scroll position against the
 
 Note that `afterNavigate` callbacks can't tell whether a navigation used [`data-sveltekit-noscroll`](link-options#data-sveltekit-noscroll) or `goto`'s `noScroll` option, so the container is also reset on those navigations.
 
-> [!NOTE] Passing [`behavior: 'instant'`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTo) makes the reset immediate even if the container has [`scroll-behavior: smooth`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior) in CSS, which would otherwise animate it on every navigation.
+> [!NOTE] Passing [`behavior: 'instant'`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTo) makes the reset and the restore immediate even if the container has [`scroll-behavior: smooth`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior) in CSS, which would otherwise animate them.


### PR DESCRIPTION
Adds the "scroll management" page to the advanced docs that #8723's review asked for. Rich preferred documenting the snapshot plus `afterNavigate` recipe over adding a container attribute to client.js, teemingc suggested documenting it again later on #2733, and the page never got written.

One reason it couldn't be written sooner: the recipe relies on snapshots restoring after the `afterNavigate` callbacks, which wasn't the actual order until #10823 was fixed. On current `version-3` the ordering holds.

Every claim on the page is verified against a real app using the documented layout verbatim (`html`/`body` with `overflow: hidden`, inner scroller): without the recipe the container keeps its scroll position across navigations, with it forward navigations reset to top, back navigations restore the saved position, capture runs before the page updates, restore runs after `afterNavigate`, and the position survives a reload via `sessionStorage`. The `behavior: 'instant'` note keeps the reset immediate under `scroll-behavior: smooth`.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
