### PR TITLE
fix: hide stack traces for internal errors like 404s

### DIFF
--- a/.changeset/cozy-crabs-attend.md
+++ b/.changeset/cozy-crabs-attend.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: hide stack traces for internal errors like 404s

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -5,6 +5,7 @@ import { options, get_hooks } from '__SERVER__/internal.js';
 import { set_read_implementation, set_manifest } from './internal.js';
 import { set_env } from '__sveltekit/env';
 import { set_app } from './app.js';
+import { SvelteKitError } from '@sveltejs/kit/internal';
 
 /** @type {Promise<any>} */
 let init_promise;
@@ -107,6 +108,11 @@ export class Server {
 					handleError:
 						module.handleError ||
 						(({ error }) => {
+							if (error instanceof SvelteKitError) {
+								// don't log stack traces for 404s etc, it's all internal gubbins
+								return;
+							}
+
 							let e = error;
 							while (e instanceof Error) {
 								if (e.stack) {


### PR DESCRIPTION
When an unexpected error occurs, we log a stack trace. That stack trace is useless in the case of an error thrown by SvelteKit itself, like a 404 or 413. We are better off just omitting it.

Going to open a follow-up issue for this as I think we need to decide between a couple of options:

- continue to pass these errors to `handleError`, but make it easy to identify them so that people can choose to omit stack traces themselves
- don't pass these errors to `handleError`, since they indicate user error rather than bugs

Of those I like option 2, but that requires design discussion whereas this change feels like a no-brainer.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
