### PR TITLE
fix: reject malformed streamed data encoding

### DIFF
--- a/.changeset/common-wings-doubt.md
+++ b/.changeset/common-wings-doubt.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: reject malformed streamed data encoding

--- a/packages/kit/src/runtime/client/ndjson.js
+++ b/packages/kit/src/runtime/client/ndjson.js
@@ -6,7 +6,7 @@ import { read_stream } from './stream.js';
  * @param {ReadableStreamDefaultReader<Uint8Array>} reader
  */
 export async function* read_ndjson(reader) {
-	for await (const block of read_stream(reader, '\n')) {
+	for await (const block of read_stream(reader, '\n', { fatal: true })) {
 		const line = block.trim();
 		if (line) {
 			yield JSON.parse(line);

--- a/packages/kit/src/runtime/client/ndjson.spec.js
+++ b/packages/kit/src/runtime/client/ndjson.spec.js
@@ -1,0 +1,48 @@
+import { expect, test } from 'vitest';
+import { read_ndjson } from './ndjson.js';
+
+const encoder = new TextEncoder();
+
+/**
+ * @param {Uint8Array[]} chunks
+ */
+function read(chunks) {
+	return read_ndjson(
+		new ReadableStream({
+			start(controller) {
+				for (const chunk of chunks) {
+					controller.enqueue(chunk);
+				}
+				controller.close();
+			}
+		}).getReader()
+	);
+}
+
+/**
+ * @param {Uint8Array[]} chunks
+ */
+async function collect(chunks) {
+	const values = [];
+	for await (const value of read(chunks)) {
+		values.push(value);
+	}
+	return values;
+}
+
+test('parses streamed data when UTF-8 code points are split across chunks', async () => {
+	const bytes = encoder.encode(`${JSON.stringify({ type: 'data', value: '\u00e9' })}\n`);
+	const chunks = Array.from(bytes, (byte) => new Uint8Array([byte]));
+
+	await expect(collect(chunks)).resolves.toEqual([{ type: 'data', value: '\u00e9' }]);
+});
+
+test('rejects malformed UTF-8 before parsing streamed data', async () => {
+	const chunks = [
+		encoder.encode('{"type":"data","nodes":[{"id":239,'),
+		new Uint8Array([0xff]),
+		encoder.encode('"url":240}]}\n')
+	];
+
+	await expect(collect(chunks)).rejects.toThrow(TypeError);
+});

--- a/packages/kit/src/runtime/client/stream.js
+++ b/packages/kit/src/runtime/client/stream.js
@@ -4,11 +4,12 @@
  * stream closes.
  * @param {ReadableStreamDefaultReader<Uint8Array>} reader
  * @param {string} delimiter
+ * @param {TextDecoderOptions} [options]
  */
-export async function* read_stream(reader, delimiter) {
+export async function* read_stream(reader, delimiter, options) {
 	let done = false;
 	let buffer = '';
-	const decoder = new TextDecoder();
+	const decoder = new TextDecoder(undefined, options);
 
 	while (true) {
 		let split = buffer.indexOf(delimiter);


### PR DESCRIPTION
Related to #15511.

## Summary

Thanks for SvelteKit. I really appreciate the care that goes into this project.

This PR tightens streamed `__data.json` parsing so newline-delimited JSON data is decoded with fatal UTF-8 handling. Previously, malformed UTF-8 bytes could be decoded as replacement characters and then surface later as `JSON.parse` syntax errors. With this change, malformed stream encoding is rejected at the decoding boundary instead of being parsed as corrupted JSON text.

The diagnostic path that led to this patch traced the streamed response across the raw bytes -> UTF-8 text -> NDJSON record -> JSON parse boundary. That pointed at the byte-to-text transition as the useful place to fail fast, rather than changing the later JSON parsing path.

I also added regression coverage for the streamed-data parser:

- split UTF-8 code points across chunks still parse correctly
- malformed UTF-8 is rejected before JSON parsing

I did not have a reliable end-to-end reproduction of the original timing/network conditions described in #15511. The issue notes that the full problem has been difficult to reproduce, so this PR focuses on the malformed UTF-8 / NDJSON boundary shown by the replacement-character failures in the report. Happy to adjust the scope, wording, or test shape if you would prefer a different framing.

## Validation

Passed:

- `pnpm -F @sveltejs/kit test:unit`
- `pnpm lint` after rerunning with a larger Node heap because the default local heap hit an OOM during repo-wide ESLint
- `pnpm check`
- `git diff --check`

Also run:

- `KIT_E2E_BROWSER=chromium pnpm run test:kit`

That package-level browser/integration run reached the Chromium Playwright tests, but failed in `packages/kit/test/apps/async` on an existing direct `http.get` / Playwright webServer readiness case with `ECONNREFUSED 127.0.0.1:5173`. I did not change that area; the new unit regression passed in the focused and full `@sveltejs/kit` unit runs.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.

Disclosure: I used AI-assisted coding tools while preparing this PR. I reviewed the changes myself, tested them, and take responsibility for the implementation and any follow-up revisions needed.
