### PR TITLE
docs: show a reliable way to preload fonts

### DIFF
--- a/documentation/docs/40-best-practices/05-performance.md
+++ b/documentation/docs/40-best-practices/05-performance.md
@@ -51,6 +51,20 @@ Video files can be very large, so extra care should be taken to ensure that they
 
 SvelteKit automatically preloads critical `.js` and `.css` files when the user visits a page, but it does _not_ preload fonts by default, since this may cause unnecessary files (such as font weights that are referenced by your CSS but not actually used on the current page) to be downloaded. Having said that, preloading fonts correctly can make a big difference to how fast your site feels. In your [`handle`](hooks#handle) hook, you can call `resolve` with a `preload` filter that includes your fonts.
 
+Match fonts on `name`, which is the file name before hashing. Matching `path` instead means matching a hashed file name, which changes whenever the file does:
+
+```js
+/// file: src/hooks.server.js
+/** @type {import('@sveltejs/kit').Handle} */
+export async function handle({ event, resolve }) {
+	return resolve(event, {
+		preload: (input) => input.type !== 'font' || input.name === 'inter-latin-400.woff2'
+	});
+}
+```
+
+A filter that names a font it can no longer find preloads nothing, with no warning. If you would rather find out at build time, import the font with Vite's [`?url` suffix](https://vitejs.dev/guide/assets.html#explicit-url-imports) somewhere in your app, so that removing it fails the build.
+
 You can reduce the size of font files by [subsetting](https://web.dev/learn/performance/optimize-web-fonts#subset_your_web_fonts) your fonts.
 
 ## Reducing code size

--- a/documentation/docs/40-best-practices/05-performance.md
+++ b/documentation/docs/40-best-practices/05-performance.md
@@ -49,23 +49,25 @@ Video files can be very large, so extra care should be taken to ensure that they
 
 ### Fonts
 
-SvelteKit automatically preloads critical `.js` and `.css` files when the user visits a page, but it does _not_ preload fonts by default, since this may cause unnecessary files (such as font weights that are referenced by your CSS but not actually used on the current page) to be downloaded. Having said that, preloading fonts correctly can make a big difference to how fast your site feels. In your [`handle`](hooks#handle) hook, you can call `resolve` with a `preload` filter that includes your fonts.
-
-Match fonts on `filename`, the source file's path relative to the project root. `path` is the hashed output path, which changes whenever the file's contents do:
+SvelteKit automatically preloads critical `.js` and `.css` files when the user visits a page, but it does _not_ preload fonts by default, since this may cause unnecessary files (such as font weights that are referenced by your CSS but not actually used on the current page) to be downloaded. Having said that, preloading fonts correctly can make a big difference to how fast your site feels. In your [`handle`](hooks#handle) hook, you can call `resolve` with a `preload` filter that includes your fonts:
 
 ```js
 /// file: src/hooks.server.js
 /** @type {import('@sveltejs/kit').Handle} */
 export async function handle({ event, resolve }) {
 	return resolve(event, {
-		preload: (input) =>
-			input.type !== 'font' ||
-			input.filename === 'node_modules/@fontsource/inter/files/inter-latin-400-normal.woff2'
+		preload: (asset) => {
+			if (asset.type === 'font') {
+				return asset.filename === 'node_modules/@fontsource/inter/files/inter-latin-400-normal.woff2';
+			}
+
+			return true;
+		}
 	});
 }
 ```
 
-A `filename` that no longer exists matches nothing, so renaming or removing the font quietly stops the preload. To find out at build time instead, import the font with Vite's [`?url` suffix](https://vitejs.dev/guide/assets.html#explicit-url-imports) from a module that uses it, so that a missing file fails the build.
+`filename` is the source filename relative to the project root, and is only available when `asset.type === 'font'` since JS and CSS assets are bundled by Vite.
 
 You can reduce the size of font files by [subsetting](https://web.dev/learn/performance/optimize-web-fonts#subset_your_web_fonts) your fonts.
 

--- a/documentation/docs/40-best-practices/05-performance.md
+++ b/documentation/docs/40-best-practices/05-performance.md
@@ -51,19 +51,21 @@ Video files can be very large, so extra care should be taken to ensure that they
 
 SvelteKit automatically preloads critical `.js` and `.css` files when the user visits a page, but it does _not_ preload fonts by default, since this may cause unnecessary files (such as font weights that are referenced by your CSS but not actually used on the current page) to be downloaded. Having said that, preloading fonts correctly can make a big difference to how fast your site feels. In your [`handle`](hooks#handle) hook, you can call `resolve` with a `preload` filter that includes your fonts.
 
-Match fonts on `name`, which is the file name before hashing. Matching `path` instead means matching a hashed file name, which changes whenever the file does:
+Match fonts on `filename`, the source file's path relative to the project root. `path` is the hashed output path, which changes whenever the file's contents do:
 
 ```js
 /// file: src/hooks.server.js
 /** @type {import('@sveltejs/kit').Handle} */
 export async function handle({ event, resolve }) {
 	return resolve(event, {
-		preload: (input) => input.type !== 'font' || input.name === 'inter-latin-400.woff2'
+		preload: (input) =>
+			input.type !== 'font' ||
+			input.filename === 'node_modules/@fontsource/inter/files/inter-latin-400-normal.woff2'
 	});
 }
 ```
 
-A filter that names a font it can no longer find preloads nothing, with no warning. If you would rather find out at build time, import the font with Vite's [`?url` suffix](https://vitejs.dev/guide/assets.html#explicit-url-imports) in a module that already uses it, so that removing the font fails the build.
+A `filename` that no longer exists matches nothing, so renaming or removing the font quietly stops the preload. To find out at build time instead, import the font with Vite's [`?url` suffix](https://vitejs.dev/guide/assets.html#explicit-url-imports) from a module that uses it, so that a missing file fails the build.
 
 You can reduce the size of font files by [subsetting](https://web.dev/learn/performance/optimize-web-fonts#subset_your_web_fonts) your fonts.
 

--- a/documentation/docs/40-best-practices/05-performance.md
+++ b/documentation/docs/40-best-practices/05-performance.md
@@ -63,7 +63,7 @@ export async function handle({ event, resolve }) {
 }
 ```
 
-A filter that names a font it can no longer find preloads nothing, with no warning. If you would rather find out at build time, import the font with Vite's [`?url` suffix](https://vitejs.dev/guide/assets.html#explicit-url-imports) somewhere in your app, so that removing it fails the build.
+A filter that names a font it can no longer find preloads nothing, with no warning. If you would rather find out at build time, import the font with Vite's [`?url` suffix](https://vitejs.dev/guide/assets.html#explicit-url-imports) in a module that already uses it, so that removing the font fails the build.
 
 You can reduce the size of font files by [subsetting](https://web.dev/learn/performance/optimize-web-fonts#subset_your_web_fonts) your fonts.
 


### PR DESCRIPTION
The docs say to opt fonts into preloading with a `preload` filter but not what to match against, so what everyone writes is a substring check against the hashed output path, which silently stops matching when the font is renamed. #16443 added `filename` for this; this shows it.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.

