### PR TITLE
fix: preserve stripped path prefixes in trailing-slash redirects

### DIFF
--- a/.changeset/tidy-pumas-travel.md
+++ b/.changeset/tidy-pumas-travel.md
@@ -1,0 +1,6 @@
+---
+'@sveltejs/kit': patch
+'@sveltejs/adapter-node': patch
+---
+
+fix: preserve stripped path prefixes by making trailing-slash redirects relative

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -94,8 +94,7 @@ function serve_prerendered() {
 		// remove or add trailing slash as appropriate
 		const inverted = pathname.at(-1) === '/' ? pathname.slice(0, -1) : pathname + '/';
 		if (prerendered.has(inverted)) {
-			let location = relative_pathname(pathname, inverted);
-			if (query) location += search;
+			const location = relative_pathname(pathname, inverted) + (query ? search : '');
 			res.writeHead(308, { location }).end();
 		} else {
 			void next();

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -61,14 +61,14 @@ function serve(path, client = false) {
 }
 
 /**
- * Relative reference from `from` to `to`, which must differ only by a trailing slash
+ * Relative reference from `from` to `to`, which must differ only by a trailing slash.
+ * Keep in sync with the copy in `packages/kit/src/utils/url.js`
  * @param {string} from
  * @param {string} to
  * @returns {string}
  */
 function relative_pathname(from, to) {
-	const pathname = from.endsWith('/') ? to : from;
-	const segment = pathname.slice(pathname.lastIndexOf('/') + 1);
+	const segment = to.replace(/\/$/, '').split('/').at(-1);
 
 	return from.endsWith('/') ? `../${segment}` : `${segment}/`;
 }

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -61,6 +61,7 @@ function serve(path, client = false) {
 }
 
 /**
+ * Relative reference from `from` to `to`, which must differ only by a trailing slash
  * @param {string} from
  * @param {string} to
  * @returns {string}

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -60,6 +60,18 @@ function serve(path, client = false) {
 		: undefined;
 }
 
+/**
+ * @param {string} from
+ * @param {string} to
+ * @returns {string}
+ */
+function relative_pathname(from, to) {
+	const pathname = from.endsWith('/') ? to : from;
+	const segment = pathname.slice(pathname.lastIndexOf('/') + 1);
+
+	return from.endsWith('/') ? `../${segment}` : `${segment}/`;
+}
+
 // required because the static file server ignores trailing slashes
 /** @returns {import('polka').Middleware} */
 function serve_prerendered() {
@@ -79,8 +91,9 @@ function serve_prerendered() {
 		}
 
 		// remove or add trailing slash as appropriate
-		let location = pathname.at(-1) === '/' ? pathname.slice(0, -1) : pathname + '/';
-		if (prerendered.has(location)) {
+		const inverted = pathname.at(-1) === '/' ? pathname.slice(0, -1) : pathname + '/';
+		if (prerendered.has(inverted)) {
+			let location = relative_pathname(pathname, inverted);
 			if (query) location += search;
 			res.writeHead(308, { location }).end();
 		} else {

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -11,7 +11,12 @@ import { respond_with_error } from './page/respond_with_error.js';
 import { get_self_origin, is_csrf_forbidden, is_remote_forbidden } from './csrf.js';
 import { has_prerendered_path, method_not_allowed, redirect_response } from './utils.js';
 import { handle_fatal_error } from './errors.js';
-import { decode_pathname, disable_search, normalize_path } from '../../utils/url.js';
+import {
+	decode_pathname,
+	disable_search,
+	normalize_path,
+	relative_pathname
+} from '../../utils/url.js';
 import { find_route } from '../../utils/routing.js';
 import { redirect_json_response, render_data } from './data/index.js';
 import { add_cookies_to_headers, get_cookies } from './cookie.js';
@@ -378,10 +383,9 @@ export async function internal_respond(request, options, manifest, state) {
 						status: 308,
 						headers: {
 							'x-sveltekit-normalize': '1',
+							// relative so (possibly invisible) path prefixes are preserved
 							location:
-								// ensure paths starting with '//' are not treated as protocol-relative
-								(normalized.startsWith('//') ? url.origin + normalized : normalized) +
-								(url.search === '?' ? '' : url.search)
+								relative_pathname(url.pathname, normalized) + (url.search === '?' ? '' : url.search)
 						}
 					});
 				}

--- a/packages/kit/src/utils/url.js
+++ b/packages/kit/src/utils/url.js
@@ -28,6 +28,18 @@ export function is_root_relative(path) {
 }
 
 /**
+ * @param {string} from
+ * @param {string} to
+ * @returns {string}
+ */
+export function relative_pathname(from, to) {
+	const pathname = from.endsWith('/') ? to : from;
+	const segment = pathname.slice(pathname.lastIndexOf('/') + 1);
+
+	return from.endsWith('/') ? `../${segment}` : `${segment}/`;
+}
+
+/**
  * @param {string} location
  * @param {string} allowed
  */

--- a/packages/kit/src/utils/url.js
+++ b/packages/kit/src/utils/url.js
@@ -34,8 +34,7 @@ export function is_root_relative(path) {
  * @returns {string}
  */
 export function relative_pathname(from, to) {
-	const pathname = from.endsWith('/') ? to : from;
-	const segment = pathname.slice(pathname.lastIndexOf('/') + 1);
+	const segment = to.replace(/\/$/, '').split('/').at(-1);
 
 	return from.endsWith('/') ? `../${segment}` : `${segment}/`;
 }

--- a/packages/kit/src/utils/url.js
+++ b/packages/kit/src/utils/url.js
@@ -28,6 +28,7 @@ export function is_root_relative(path) {
 }
 
 /**
+ * Relative reference from `from` to `to`, which must differ only by a trailing slash
  * @param {string} from
  * @param {string} to
  * @returns {string}

--- a/packages/kit/src/utils/url.spec.js
+++ b/packages/kit/src/utils/url.spec.js
@@ -2,6 +2,7 @@ import { assert, describe } from 'vitest';
 import {
 	resolve,
 	normalize_path,
+	relative_pathname,
 	make_trackable,
 	disable_search,
 	matches_external_allowlist_entry
@@ -70,6 +71,29 @@ describe('resolve', (test) => {
 
 	test('resolves .', () => {
 		assert.equal(resolve('/a/b/c', '.'), '/a/b/');
+	});
+});
+
+describe('relative_pathname', (test) => {
+	test('converts trailing-slash redirects to relative URL references', () => {
+		const cases = [
+			['/a/b', '/a/b/', 'b/'],
+			['/a/b/', '/a/b', '../b'],
+			['/path-base/slash', '/path-base/slash/', 'slash/'],
+			['//x', '//x/', 'x/'],
+			['//x/', '//x', '../x'],
+			['/a/b%2Fc', '/a/b%2Fc/', 'b%2Fc/']
+		];
+
+		for (const [from, to, expected] of cases) {
+			const result = relative_pathname(from, to);
+			const base = new URL('http://internal');
+			base.pathname = from;
+
+			assert.equal(result, expected);
+			assert.equal(result.startsWith('/'), false);
+			assert.equal(new URL(result, base).pathname, to);
+		}
 	});
 });
 

--- a/packages/kit/test/apps/options/test/test.js
+++ b/packages/kit/test/apps/options/test/test.js
@@ -1,4 +1,3 @@
-import * as http from 'node:http';
 import process from 'node:process';
 import { expect } from '@playwright/test';
 import { test } from '../../../utils.js';
@@ -108,18 +107,9 @@ test.describe('env', () => {
 test.describe('trailingSlash', () => {
 	test('adds trailing slash', async ({ baseURL, page, clicknav }) => {
 		// we can't use Playwright's `request` here, because it resolves redirects
-		const [status, location] =
-			await /** @type {Promise<[number | undefined, string | undefined]>} */ (
-				new Promise((fulfil, reject) => {
-					const request = http.get(`${baseURL}/path-base/slash`);
-					request.on('error', reject);
-					request.on('response', (response) => {
-						fulfil([response.statusCode, response.headers.location]);
-					});
-				})
-			);
-		expect(status).toBe(308);
-		expect(location).toBe('slash/');
+		const response = await fetch(`${baseURL}/path-base/slash`, { redirect: 'manual' });
+		expect(response.status).toBe(308);
+		expect(response.headers.get('location')).toBe('slash/');
 
 		await page.goto('/path-base/slash');
 
@@ -132,18 +122,9 @@ test.describe('trailingSlash', () => {
 	});
 
 	test('removes trailing slash on endpoint', async ({ baseURL, request }) => {
-		const [status, location] =
-			await /** @type {Promise<[number | undefined, string | undefined]>} */ (
-				new Promise((fulfil, reject) => {
-					const request = http.get(`${baseURL}/path-base/endpoint/`);
-					request.on('error', reject);
-					request.on('response', (response) => {
-						fulfil([response.statusCode, response.headers.location]);
-					});
-				})
-			);
-		expect(status).toBe(308);
-		expect(location).toBe('../endpoint');
+		const response = await fetch(`${baseURL}/path-base/endpoint/`, { redirect: 'manual' });
+		expect(response.status).toBe(308);
+		expect(response.headers.get('location')).toBe('../endpoint');
 
 		const r1 = await request.get('/path-base/endpoint/');
 		expect(r1.url()).toBe(`${baseURL}/path-base/endpoint`);

--- a/packages/kit/test/apps/options/test/test.js
+++ b/packages/kit/test/apps/options/test/test.js
@@ -108,14 +108,18 @@ test.describe('env', () => {
 test.describe('trailingSlash', () => {
 	test('adds trailing slash', async ({ baseURL, page, clicknav }) => {
 		// we can't use Playwright's `request` here, because it resolves redirects
-		const status = await new Promise((fulfil, reject) => {
-			const request = http.get(`${baseURL}/path-base/slash`);
-			request.on('error', reject);
-			request.on('response', (response) => {
-				fulfil(response.statusCode);
-			});
-		});
+		const [status, location] =
+			await /** @type {Promise<[number | undefined, string | undefined]>} */ (
+				new Promise((fulfil, reject) => {
+					const request = http.get(`${baseURL}/path-base/slash`);
+					request.on('error', reject);
+					request.on('response', (response) => {
+						fulfil([response.statusCode, response.headers.location]);
+					});
+				})
+			);
 		expect(status).toBe(308);
+		expect(location).toBe('slash/');
 
 		await page.goto('/path-base/slash');
 
@@ -128,6 +132,19 @@ test.describe('trailingSlash', () => {
 	});
 
 	test('removes trailing slash on endpoint', async ({ baseURL, request }) => {
+		const [status, location] =
+			await /** @type {Promise<[number | undefined, string | undefined]>} */ (
+				new Promise((fulfil, reject) => {
+					const request = http.get(`${baseURL}/path-base/endpoint/`);
+					request.on('error', reject);
+					request.on('response', (response) => {
+						fulfil([response.statusCode, response.headers.location]);
+					});
+				})
+			);
+		expect(status).toBe(308);
+		expect(location).toBe('../endpoint');
+
 		const r1 = await request.get('/path-base/endpoint/');
 		expect(r1.url()).toBe(`${baseURL}/path-base/endpoint`);
 		expect(await r1.text()).toBe('hi');


### PR DESCRIPTION
Fixes #13718. Supersedes #13719, credit to @HoldYourWaffle for the diagnosis and approach.

The trailing slash redirects use absolute pathnames, so any prefix a parent server strips before the request reaches kit (an Express mount, #13702) is dropped and the browser lands outside the app. The prefix never reaches Polka's parser, so it can't be reconstructed server side. A relative Location resolves against the full browser URL and is prefix-agnostic.

Per the review on #13719, the helper is implemented in kit rather than adding `get-relative-path`, stays internal instead of being exported from `@sveltejs/kit/node`, and adapter-node gets a local copy since its handler is bundled standalone. Both call sites only produce pathnames differing by a trailing slash, so it handles exactly that case. The #2515 guard becomes unnecessary, a relative reference never starts with `/`.

The options app trailingSlash tests now assert the Location values and fail on the old code. The prerender crawler resolves locations with `new URL()`, so it follows the relative form unchanged. Verified end to end with an adapter-node build mounted under a stripped prefix, both the SSR and the prerendered redirect.

No adapter-node test app here since #16305 is establishing that infrastructure.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
