### PR TITLE
chore: remove stale sync TODO in write_server

### DIFF
--- a/packages/kit/src/core/sync/write_server.js
+++ b/packages/kit/src/core/sync/write_server.js
@@ -83,10 +83,6 @@ export async function get_hooks() {
 export { set_assets, set_building, set_fix_stack_trace, set_manifest, set_prerendering, set_read_implementation };
 `;
 
-// TODO need to re-run this whenever src/app.html or src/error.html are
-// created or changed, or src/service-worker.js is created or deleted.
-// Also, need to check that updating hooks.server.js works
-
 /**
  * Write server configuration to disk
  * @param {import('types').ValidatedConfig} config


### PR DESCRIPTION
Already implemented, #8429 added this TODO and the `sync.server` watcher fulfilling it in the same PR, #7944 covers the reload. Verified live, app.html edits apply without a restart.
