### PR TITLE
chore: fix CI on main

### DIFF
--- a/packages/kit/src/exports/env/index.js
+++ b/packages/kit/src/exports/env/index.js
@@ -1,9 +1,7 @@
-/** @import { EnvVarConfig } from '@sveltejs/kit' */
-
 /**
  * Utility for defining [environment variables](https://svelte.dev/docs/kit/environment-variables),
  * which are made available via `$app/env/public` and `$app/env/private`.
- * @template {Record<string, EnvVarConfig<any>>} T
+ * @template {Record<string, import('@sveltejs/kit').EnvVarConfig<any>>} T
  * @param {T} variables
  * @returns {T}
  */

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -3026,7 +3026,7 @@ declare module '@sveltejs/kit' {
 	}>;
 	export const VERSION: string;
 	class HttpError_1 {
-
+		
 		constructor(status: number, body: {
 			message: string;
 		} extends App.Error ? (App.Error | string | undefined) : App.Error);
@@ -3035,7 +3035,7 @@ declare module '@sveltejs/kit' {
 		toString(): string;
 	}
 	class Redirect_1 {
-
+		
 		constructor(status: 300 | 301 | 302 | 303 | 304 | 305 | 306 | 307 | 308, location: string);
 		status: 300 | 301 | 302 | 303 | 304 | 305 | 306 | 307 | 308;
 		location: string;
@@ -3046,12 +3046,11 @@ declare module '@sveltejs/kit' {
 }
 
 declare module '@sveltejs/kit/env' {
-	import type { EnvVarConfig } from '@sveltejs/kit';
 	/**
 	 * Utility for defining [environment variables](https://svelte.dev/docs/kit/environment-variables),
 	 * which are made available via `$app/env/public` and `$app/env/private`.
 	 * */
-	export function defineEnvVars<T extends Record<string, EnvVarConfig<any>>>(variables: T): T;
+	export function defineEnvVars<T extends Record<string, import("@sveltejs/kit").EnvVarConfig<any>>>(variables: T): T;
 
 	export {};
 }
@@ -3668,9 +3667,9 @@ declare module '$app/server' {
 		 *
 		 * */
 		function live<Output>(fn: (arg: void) => RemoteLiveQueryUserFunctionReturnType<Output>): RemoteLiveQueryFunction<void, Output>;
-
+		
 		function live<Input, Output>(validate: "unchecked", fn: (arg: Input) => RemoteLiveQueryUserFunctionReturnType<Output>): RemoteLiveQueryFunction<Input, Output>;
-
+		
 		function live<Schema extends StandardSchemaV1, Output>(schema: Schema, fn: (arg: StandardSchemaV1.InferOutput<Schema>) => RemoteLiveQueryUserFunctionReturnType<Output>): RemoteLiveQueryFunction<StandardSchemaV1.InferInput<Schema>, Output, StandardSchemaV1.InferOutput<Schema>>;
 	}
 	/**
@@ -3837,11 +3836,11 @@ declare module '$app/state' {
 
 declare module '$app/stores' {
 	export function getStores(): {
-
+		
 		page: typeof page;
-
+		
 		navigating: typeof navigating;
-
+		
 		updated: typeof updated;
 	};
 	/**


### PR DESCRIPTION
`main` has been red since #16378 landed on the 17th. Two separate failures in `lint-all`.

`pnpm run check` fails because the `EnvVarConfig` import in `src/exports/env/index.js` is only referenced from a `@template` constraint, and tsc doesn't count that as usage:

```
src/exports/env/index.js(1,5): error TS6133: 'EnvVarConfig' is declared but its value is never read.
```

Inlining the import is what `src/exports/params.js` already does for the same shape.

The `prepublishOnly` diff check fails because the committed `types/index.d.ts` lost its trailing whitespace and its final newline when it was regenerated in #16417, so the generator reports a diff on every run. Regenerating restores them. That file isn't prettier-covered, so nothing strips them again on its own.

All three `lint-all` steps pass on this branch. The second and third both fail on `main` at 08cfba0ad.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
