### PR TITLE
chore: remove unused module ID

### DIFF
--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -57,7 +57,6 @@ import {
 	sveltekit_env_private,
 	sveltekit_env_service_worker,
 	sveltekit_manifest_data,
-	sveltekit_server,
 	sveltekit_env_public_client,
 	sveltekit_env_public_server
 } from './module_ids.js';
@@ -668,8 +667,7 @@ function kit({ svelte_config }) {
 					exactRegex(sveltekit_env_public_client),
 					exactRegex(sveltekit_env_public_server),
 					exactRegex(sveltekit_env_service_worker),
-					exactRegex(sveltekit_manifest_data),
-					exactRegex(sveltekit_server)
+					exactRegex(sveltekit_manifest_data)
 				]
 			},
 			handler(id) {

--- a/packages/kit/src/exports/vite/module_ids.js
+++ b/packages/kit/src/exports/vite/module_ids.js
@@ -9,8 +9,6 @@ export const sveltekit_env_service_worker = '\0virtual:__sveltekit/env/service-w
 
 export const service_worker = '\0virtual:service-worker';
 
-export const sveltekit_server = '\0virtual:__sveltekit/server';
-
 export const sveltekit_manifest_data = '\0virtual:__sveltekit/manifest-data';
 
 export const app_server = posixify(


### PR DESCRIPTION
The module ID has no references. Must be a leftover after the changes from adding $app/manifest?