### PR TITLE
docs: clarify how onNavigate differs from beforeNavigate

### DIFF
--- a/.changeset/onnavigate-doc-clarify.md
+++ b/.changeset/onnavigate-doc-clarify.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+docs: clarify how `onNavigate` differs from `beforeNavigate`

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2299,7 +2299,7 @@ export function beforeNavigate(callback) {
 }
 
 /**
- * A lifecycle function that runs the supplied `callback` immediately before we navigate to a new URL except during full-page navigations.
+ * A lifecycle function that runs the supplied `callback` immediately before SvelteKit renders the target page and navigates to a new URL, except during full-page navigations. Unlike `beforeNavigate`, `onNavigate` runs once the navigation is already committed and cannot cancel it.
  *
  * If you return a `Promise`, SvelteKit will wait for it to resolve before completing the navigation. This allows you to — for example — use `document.startViewTransition`. Avoid promises that are slow to resolve, since navigation will appear stalled to the user.
  *

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -3134,7 +3134,7 @@ declare module '$app/navigation' {
 	 * */
 	export function beforeNavigate(callback: (navigation: import("@sveltejs/kit").BeforeNavigate) => void): void;
 	/**
-	 * A lifecycle function that runs the supplied `callback` immediately before we navigate to a new URL except during full-page navigations.
+	 * A lifecycle function that runs the supplied `callback` immediately before SvelteKit renders the target page and navigates to a new URL, except during full-page navigations. Unlike `beforeNavigate`, `onNavigate` runs once the navigation is already committed and cannot cancel it.
 	 *
 	 * If you return a `Promise`, SvelteKit will wait for it to resolve before completing the navigation. This allows you to — for example — use `document.startViewTransition`. Avoid promises that are slow to resolve, since navigation will appear stalled to the user.
 	 *


### PR DESCRIPTION
closes #16439

The `onNavigate` JSDoc read "runs the supplied `callback` immediately before we navigate to a new URL except during full-page navigations", which doesn't make the distinction from `beforeNavigate` clear and has a small grammar slip. This rewords it to spell out that `onNavigate` fires right before SvelteKit renders the target page and, unlike `beforeNavigate`, runs after the navigation is committed and cannot cancel it. The generated `types/index.d.ts` copy is updated to match.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.