### PR TITLE
fix: await init on every request to prevent race condition

### DIFF
--- a/.changeset/spotty-pandas-wait.md
+++ b/.changeset/spotty-pandas-wait.md
@@ -1,0 +1,6 @@
+---
+'@sveltejs/adapter-netlify': patch
+'@sveltejs/adapter-vercel': patch
+---
+
+fix: await `init` on every request to prevent race condition

--- a/packages/adapter-netlify/src/edge.js
+++ b/packages/adapter-netlify/src/edge.js
@@ -31,8 +31,10 @@ const initialized = server.init({
 export default async function handler(request, context) {
 	if (!origin) {
 		origin = new URL(request.url).origin;
-		await initialized;
 	}
+
+	// always await initialization to prevent race condition with concurrent requests
+	await initialized;
 
 	return server.respond(request, {
 		platform: { context },

--- a/packages/adapter-vercel/files/edge.js
+++ b/packages/adapter-vercel/files/edge.js
@@ -54,8 +54,10 @@ const initialized = server.init({
 export default async (request, context) => {
 	if (!origin) {
 		origin = new URL(request.url).origin;
-		await initialized;
 	}
+
+	// always await initialization to prevent race condition with concurrent requests
+	await initialized;
 
 	return server.respond(request, {
 		getClientAddress() {


### PR DESCRIPTION
#15161 fixed a cold-start race in adapter-cloudflare, where a concurrent second request could reach `server.respond` before `server.init` finished. The pattern came from #13859 in all three edge adapters, but only cloudflare got the fix. This applies the same change to the Vercel and Netlify edge entries.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
