### PR TITLE
fix: avoid empty getElementById() call on hash routing navigation

### DIFF
--- a/.changeset/hip-lions-check.md
+++ b/.changeset/hip-lions-check.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: avoid empty getElementById() call on hash routing navigation

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1986,14 +1986,14 @@ async function navigate({
 	}
 
 	// we reset scroll before dealing with focus, to avoid a flash of unscrolled content
-	/** @type {Element | null | ''} */
+	/** @type {Element | null} */
 	let deep_linked = null;
 
 	if (autoscroll) {
 		const scroll = popped ? popped.scroll : noscroll ? scroll_state() : null;
 		if (scroll) {
 			scrollTo(scroll.x, scroll.y);
-		} else if ((deep_linked = url.hash && document.getElementById(get_id(url)))) {
+		} else if ((deep_linked = get_hash_element(url))) {
 			// Here we use `scrollIntoView` on the element instead of `scrollTo`
 			// because it natively supports the `scroll-margin` and `scroll-behavior`
 			// CSS properties.
@@ -3294,8 +3294,8 @@ function reset_focus(url, scroll = true) {
 
 		// Mimic the browsers' behaviour and set the sequential focus navigation
 		// starting point to the fragment identifier.
-		const id = get_id(url);
-		if (id && document.getElementById(id)) {
+		const element = get_hash_element(url);
+		if (element) {
 			const { x, y } = scroll_state();
 
 			// `element.focus()` doesn't work on Safari and Firefox Ubuntu so we need
@@ -3304,7 +3304,7 @@ function reset_focus(url, scroll = true) {
 				const history_state = history.state;
 
 				resetting_focus = true;
-				location.replace(new URL(`#${id}`, location.href));
+				location.replace(new URL(`#${element.id}`, location.href));
 
 				// Firefox has a bug that sets the history state to `null` so we need to
 				// restore it after. See https://bugzilla.mozilla.org/show_bug.cgi?id=1199924
@@ -3454,6 +3454,15 @@ function get_id(url) {
 	}
 
 	return decodeURIComponent(id);
+}
+
+/**
+ * @param {URL} url
+ * @returns {Element | null}
+ */
+function get_hash_element(url) {
+	const id = get_id(url);
+	return id ? document.getElementById(id) : null;
 }
 
 if (DEV) {

--- a/packages/kit/test/apps/hash-based-routing/test/test.js
+++ b/packages/kit/test/apps/hash-based-routing/test/test.js
@@ -129,10 +129,10 @@ test.describe('hash based navigation', () => {
 
 	test('does not look up an empty anchor id on navigation', async ({ page }) => {
 		await page.addInitScript(`
-			window.empty_id_lookups = 0;
+			window.empty_id_lookups = [];
 			const get_element_by_id = Document.prototype.getElementById;
 			Document.prototype.getElementById = function (id) {
-				if (id === '') window.empty_id_lookups++;
+				if (id === '') window.empty_id_lookups.push(new Error().stack);
 				return get_element_by_id.call(this, id);
 			};
 		`);
@@ -141,7 +141,31 @@ test.describe('hash based navigation', () => {
 		await page.locator('a[href="/#/a"]').click();
 		await expect(page.locator('p')).toHaveText('a');
 
-		expect(await page.evaluate('window.empty_id_lookups')).toBe(0);
+		// on failure, the captured stack traces reveal which call site made the empty lookup
+		expect(await page.evaluate('window.empty_id_lookups')).toEqual([]);
+	});
+
+	test('does not look up an empty anchor id when resetting focus to a real anchor', async ({
+		page
+	}) => {
+		await page.addInitScript(`
+			window.empty_id_lookups = [];
+			const get_element_by_id = Document.prototype.getElementById;
+			Document.prototype.getElementById = function (id) {
+				if (id === '') window.empty_id_lookups.push(new Error().stack);
+				return get_element_by_id.call(this, id);
+			};
+		`);
+
+		await page.goto('/#/focus');
+		await page.locator('a[href="#/focus/a#p"]').click();
+		await page.waitForURL('#/focus/a#p');
+
+		// `reset_focus` sets the sequential focus navigation starting point to the
+		// anchor. This exercises the branch that looks up a real anchor and restores
+		// the hash from `element.id`, so the hash must be preserved exactly.
+		expect(new URL(page.url()).hash).toBe('#/focus/a#p');
+		expect(await page.evaluate('window.empty_id_lookups')).toEqual([]);
 	});
 
 	test('resolve works', async ({ page }) => {

--- a/packages/kit/test/apps/hash-based-routing/test/test.js
+++ b/packages/kit/test/apps/hash-based-routing/test/test.js
@@ -127,6 +127,23 @@ test.describe('hash based navigation', () => {
 		await expect(page.locator('button[id="button3"]')).toBeFocused();
 	});
 
+	test('does not look up an empty anchor id on navigation', async ({ page }) => {
+		await page.addInitScript(`
+			window.empty_id_lookups = 0;
+			const get_element_by_id = Document.prototype.getElementById;
+			Document.prototype.getElementById = function (id) {
+				if (id === '') window.empty_id_lookups++;
+				return get_element_by_id.call(this, id);
+			};
+		`);
+
+		await page.goto('/');
+		await page.locator('a[href="/#/a"]').click();
+		await expect(page.locator('p')).toHaveText('a');
+
+		expect(await page.evaluate('window.empty_id_lookups')).toBe(0);
+	});
+
 	test('resolve works', async ({ page }) => {
 		await page.goto('/#/resolve');
 		await page.locator('a', { hasText: 'go to home' }).click();


### PR DESCRIPTION
closes #14956

`reset_focus` already guards the empty id, `navigate` didn't. Both lookups now share one guarded helper. The test asserts on the call itself since the warning only exists in Firefox.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
