### PR TITLE
fix: return a lightweight 404 instead of rendering the error page for subresource requests

### DIFF
--- a/.changeset/tidy-icons-rest.md
+++ b/.changeset/tidy-icons-rest.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: return a lightweight 404 instead of rendering the error page for subresource requests

--- a/packages/kit/src/runtime/server/errors.js
+++ b/packages/kit/src/runtime/server/errors.js
@@ -17,7 +17,7 @@ export async function handle_fatal_error(event, state, options, error) {
 	const body = await handle_error_and_jsonify(event, state, options, error);
 	const status = body.status;
 
-	// sec-fetch-dest would be nicer, but it's absent for old browsers, non-browser clients and plain HTTP
+	// sec-fetch-dest would be nicer, but non-browser clients and plain HTTP hosts don't send it
 	const type = negotiate(event.request.headers.get('accept') || 'text/html', [
 		'application/json',
 		'text/html'

--- a/packages/kit/src/runtime/server/errors.js
+++ b/packages/kit/src/runtime/server/errors.js
@@ -17,7 +17,7 @@ export async function handle_fatal_error(event, state, options, error) {
 	const body = await handle_error_and_jsonify(event, state, options, error);
 	const status = body.status;
 
-	// Accept remains: sec-fetch is absent for old browsers, non-browser clients and HTTP off localhost
+	// sec-fetch-dest would be nicer, but it's absent for old browsers, non-browser clients and plain HTTP
 	const type = negotiate(event.request.headers.get('accept') || 'text/html', [
 		'application/json',
 		'text/html'

--- a/packages/kit/src/runtime/server/errors.js
+++ b/packages/kit/src/runtime/server/errors.js
@@ -17,7 +17,7 @@ export async function handle_fatal_error(event, state, options, error) {
 	const body = await handle_error_and_jsonify(event, state, options, error);
 	const status = body.status;
 
-	// ideally we'd use sec-fetch-dest instead, but Safari — quelle surprise — doesn't support it
+	// Accept remains: sec-fetch is absent for old browsers, non-browser clients and HTTP off localhost
 	const type = negotiate(event.request.headers.get('accept') || 'text/html', [
 		'application/json',
 		'text/html'

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -50,6 +50,26 @@ const default_filter = () => false;
 /** @type {import('types').RequiredResolveOptions['preload']} */
 const default_preload = ({ type }) => type === 'js' || type === 'css';
 
+const non_html_fetch_destinations = new Set([
+	'audio',
+	'audioworklet',
+	'font',
+	'image',
+	'json',
+	'manifest',
+	'paintworklet',
+	'report',
+	'script',
+	'serviceworker',
+	'sharedworker',
+	'style',
+	'track',
+	'video',
+	'webidentity',
+	'worker',
+	'xslt'
+]);
+
 const page_methods = new Set(['GET', 'HEAD', 'POST']);
 
 const allowed_page_methods = new Set(['GET', 'HEAD', 'OPTIONS']);
@@ -736,6 +756,13 @@ export async function internal_respond(request, options, manifest, state) {
 			// if this request came direct from the user, rather than
 			// via our own `fetch`, render a 404 page
 			if (state.depth === 0) {
+				if (non_html_fetch_destinations.has(event.request.headers.get('sec-fetch-dest') ?? '')) {
+					return text('Not Found', {
+						status: 404,
+						headers: { vary: 'Sec-Fetch-Dest' }
+					});
+				}
+
 				return await respond_with_error({
 					event,
 					event_state,

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -51,6 +51,7 @@ const default_filter = () => false;
 const default_preload = ({ type }) => type === 'js' || type === 'css';
 
 // `Sec-Fetch-Dest` values for subresource requests that can never render an HTML error page
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-Fetch-Dest
 const non_html_fetch_destinations = new Set([
 	'audio',
 	'audioworklet',

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -50,6 +50,7 @@ const default_filter = () => false;
 /** @type {import('types').RequiredResolveOptions['preload']} */
 const default_preload = ({ type }) => type === 'js' || type === 'css';
 
+// `Sec-Fetch-Dest` values for subresource requests that can never render an HTML error page
 const non_html_fetch_destinations = new Set([
 	'audio',
 	'audioworklet',

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -543,6 +543,29 @@ test.describe('Errors', () => {
 		}
 	});
 
+	test('returns a lightweight 404 for subresource requests', async ({ request }) => {
+		const response = await request.get('/errors/does-not-exist-subresource', {
+			headers: { 'sec-fetch-dest': 'image' }
+		});
+
+		expect(response.status()).toBe(404);
+		expect(await response.text()).toBe('Not Found');
+		expect(response.headers()['vary']).toContain('Sec-Fetch-Dest');
+		expect(response.headers()['content-type']).toBeUndefined();
+	});
+
+	test('renders the error page for document and fetch requests', async ({ request }) => {
+		for (const destination of ['document', null, 'empty']) {
+			const response = await request.get(
+				'/errors/does-not-exist-subresource',
+				destination ? { headers: { 'sec-fetch-dest': destination } } : {}
+			);
+
+			expect(response.status()).toBe(404);
+			expect(await response.text()).toContain('This is your custom error page saying:');
+		}
+	});
+
 	test('stack traces are not fixed twice', async ({ page }) => {
 		await page.goto('/errors/stack-trace');
 		expect(await page.textContent('#message')).toBe(

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -551,7 +551,6 @@ test.describe('Errors', () => {
 		expect(response.status()).toBe(404);
 		expect(await response.text()).toBe('Not Found');
 		expect(response.headers()['vary']).toContain('Sec-Fetch-Dest');
-		expect(response.headers()['content-type']).toBeUndefined();
 	});
 
 	test('renders the error page for document and fetch requests', async ({ request }) => {


### PR DESCRIPTION
closes #13734

Diagnosis in the issue. Requests whose `Sec-Fetch-Dest` can never render HTML now get a plain `Not Found` with `Vary: Sec-Fetch-Dest` instead of the SSR'd error page, same shape as the `/_app/` 404 a few lines up. Absent header, `empty`, `document` and unknown values are unchanged. Also fixes the stale Safari comment in `errors.js` (sec-fetch-dest ships since 16.4). Prior art: vercel/next.js#95930, vitejs/vite#20866.

Note: `handleError` no longer runs for these (the default hook discards them anyway).

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
