### PR TITLE
fix: generate sourcemaps for remote modules

### DIFF
--- a/.changeset/happy-deer-drive.md
+++ b/.changeset/happy-deer-drive.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: generate sourcemaps for remote modules

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -7,6 +7,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 import { styleText } from 'node:util';
+import MagicString from 'magic-string';
 import { loadEnv } from 'vite';
 import { exactRegex, prefixRegex } from 'rolldown/filter';
 
@@ -922,23 +923,25 @@ function kit({ svelte_config }) {
 					// an ssrLoadModule during dev. During a link preload, the module can be mistakenly
 					// loaded and transformed twice and the first time all its exports would be undefined
 					// triggering a dev server error. By adding a microtask we ensure that the module is fully loaded
+					const ms = new MagicString(code);
 
 					// Extra newlines to prevent syntax errors around missing semicolons or comments
-					code +=
+					ms.append(
 						'\n\n' +
-						dedent`
-					import * as $$_self_$$ from './${path.basename(id)}';
-					import { init_remote_functions as $$_init_$$ } from '@sveltejs/kit/internal/server';
+							dedent`
+								import * as $$_self_$$ from './${path.basename(id)}';
+								import { init_remote_functions as $$_init_$$ } from '@sveltejs/kit/internal/server';
 
-					${dev_server ? 'await Promise.resolve()' : ''}
+								${dev_server ? 'await Promise.resolve()' : ''}
 
-					$$_init_$$($$_self_$$, ${s(file)}, ${s(remote.hash)});
+								$$_init_$$($$_self_$$, ${s(file)}, ${s(remote.hash)});
 
-					for (const [name, fn] of Object.entries($$_self_$$)) {
-						fn.__.id = ${s(remote.hash)} + '/' + name;
-						fn.__.name = name;
-					}
-				`;
+								for (const [name, fn] of Object.entries($$_self_$$)) {
+									fn.__.id = ${s(remote.hash)} + '/' + name;
+									fn.__.name = name;
+								}
+							`
+					);
 
 					// Emit a dedicated entry chunk for this remote in SSR builds (prod only)
 					if (!dev_server) {
@@ -953,7 +956,10 @@ function kit({ svelte_config }) {
 						}
 					}
 
-					return code;
+					return {
+						code: ms.toString(),
+						map: ms.generateMap()
+					};
 				}
 
 				// For the client, read the exports and create a new module that only contains fetch functions with the correct metadata
@@ -1003,7 +1009,8 @@ function kit({ svelte_config }) {
 				}
 
 				return {
-					code: result
+					code: result,
+					map: null
 				};
 			}
 		}

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -958,7 +958,7 @@ function kit({ svelte_config }) {
 
 					return {
 						code: ms.toString(),
-						map: ms.generateMap()
+						map: ms.generateMap({ hires: 'boundary' })
 					};
 				}
 

--- a/packages/kit/test/apps/async/unit-test/node.spec.js
+++ b/packages/kit/test/apps/async/unit-test/node.spec.js
@@ -1,13 +1,15 @@
-import { execSync } from 'node:child_process';
+import { execSync, spawnSync } from 'node:child_process';
 import path from 'node:path';
 import fs from 'node:fs';
 import { expect, test } from 'vitest';
 
 const timeout = 60_000;
 
+const cwd = path.resolve(import.meta.dirname, '..');
+
 test('SvelteKit runtime JS files stay stable between rebuilds', { timeout }, () => {
 	execSync('pnpm build', {
-		cwd: path.join(import.meta.dirname, '../'),
+		cwd,
 		stdio: 'pipe',
 		timeout
 	});
@@ -15,7 +17,7 @@ test('SvelteKit runtime JS files stay stable between rebuilds', { timeout }, () 
 	const before = get_client_chunk_name();
 
 	execSync('pnpm build', {
-		cwd: path.join(import.meta.dirname, '../'),
+		cwd,
 		stdio: 'pipe',
 		timeout
 	});
@@ -45,4 +47,15 @@ test('SvelteKit runtime JS files stay stable between rebuilds', { timeout }, () 
 		}
 		return chunk_file;
 	}
+});
+
+test("Sourcemaps aren't broken", { timeout }, () => {
+	const result = spawnSync('pnpm', ['build'], {
+		cwd,
+		encoding: 'utf-8',
+		timeout
+	});
+
+	expect(result.error).toBeUndefined();
+	expect(result.stderr).not.toContain('[SOURCEMAP_BROKEN] Sourcemap is likely to be incorrect');
 });

--- a/packages/kit/test/apps/async/vite.config.js
+++ b/packages/kit/test/apps/async/vite.config.js
@@ -21,7 +21,7 @@ export default defineConfig({
 			},
 			typescript: {
 				config(config) {
-					config.include.push('../unit-test/*.js', '../test/*.js', '../playwright.config.js')
+					config.include.push('../unit-test/*.js', '../test/*.js', '../playwright.config.js');
 				}
 			}
 		})

--- a/packages/kit/test/apps/async/vite.config.js
+++ b/packages/kit/test/apps/async/vite.config.js
@@ -18,6 +18,11 @@ export default defineConfig({
 			experimental: {
 				remoteFunctions: true,
 				forkPreloads: true
+			},
+			typescript: {
+				config(config) {
+					config.include.push('../unit-test/*.js', '../test/*.js', '../playwright.config.js')
+				}
 			}
 		})
 	],

--- a/packages/kit/test/apps/options/unit-test/vite.spec.js
+++ b/packages/kit/test/apps/options/unit-test/vite.spec.js
@@ -2,12 +2,16 @@ import { test, expect } from 'vitest';
 import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 
+const timeout = 60_000;
+
 const cwd = path.resolve(import.meta.dirname, '..');
 
 test('no overridden options warning', () => {
 	const result = spawnSync('vitest', ['run', '--config', './vite.custom.config.js', '-t', 'noop'], {
 		cwd,
-		encoding: 'utf-8'
+		stdio: 'pipe',
+		encoding: 'utf-8',
+		timeout
 	});
 
 	expect(result.error).toBeUndefined();


### PR DESCRIPTION
Building an app with remote functions logs a big ugly warning about broken source maps. This fixes it by using magic string to generate them.