### PR TITLE
fix: correct ResolvedPathname generation for root routes and base paths

### DIFF
--- a/.changeset/calm-paths-resolve.md
+++ b/.changeset/calm-paths-resolve.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: generate correct `ResolvedPathname` type for root routes and base paths

--- a/packages/kit/src/core/sync/write_non_ambient.js
+++ b/packages/kit/src/core/sync/write_non_ambient.js
@@ -22,6 +22,8 @@ const remove_group_segments = (/** @type {string} */ id) => {
  * @returns {string[]}
  */
 function get_pathnames_for_trailing_slash(pathname, route) {
+	if (pathname === '') return [''];
+
 	/** @type {Set<string>} */
 	const pathnames = new Set();
 
@@ -81,7 +83,7 @@ export {};
  * @param {import('types').ManifestData} manifest_data
  * @param {import('types').ValidatedKitConfig} config
  */
-function generate_app_types(manifest_data, config) {
+export function generate_app_types(manifest_data, config) {
 	/** @type {Map<string, string>} */
 	const matcher_types = new Map();
 
@@ -245,7 +247,7 @@ function generate_app_types(manifest_data, config) {
 		`\t\tRouteParams(): {\n\t\t\t${dynamic_routes.join(';\n\t\t\t')}\n\t\t};`,
 		`\t\tLayoutParams(): {\n\t\t\t${layouts.join(';\n\t\t\t')}\n\t\t};`,
 		`\t\tPath(): ${Array.from(pathnames).join(' | ')};`,
-		'\t\tResolvedPathname(): `${"/" | `/${string}/`}${ReturnType<AppTypes[\'Path\']>}`;',
+		`\t\tResolvedPathname(): \`\${${s(config.paths.base + '/')}}\${ReturnType<AppTypes['Path']>}\`;`,
 		`\t\tAssetPath(): ${assets.join(' | ') || 'never'};`,
 		'\t}',
 		'}'

--- a/packages/kit/src/core/sync/write_non_ambient.js
+++ b/packages/kit/src/core/sync/write_non_ambient.js
@@ -22,6 +22,7 @@ const remove_group_segments = (/** @type {string} */ id) => {
  * @returns {string[]}
  */
 function get_pathnames_for_trailing_slash(pathname, route) {
+	// the root pathname never gains a trailing slash (mirrors normalize_path)
 	if (pathname === '') return [''];
 
 	/** @type {Set<string>} */

--- a/packages/kit/src/core/sync/write_non_ambient.spec.js
+++ b/packages/kit/src/core/sync/write_non_ambient.spec.js
@@ -3,69 +3,50 @@ import { validate_config } from '../config/index.js';
 import { generate_app_types } from './write_non_ambient.js';
 
 /**
- * @param {string} output
- * @param {string} declaration
+ * @param {string} id
+ * @param {import('types').TrailingSlash} trailingSlash
  */
-const find_line = (output, declaration) =>
-	output.split('\n').find((line) => line.includes(declaration));
+const page = (id, trailingSlash) => ({
+	id,
+	params: [],
+	leaf: { page_options: { trailingSlash } },
+	endpoint: null
+});
+
+/**
+ * @param {ReturnType<typeof page>[]} routes
+ * @param {import('@sveltejs/kit').Config} [config]
+ */
+const generate = (routes, config = {}) =>
+	generate_app_types(
+		/** @type {import('types').ManifestData} */ (/** @type {unknown} */ ({ assets: [], routes })),
+		validate_config(config).kit
+	);
+
+/**
+ * @param {string} output
+ * @param {string} name
+ */
+const declaration = (output, name) =>
+	output.split('\n').find((line) => line.startsWith(`\t\t${name}():`));
 
 test('generates paths with the configured trailing slash', () => {
-	const { kit } = validate_config({});
-
 	for (const trailingSlash of /** @type {const} */ (['always', 'ignore'])) {
-		const output = generate_app_types(
-			/** @type {import('types').ManifestData} */ (
-				/** @type {unknown} */ ({
-					assets: [],
-					routes: [
-						{
-							id: '/',
-							params: [],
-							leaf: { page_options: { trailingSlash } },
-							endpoint: null
-						}
-					]
-				})
-			),
-			kit
-		);
+		const output = generate([page('/', trailingSlash)]);
 
-		expect(find_line(output, '\tPath():')).toBe('\t\tPath(): "";');
-		expect(find_line(output, '\tResolvedPathname():')).toBe(
+		expect(declaration(output, 'Path')).toBe('\t\tPath(): "";');
+		expect(declaration(output, 'ResolvedPathname')).toBe(
 			'\t\tResolvedPathname(): `${"/"}${ReturnType<AppTypes[\'Path\']>}`;'
 		);
 	}
 
-	const output = generate_app_types(
-		/** @type {import('types').ManifestData} */ (
-			/** @type {unknown} */ ({
-				assets: [],
-				routes: [
-					{
-						id: '/about',
-						params: [],
-						leaf: { page_options: { trailingSlash: 'always' } },
-						endpoint: null
-					}
-				]
-			})
-		),
-		kit
-	);
-
-	expect(find_line(output, '\tPath():')).toBe('\t\tPath(): "about/";');
+	expect(declaration(generate([page('/about', 'always')]), 'Path')).toBe('\t\tPath(): "about/";');
 });
 
 test('generates resolved pathnames with the configured base path', () => {
-	const { kit } = validate_config({ kit: { paths: { base: '/path-base' } } });
-	const output = generate_app_types(
-		/** @type {import('types').ManifestData} */ (
-			/** @type {unknown} */ ({ assets: [], routes: [] })
-		),
-		kit
-	);
+	const output = generate([], { kit: { paths: { base: '/path-base' } } });
 
-	expect(find_line(output, '\tResolvedPathname():')).toBe(
+	expect(declaration(output, 'ResolvedPathname')).toBe(
 		'\t\tResolvedPathname(): `${"/path-base/"}${ReturnType<AppTypes[\'Path\']>}`;'
 	);
 });

--- a/packages/kit/src/core/sync/write_non_ambient.spec.js
+++ b/packages/kit/src/core/sync/write_non_ambient.spec.js
@@ -2,9 +2,17 @@ import { expect, test } from 'vitest';
 import { validate_config } from '../config/index.js';
 import { generate_app_types } from './write_non_ambient.js';
 
+/**
+ * @param {string} output
+ * @param {string} declaration
+ */
+const find_line = (output, declaration) =>
+	output.split('\n').find((line) => line.includes(declaration));
+
 test('generates paths with the configured trailing slash', () => {
+	const { kit } = validate_config({});
+
 	for (const trailingSlash of /** @type {const} */ (['always', 'ignore'])) {
-		const { kit } = validate_config({});
 		const output = generate_app_types(
 			/** @type {import('types').ManifestData} */ (
 				/** @type {unknown} */ ({
@@ -22,13 +30,12 @@ test('generates paths with the configured trailing slash', () => {
 			kit
 		);
 
-		expect(output.split('\n').find((line) => line.includes('\tPath():'))).toBe('\t\tPath(): "";');
-		expect(output.split('\n').find((line) => line.includes('\tResolvedPathname():'))).toBe(
+		expect(find_line(output, '\tPath():')).toBe('\t\tPath(): "";');
+		expect(find_line(output, '\tResolvedPathname():')).toBe(
 			'\t\tResolvedPathname(): `${"/"}${ReturnType<AppTypes[\'Path\']>}`;'
 		);
 	}
 
-	const { kit } = validate_config({});
 	const output = generate_app_types(
 		/** @type {import('types').ManifestData} */ (
 			/** @type {unknown} */ ({
@@ -46,9 +53,7 @@ test('generates paths with the configured trailing slash', () => {
 		kit
 	);
 
-	expect(output.split('\n').find((line) => line.includes('\tPath():'))).toBe(
-		'\t\tPath(): "about/";'
-	);
+	expect(find_line(output, '\tPath():')).toBe('\t\tPath(): "about/";');
 });
 
 test('generates resolved pathnames with the configured base path', () => {
@@ -60,7 +65,7 @@ test('generates resolved pathnames with the configured base path', () => {
 		kit
 	);
 
-	expect(output.split('\n').find((line) => line.includes('\tResolvedPathname():'))).toBe(
+	expect(find_line(output, '\tResolvedPathname():')).toBe(
 		'\t\tResolvedPathname(): `${"/path-base/"}${ReturnType<AppTypes[\'Path\']>}`;'
 	);
 });

--- a/packages/kit/src/core/sync/write_non_ambient.spec.js
+++ b/packages/kit/src/core/sync/write_non_ambient.spec.js
@@ -1,0 +1,66 @@
+import { expect, test } from 'vitest';
+import { validate_config } from '../config/index.js';
+import { generate_app_types } from './write_non_ambient.js';
+
+test('generates paths with the configured trailing slash', () => {
+	for (const trailingSlash of /** @type {const} */ (['always', 'ignore'])) {
+		const { kit } = validate_config({});
+		const output = generate_app_types(
+			/** @type {import('types').ManifestData} */ (
+				/** @type {unknown} */ ({
+					assets: [],
+					routes: [
+						{
+							id: '/',
+							params: [],
+							leaf: { page_options: { trailingSlash } },
+							endpoint: null
+						}
+					]
+				})
+			),
+			kit
+		);
+
+		expect(output.split('\n').find((line) => line.includes('\tPath():'))).toBe('\t\tPath(): "";');
+		expect(output.split('\n').find((line) => line.includes('\tResolvedPathname():'))).toBe(
+			'\t\tResolvedPathname(): `${"/"}${ReturnType<AppTypes[\'Path\']>}`;'
+		);
+	}
+
+	const { kit } = validate_config({});
+	const output = generate_app_types(
+		/** @type {import('types').ManifestData} */ (
+			/** @type {unknown} */ ({
+				assets: [],
+				routes: [
+					{
+						id: '/about',
+						params: [],
+						leaf: { page_options: { trailingSlash: 'always' } },
+						endpoint: null
+					}
+				]
+			})
+		),
+		kit
+	);
+
+	expect(output.split('\n').find((line) => line.includes('\tPath():'))).toBe(
+		'\t\tPath(): "about/";'
+	);
+});
+
+test('generates resolved pathnames with the configured base path', () => {
+	const { kit } = validate_config({ kit: { paths: { base: '/path-base' } } });
+	const output = generate_app_types(
+		/** @type {import('types').ManifestData} */ (
+			/** @type {unknown} */ ({ assets: [], routes: [] })
+		),
+		kit
+	);
+
+	expect(output.split('\n').find((line) => line.includes('\tResolvedPathname():'))).toBe(
+		'\t\tResolvedPathname(): `${"/path-base/"}${ReturnType<AppTypes[\'Path\']>}`;'
+	);
+});

--- a/packages/kit/test/apps/options/source/pages/match/+server.js
+++ b/packages/kit/test/apps/options/source/pages/match/+server.js
@@ -1,7 +1,6 @@
 import { json } from '@sveltejs/kit';
 import { match } from '$app/paths';
 
-/** @satisfies {import('$app/types').ResolvedPathname[]} */
 const test_paths = [
 	'/path-base/base/',
 	'/path-base/base/resolved/',

--- a/packages/kit/test/apps/options/source/pages/match/+server.js
+++ b/packages/kit/test/apps/options/source/pages/match/+server.js
@@ -1,11 +1,11 @@
 import { json } from '@sveltejs/kit';
 import { match } from '$app/paths';
 
-const test_paths = [
-	'/path-base/base/',
-	'/path-base/base/resolved/',
-	'/path-base/not-a-real-route-that-exists/'
-];
+/** @satisfies {import('$app/types').ResolvedPathname[]} */
+const valid_paths = ['/path-base/base/', '/path-base/base/resolved/'];
+
+// deliberately not a route so match() returns null
+const test_paths = [...valid_paths, '/path-base/not-a-real-route-that-exists/'];
 
 export async function GET() {
 	const results = await Promise.all(

--- a/packages/kit/test/apps/options/test/test.js
+++ b/packages/kit/test/apps/options/test/test.js
@@ -246,7 +246,7 @@ test.describe('$app/paths', () => {
 		const response = await request.get('/path-base/match');
 
 		expect(await response.json()).toEqual(
-			/** @satisfies {({ path: import('$app/types').ResolvedPathname ; result: { id: import('$app/types').RouteId; params: Record<string, string> } | null})[]} */
+			/** @satisfies {({ path: string; result: { id: import('$app/types').RouteId; params: Record<string, string> } | null})[]} */
 			([
 				{
 					path: '/path-base/base/',


### PR DESCRIPTION
Fixes #16437

This implements both halves from the issue thread. They only work together, with the literal base alone a root route under `trailingSlash: 'always'` still accepts `'//'` and rejects `'/'`.

The options app's `@satisfies ResolvedPathname[]` annotations on a deliberately nonexistent route date from #15507, when the type was loose; `match()` accepts arbitrary strings via `(string & {})`, so nothing needs them.

`${string}` members from dynamic segments can still contain `/`, so `'//'` stays representable in apps with a root-level dynamic param.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
