### PR TITLE
feat: make `$app/paths` importable in service workers

### DIFF
--- a/.changeset/honest-pumas-leave.md
+++ b/.changeset/honest-pumas-leave.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: make `$app/paths` importable in service workers

--- a/packages/kit/src/runtime/app/paths/client.js
+++ b/packages/kit/src/runtime/app/paths/client.js
@@ -1,8 +1,7 @@
 /** @import { AssetPath, RouteId, RouteIdWithSearchOrHash, Path, PathnameWithSearchOrHash, ResolvedPathname, RouteParams } from '$app/types' */
 /** @import { ResolveArgs } from './types.js' */
-import { base, assets, hash_routing } from './internal/client.js';
+import { base, assets, hash_routing, match_implementation } from './internal/client.js';
 import { resolve_route } from '../../../utils/routing.js';
-import { get_navigation_intent } from '../../client/client.js';
 import { DEV } from 'esm-env';
 
 /**
@@ -96,19 +95,6 @@ export function resolve(...args) {
  * @param {Path | URL | (string & {})} url
  * @returns {Promise<{ [K in RouteId]: { id: K; params: RouteParams<K>; } }[RouteId] | null>}
  */
-export async function match(url) {
-	if (typeof url === 'string') {
-		url = new URL(url, location.href);
-	}
-
-	const intent = await get_navigation_intent(url, false);
-
-	if (intent) {
-		return {
-			id: /** @type {RouteId} */ (intent.route.id),
-			params: intent.params
-		};
-	}
-
-	return null;
+export function match(url) {
+	return match_implementation(url);
 }

--- a/packages/kit/src/runtime/app/paths/internal/client.js
+++ b/packages/kit/src/runtime/app/paths/internal/client.js
@@ -1,6 +1,32 @@
+/** @import { RouteId, Path } from '$app/types' */
 import { payload } from '../../../client/payload.js';
 
 export const base = payload.base ?? __SVELTEKIT_PATHS_BASE__;
 export const assets = payload.assets ?? base ?? __SVELTEKIT_PATHS_ASSETS__;
 export const app_dir = __SVELTEKIT_APP_DIR__;
 export const hash_routing = __SVELTEKIT_HASH_ROUTING__;
+
+/**
+ * We make this configurable per-environment so that it's possible to import `$app/paths`
+ * into a service worker without importing the entire client
+ * @param {Path | URL | (string & {})} _url
+ * @returns {Promise<{ [K in RouteId]: { id: K; params: RouteParams<K>; } }[RouteId] | null>}
+ */
+// eslint-disable-next-line @typescript-eslint/require-await
+export let match_implementation = async (_url) => {
+	// @ts-ignore
+	if (typeof ServiceWorkerGlobalScope !== 'undefined' && self instanceof ServiceWorkerGlobalScope) {
+		throw new Error(
+			'Cannot use `match(...)` inside a service worker, as it depends on the SvelteKit client instance'
+		);
+	}
+
+	return null;
+};
+
+/**
+ * @param {typeof match_implementation} fn
+ */
+export function set_match_implementation(fn) {
+	match_implementation = fn;
+}

--- a/packages/kit/src/runtime/app/paths/internal/client.js
+++ b/packages/kit/src/runtime/app/paths/internal/client.js
@@ -1,4 +1,4 @@
-/** @import { RouteId, Path } from '$app/types' */
+/** @import { RouteId, Path, RouteParams } from '$app/types' */
 import { payload } from '../../../client/payload.js';
 
 export const base = payload.base ?? __SVELTEKIT_PATHS_BASE__;

--- a/packages/kit/src/runtime/app/paths/internal/client.js
+++ b/packages/kit/src/runtime/app/paths/internal/client.js
@@ -1,4 +1,4 @@
-/** @import { RouteId, Path, RouteParams } from '$app/types' */
+/** @import { RouteId, Path } from '$app/types' */
 import { payload } from '../../../client/payload.js';
 
 export const base = payload.base ?? __SVELTEKIT_PATHS_BASE__;
@@ -10,7 +10,7 @@ export const hash_routing = __SVELTEKIT_HASH_ROUTING__;
  * We make this configurable per-environment so that it's possible to import `$app/paths`
  * into a service worker without importing the entire client
  * @param {Path | URL | (string & {})} _url
- * @returns {Promise<{ [K in RouteId]: { id: K; params: RouteParams<K>; } }[RouteId] | null>}
+ * @returns {Promise<{ [K in RouteId]: { id: K; params: import('$app/types').RouteParams<K>; } }[RouteId] | null>}
  */
 // eslint-disable-next-line @typescript-eslint/require-await
 export let match_implementation = async (_url) => {

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1,3 +1,4 @@
+/** @import { RouteId } from '$app/types' */
 /** @import { RemoteFunctionDataNode, ServerNodesResponse, ServerRedirectNode } from 'types' */
 /** @import { NavigationIntent } from './types.js' */
 /** @import { RenderNode } from '../types.js' */
@@ -21,7 +22,7 @@ import {
 	scroll_state,
 	load_css
 } from './utils.js';
-import { base } from '$app/paths/internal/client';
+import { base, set_match_implementation } from '$app/paths/internal/client';
 import * as devalue from 'devalue';
 import {
 	HISTORY_INDEX,
@@ -364,6 +365,23 @@ export async function start(_app, _target, hydrate) {
 	}
 
 	app = _app;
+
+	set_match_implementation(async (url) => {
+		if (typeof url === 'string') {
+			url = new URL(url, location.href);
+		}
+
+		const intent = await get_navigation_intent(url, false);
+
+		if (intent) {
+			return {
+				id: /** @type {RouteId} */ (intent.route.id),
+				params: intent.params
+			};
+		}
+
+		return null;
+	});
 
 	await _app.hooks.init?.();
 

--- a/packages/kit/test/apps/options-2/src/service-worker.js
+++ b/packages/kit/test/apps/options-2/src/service-worker.js
@@ -1,10 +1,11 @@
-import { base, build } from '$service-worker';
+import { build } from '$service-worker';
 import { version } from '$app/env';
 import { MESSAGE } from '$app/env/public';
+import { resolve } from '$app/paths';
 import src from './image.jpg?url';
 
 //@ts-ignore
-self.base = base;
+self.base = resolve('');
 //@ts-ignore
 self.build = build;
 //@ts-ignore

--- a/packages/kit/test/apps/options-2/test/service-worker.test.js
+++ b/packages/kit/test/apps/options-2/test/service-worker.test.js
@@ -39,7 +39,7 @@ test('build /basepath/service-worker.js', async ({ baseURL, request }) => {
 		pathname
 	});
 
-	expect(self.base).toBe('/basepath');
+	expect(self.base).toBe('/basepath/');
 	expect(self.build?.[0]).toMatch(/\/basepath\/_app\/immutable\/bundle\.[\w-]+\.js/);
 	expect(self.image_src).toMatch(/\/basepath\/_app\/immutable\/assets\/image\.[\w-]+\.jpg/);
 });


### PR DESCRIPTION
Part of #16159. This makes `$app/paths` importable in service workers, which removes the last import from `$service-worker` that might be necessary.

It's a tiny bit hacky albeit a fairly non-invasive change: `match` now needs to delegate to a per-environment `match_implementation` that gets overridden in `client.js`.

Once this is merged I'll open a PR removing `$service-worker` altogether.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
