### PR TITLE
chore: remove explicit env var flag from service workers

### DIFF
--- a/packages/kit/src/core/env.js
+++ b/packages/kit/src/core/env.js
@@ -254,8 +254,6 @@ export function create_sveltekit_env_service_worker(variables, env, global, base
 	return dedent`
 		import { env } from '${base}/${app_dir}/env.js';
 
-		globalThis.__SVELTEKIT_EXPERIMENTAL_EXPLICIT_ENVIRONMENT_VARIABLES__ = true;
-
 		${global} = { env };
 	`;
 }
@@ -283,8 +281,6 @@ export function create_sveltekit_env_service_worker_dev(variables, env, global) 
 	handle_issues(issues);
 
 	return dedent`
-		globalThis.__SVELTEKIT_EXPERIMENTAL_EXPLICIT_ENVIRONMENT_VARIABLES__ = true;
-
 		${global} = {
 			env: {
 				${properties.join(',\n\t\t') || '// empty'}


### PR DESCRIPTION
this was needed in v2, but we no longer use this flag