### PR TITLE
fix: populate `version` in service workers

### DIFF
--- a/.changeset/ready-dragons-mix.md
+++ b/.changeset/ready-dragons-mix.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: populate `version` in service workers

--- a/packages/kit/src/core/env.js
+++ b/packages/kit/src/core/env.js
@@ -238,23 +238,31 @@ export function create_sveltekit_env_public(variables, env, prelude) {
  * `env.js`. If there are none, values are inlined.
  * @param {Record<string, EnvVarConfig<any>> | null} variables
  * @param {Record<string, string>} env
+ * @param {string} version
  * @param {string} global
  * @param {string} base
  * @param {string} app_dir
  */
-export function create_sveltekit_env_service_worker(variables, env, global, base, app_dir) {
+export function create_sveltekit_env_service_worker(
+	variables,
+	env,
+	version,
+	global,
+	base,
+	app_dir
+) {
 	const has_dynamic_public_env = Object.values(variables ?? {}).some(
 		(config) => config.public && !config.static
 	);
 
 	if (!has_dynamic_public_env) {
-		return create_sveltekit_env_service_worker_dev(variables, env, global);
+		return create_sveltekit_env_service_worker_dev(variables, env, version, global);
 	}
 
 	return dedent`
 		import { env } from '${base}/${app_dir}/env.js';
 
-		${global} = { env };
+		${global} = { env, version: ${JSON.stringify(version)} };
 	`;
 }
 
@@ -262,9 +270,10 @@ export function create_sveltekit_env_service_worker(variables, env, global, base
  * Creates the `__sveltekit/env/service-worker` module used in development
  * @param {Record<string, EnvVarConfig<any>> | null} variables
  * @param {Record<string, string>} env
+ * @param {string} version
  * @param {string} global
  */
-export function create_sveltekit_env_service_worker_dev(variables, env, global) {
+export function create_sveltekit_env_service_worker_dev(variables, env, version, global) {
 	/** @type {string[]} */
 	const properties = [];
 
@@ -284,7 +293,8 @@ export function create_sveltekit_env_service_worker_dev(variables, env, global) 
 		${global} = {
 			env: {
 				${properties.join(',\n\t\t') || '// empty'}
-			}
+			},
+			version: ${JSON.stringify(version)}
 		};
 	`;
 }

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -1204,11 +1204,17 @@ function kit({ svelte_config }) {
 						? create_sveltekit_env_service_worker(
 								explicit_env_config,
 								env,
+								kit.version.name,
 								kit_global,
 								kit.paths.base,
 								kit.appDir
 							)
-						: create_sveltekit_env_service_worker_dev(explicit_env_config, env, kit_global);
+						: create_sveltekit_env_service_worker_dev(
+								explicit_env_config,
+								env,
+								kit.version.name,
+								kit_global
+							);
 				}
 
 				if (id === sveltekit_env_public_client) {

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -691,11 +691,17 @@ function kit({ svelte_config }) {
 							? create_sveltekit_env_service_worker(
 									explicit_env_config,
 									env,
+									kit.version.name,
 									kit_global,
 									kit.paths.base,
 									kit.appDir
 								)
-							: create_sveltekit_env_service_worker_dev(explicit_env_config, env, kit_global);
+							: create_sveltekit_env_service_worker_dev(
+									explicit_env_config,
+									env,
+									kit.version.name,
+									kit_global
+								);
 				}
 			}
 		}
@@ -1233,17 +1239,19 @@ function kit({ svelte_config }) {
 		applyToEnvironment(environment) {
 			return !!service_worker_entry_file && environment.config.consumer === 'client';
 		},
-		transform(code, id) {
-			if (id !== service_worker_entry_file) return;
+		transform: {
+			handler(code, id) {
+				if (id !== service_worker_entry_file) return;
 
-			// prepend the service worker with an import that configures
-			// `env`, in case `$app/env/public` is imported. In production
-			// this is required: dynamic public env vars aren't known at
-			// build time, so `env.js` is loaded at runtime. In dev, the
-			// imported module just inlines the current values instead.
-			return {
-				code: `import '__sveltekit/env/service-worker';\n${code}`
-			};
+				// prepend the service worker with an import that configures
+				// `env`, in case `$app/env/public` is imported. In production
+				// this is required: dynamic public env vars aren't known at
+				// build time, so `env.js` is loaded at runtime. In dev, the
+				// imported module just inlines the current values instead.
+				return {
+					code: `import '__sveltekit/env/service-worker';\n${code}`
+				};
+			}
 		}
 	};
 

--- a/packages/kit/test/apps/basics/src/service-worker.js
+++ b/packages/kit/test/apps/basics/src/service-worker.js
@@ -1,4 +1,5 @@
-import { build, version } from '$service-worker';
+import { build } from '$service-worker';
+import { version } from '$app/env';
 import { PUBLIC_STATIC } from '$app/env/public';
 
 const name = `cache-${version}-${PUBLIC_STATIC}`;

--- a/packages/kit/test/apps/options-2/src/service-worker.js
+++ b/packages/kit/test/apps/options-2/src/service-worker.js
@@ -1,4 +1,5 @@
-import { base, build, version } from '$service-worker';
+import { base, build } from '$service-worker';
+import { version } from '$app/env';
 import { MESSAGE } from '$app/env/public';
 import src from './image.jpg?url';
 


### PR DESCRIPTION
This PR allows you to do this inside service workers:

```js
import { version } from '$app/env';
```

This is useful for generating verison-scoped caches and suchlike. Together with #16372 it brings us closer to resolving #16159 — the only thing we would still need from the `$service-worker` module is a replacement for `base`, which means getting `$app/paths` to work in a service worker context.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
