### PR TITLE
Revert "chore(deps): update pnpm to v11.15.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"prettier-plugin-svelte": "catalog:",
 		"vitest": "catalog:"
 	},
-	"packageManager": "pnpm@11.15.0+sha512.266f8957a30d2be6e9468e5e66bcdedd35a794175f71b067ba8504d686cce1d0c0f429b33c323c3c569ad4891e667574a49ff71d1b89a22cc66f13c65818c578",
+	"packageManager": "pnpm@11.8.0+sha512.c1f5e7c4cb241c8f174b743851d82f42b802324afc8b0f116b96adb15aa06664948dde36960a3ba1079ba5b4b29dd0140135b94b5b5f5263592249d68e555f26",
 	"engines": {
 		"pnpm": ">=11.0.0"
 	}


### PR DESCRIPTION
this is causing havoc due to `minimumReleaseAge` settings