### PR TITLE
fix: serialize query values seeded with `.set()` during SSR

### DIFF
--- a/.changeset/calm-lions-smile.md
+++ b/.changeset/calm-lions-smile.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: serialize query values seeded with .set() during server-side rendering

--- a/packages/kit/src/runtime/app/server/remote/query.js
+++ b/packages/kit/src/runtime/app/server/remote/query.js
@@ -404,8 +404,8 @@ export function refresh(event, state, internals, payload, fn) {
 		return;
 	}
 
-	if (!event.isRemoteRequest) {
-		// or this is a no-JS form submission
+	if (!event.isRemoteRequest && state.is_in_remote_form_or_command) {
+		// or this is a no-JS form submission, where the page re-renders anyway
 		return;
 	}
 

--- a/packages/kit/test/apps/async/src/routes/remote/set-during-ssr/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/set-during-ssr/+page.svelte
@@ -1,0 +1,16 @@
+<script>
+	import { onMount } from 'svelte';
+	import { get_items } from './set-during-ssr.remote.js';
+
+	let hydrated = $state(false);
+
+	onMount(() => {
+		hydrated = true;
+	});
+</script>
+
+<div id="hydrated">{hydrated}</div>
+
+{#each await get_items() as id}
+	<a href="/remote/set-during-ssr/{id}">item {id}</a>
+{/each}

--- a/packages/kit/test/apps/async/src/routes/remote/set-during-ssr/[id]/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/set-during-ssr/[id]/+page.svelte
@@ -1,0 +1,7 @@
+<script>
+	import { get_item } from '../set-during-ssr.remote.js';
+
+	const { params } = $props();
+</script>
+
+<div id="item">{await get_item(params.id)}</div>

--- a/packages/kit/test/apps/async/src/routes/remote/set-during-ssr/set-during-ssr.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/set-during-ssr/set-during-ssr.remote.js
@@ -1,0 +1,12 @@
+import { query } from '$app/server';
+
+const ids = ['1', '2', '3'];
+
+export const get_items = query(() => {
+	for (const id of ids) {
+		get_item(id).set(`seeded-${id}`);
+	}
+	return ids;
+});
+
+export const get_item = query('unchecked', (id) => `fetched-${id}`);

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -67,15 +67,11 @@ test.describe('remote function mutations', () => {
 		await expect(page.locator('#hydrated')).toHaveText('true');
 
 		let request_count = 0;
-		page.on(
-			'request',
-			(r) =>
-				(request_count += r.url().includes('/_app/remote/') && r.url().includes('get_item') ? 1 : 0)
-		);
+		page.on('request', (r) => (request_count += r.url().includes('/_app/remote') ? 1 : 0));
 
 		await page.getByRole('link', { name: 'item 1' }).click();
 		await expect(page.locator('#item')).toHaveText('seeded-1');
-		await page.waitForTimeout(100);
+		await page.waitForTimeout(100); // allow all requests to finish (there shouldn't be any)
 		expect(request_count).toBe(0);
 	});
 

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -62,6 +62,23 @@ test.describe('remote function mutations', () => {
 		expect(request_count).toBe(0);
 	});
 
+	test('query values seeded during SSR are reused on navigation', async ({ page }) => {
+		await page.goto('/remote/set-during-ssr');
+		await expect(page.locator('#hydrated')).toHaveText('true');
+
+		let request_count = 0;
+		page.on(
+			'request',
+			(r) =>
+				(request_count += r.url().includes('/_app/remote/') && r.url().includes('get_item') ? 1 : 0)
+		);
+
+		await page.getByRole('link', { name: 'item 1' }).click();
+		await expect(page.locator('#item')).toHaveText('seeded-1');
+		await page.waitForTimeout(100);
+		expect(request_count).toBe(0);
+	});
+
 	test('hydrated prerender data is reused', async ({ page }) => {
 		let request_count = 0;
 		page.on('request', (r) => (request_count += r.url().includes('/_app/remote') ? 1 : 0));

--- a/packages/kit/test/apps/async/test/server.test.js
+++ b/packages/kit/test/apps/async/test/server.test.js
@@ -23,6 +23,15 @@ test.describe('remote functions', () => {
 		expect(code.includes('const with_read = prerender(')).toBe(false);
 	});
 
+	test('query values seeded with .set() are serialized during SSR', async ({ page }) => {
+		await page.goto('/remote/set-during-ssr');
+		const html = await page.content();
+
+		expect(html).toContain('seeded-1');
+		expect(html).toContain('seeded-2');
+		expect(html).toContain('seeded-3');
+	});
+
 	test("form doesn't refresh queries when not a remote request", async ({ page }) => {
 		await page.goto(`/remote/form/noop-refresh-non-enhanced/${Date.now()}${Math.random()}`);
 


### PR DESCRIPTION
closes #16384

During SSR, calling `otherQuery(arg).set(value)` inside a query populates the request cache but never reaches the serialized payload, so the client refetches data the server already had. The same call during a client-initiated request is included in the endpoint response and reused without a network call.

The cause is the `!event.isRemoteRequest` guard in the `refresh()` helper. It was added in #15803 for non-enhanced form submissions, where refreshing queries is pointless because the page re-renders. At that time `.set()` outside a form/command threw, so the guard could not affect queries. #15991 removed that error as part of the serialization rework, which made `.set()` inside queries legal and serialized on the endpoint path, while the SSR render path still hit the old guard and silently dropped the registration.

The render already serializes `state.remote.explicit` and the client already seeds its cache from the SSR payload, so the fix narrows the guard to the case #15803 actually targeted, a form or command running outside a remote request. Non-enhanced form submissions behave as before, including the noop refresh test added in #15803.

Two side effects of the narrowed guard, both consistent with the endpoint path but worth ruling on knowingly. `.set()` and `.refresh()` called from a server or universal load during SSR now also serialize. The SSR payload gains `r: true` when explicit entries exist, which the client start code ignores.

Tests mirror the reporter's reproduction. A list query seeds per-item detail queries, the server test asserts the seeded values appear in the SSR HTML, and the client test asserts a client-side navigation renders the seeded value with zero remote requests.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
