### PR TITLE
chore: deprecate the `alias` option

### DIFF
--- a/.changeset/quiet-aliases-retire.md
+++ b/.changeset/quiet-aliases-retire.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+chore: deprecate the `alias` option

--- a/documentation/docs/30-advanced/70-packaging.md
+++ b/documentation/docs/30-advanced/70-packaging.md
@@ -189,7 +189,7 @@ You can read more about that feature [here](https://www.typescriptlang.org/docs/
 
 You should avoid using SvelteKit-specific modules like `$app/env` in your packages unless you intend for them to only be consumable by other SvelteKit projects. E.g. rather than using `import { browser } from '$app/env'` you could use `import { BROWSER } from 'esm-env'` ([see esm-env docs](https://github.com/benmccann/esm-env)). You may also wish to pass in things like the current URL or a navigation action as a prop rather than relying directly on `$app/state`, `$app/navigation`, etc. Writing your app in this more generic fashion will also make it easier to set up tools for testing, UI demos and so on.
 
-Ensure that you add [aliases](configuration#alias) via the SvelteKit plugin in your `vite.config.js` (not `tsconfig.json`), so that they are processed by `svelte-package`.
+Use [subpath imports](https://nodejs.org/api/packages.html#subpath-imports) for aliases in library code. `svelte-package` rewrites `#`-prefixed imports from your package.json `imports` field to relative paths when packaging.
 
 You should think carefully about whether or not the changes you make to your package are a bug fix, a new feature, or a breaking change, and update the package version accordingly. Note that if you remove any paths from `exports` or any `export` conditions inside them from your existing library, that should be regarded as a breaking change.
 

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -1,6 +1,7 @@
 /** @import { SvelteConfig } from '@sveltejs/vite-plugin-svelte' */
 /** @import { ValidatedKitConfig } from 'types' */
 /** @import { Validator } from './types.js' */
+import { styleText } from 'node:util';
 
 const directives = object({
 	'child-src': string_array(),
@@ -77,17 +78,21 @@ export const validate_kit_options = object({
 		return input;
 	}),
 
-	alias: validate({}, (input, keypath) => {
-		if (typeof input !== 'object') {
-			throw new Error(`${keypath} should be an object`);
-		}
+	alias: deprecate(
+		validate({}, (input, keypath) => {
+			if (typeof input !== 'object') {
+				throw new Error(`${keypath} should be an object`);
+			}
 
-		for (const key in input) {
-			assert_string(input[key], `${keypath}.${key}`);
-		}
+			for (const key in input) {
+				assert_string(input[key], `${keypath}.${key}`);
+			}
 
-		return input;
-	}),
+			return input;
+		}),
+		(keypath) =>
+			`The \`${keypath}\` option is deprecated, and will be removed in a future version of SvelteKit. Use subpath imports instead: https://svelte.dev/docs/kit/$lib`
+	),
 
 	appDir: validate('_app', (input, keypath) => {
 		assert_string(input, keypath);
@@ -291,26 +296,24 @@ export const validate_kit_options = object({
 	})
 });
 
-// /**
-//  * @param {Validator} fn
-//  * @param {(keypath: string) => string} get_message
-//  * @returns {Validator}
-//  */
-// function deprecate(
-// 	fn,
-// 	get_message = (keypath) =>
-// 		`The \`${keypath}\` option is deprecated, and will be removed in a future version`
-// ) {
-// 	return (input, keypath) => {
-//		keypath = remove_kit_prefix(keypath);
-//
-// 		if (input !== undefined) {
-// 			console.warn(styleText(['bold', 'yellow'], get_message(keypath)));
-// 		}
+/**
+ * @param {Validator} fn
+ * @param {(keypath: string) => string} get_message
+ * @returns {Validator}
+ */
+function deprecate(
+	fn,
+	get_message = (keypath) =>
+		`The \`${keypath}\` option is deprecated, and will be removed in a future version`
+) {
+	return (input, keypath) => {
+		if (input !== undefined) {
+			console.warn(styleText(['bold', 'yellow'], get_message(keypath)));
+		}
 
-// 		return fn(input, keypath);
-// 	};
-// }
+		return fn(input, keypath);
+	};
+}
 
 // Derive the names of SvelteKit's own config options from the schema, so they
 // stay in sync automatically. These are used to separate Kit's options from

--- a/packages/kit/src/core/sync/write_tsconfig.js
+++ b/packages/kit/src/core/sync/write_tsconfig.js
@@ -175,7 +175,7 @@ function validate_user_config(cwd, out, config) {
 				styleText(
 					['bold', 'yellow'],
 					`You have specified a baseUrl and/or paths in your ${config.kind} which interferes with SvelteKit's auto-generated tsconfig.json. ` +
-						'Remove it to avoid problems with intellisense. For path aliases, use `config.alias` instead: https://svelte.dev/docs/kit/configuration#alias'
+						'Remove it to avoid problems with intellisense. For path aliases, use subpath imports instead: https://svelte.dev/docs/kit/$lib'
 				)
 			);
 		}

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -365,7 +365,7 @@ export interface KitConfig {
 	/**
 	 * An object containing zero or more aliases used to replace values in `import` statements. These aliases are automatically passed to Vite and TypeScript.
 	 *
-	 * This option is deprecated. Use [subpath imports](https://nodejs.org/api/packages.html#subpath-imports) (see [`#lib`](https://svelte.dev/docs/kit/$lib)) instead. Projects that want bundler and TypeScript aliases configured in one place can set [`resolve.tsconfigPaths`](https://vite.dev/config/shared-options#resolve-tsconfigpaths) in their Vite config.
+	 * This option is deprecated. Use [subpath imports](https://svelte.dev/docs/kit/$lib) instead.
 	 *
 	 * > [!NOTE] You will need to run `npm run dev` to have SvelteKit automatically generate the required alias configuration in `jsconfig.json` or `tsconfig.json`.
 	 * @deprecated

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -365,7 +365,7 @@ export interface KitConfig {
 	/**
 	 * An object containing zero or more aliases used to replace values in `import` statements. These aliases are automatically passed to Vite and TypeScript.
 	 *
-	 * This option is deprecated. Use [subpath imports](https://nodejs.org/api/packages.html#subpath-imports) (see [`#lib`]($lib)) instead. Projects that want bundler and TypeScript aliases configured in one place can set [`resolve.tsconfigPaths`](https://vite.dev/config/shared-options#resolve-tsconfigpaths) in their Vite config.
+	 * This option is deprecated. Use [subpath imports](https://nodejs.org/api/packages.html#subpath-imports) (see [`#lib`](https://svelte.dev/docs/kit/$lib)) instead. Projects that want bundler and TypeScript aliases configured in one place can set [`resolve.tsconfigPaths`](https://vite.dev/config/shared-options#resolve-tsconfigpaths) in their Vite config.
 	 *
 	 * > [!NOTE] You will need to run `npm run dev` to have SvelteKit automatically generate the required alias configuration in `jsconfig.json` or `tsconfig.json`.
 	 * @deprecated

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -365,32 +365,10 @@ export interface KitConfig {
 	/**
 	 * An object containing zero or more aliases used to replace values in `import` statements. These aliases are automatically passed to Vite and TypeScript.
 	 *
-	 * ```js
-	 * /// file: vite.config.js
-	 * import { defineConfig } from 'vite';
-	 * import { sveltekit } from '@sveltejs/kit/vite';
-	 *
-	 * export default defineConfig({
-	 *   plugins: [
-	 *     sveltekit({
-	 *       alias: {
-	 *         // this will match a file
-	 *         'my-file': 'path/to/my-file.js',
-	 *
-	 *         // this will match a directory and its contents
-	 *         // (`my-directory/x` resolves to `path/to/my-directory/x`)
-	 *         'my-directory': 'path/to/my-directory',
-	 *
-	 *         // an alias ending /* will only match
-	 *         // the contents of a directory, not the directory itself
-	 *         'my-directory/*': 'path/to/my-directory/*'
-	 *       }
-	 *     })
-	 *   ]
-	 * });
-	 * ```
+	 * This option is deprecated. Use [subpath imports](https://nodejs.org/api/packages.html#subpath-imports) (see [`#lib`]($lib)) instead. Projects that want bundler and TypeScript aliases configured in one place can set [`resolve.tsconfigPaths`](https://vite.dev/config/shared-options#resolve-tsconfigpaths) in their Vite config.
 	 *
 	 * > [!NOTE] You will need to run `npm run dev` to have SvelteKit automatically generate the required alias configuration in `jsconfig.json` or `tsconfig.json`.
+	 * @deprecated
 	 * @default {}
 	 */
 	alias?: Record<string, string>;

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -337,32 +337,10 @@ declare module '@sveltejs/kit' {
 		/**
 		 * An object containing zero or more aliases used to replace values in `import` statements. These aliases are automatically passed to Vite and TypeScript.
 		 *
-		 * ```js
-		 * /// file: vite.config.js
-		 * import { defineConfig } from 'vite';
-		 * import { sveltekit } from '@sveltejs/kit/vite';
-		 *
-		 * export default defineConfig({
-		 *   plugins: [
-		 *     sveltekit({
-		 *       alias: {
-		 *         // this will match a file
-		 *         'my-file': 'path/to/my-file.js',
-		 *
-		 *         // this will match a directory and its contents
-		 *         // (`my-directory/x` resolves to `path/to/my-directory/x`)
-		 *         'my-directory': 'path/to/my-directory',
-		 *
-		 *         // an alias ending /* will only match
-		 *         // the contents of a directory, not the directory itself
-		 *         'my-directory/*': 'path/to/my-directory/*'
-		 *       }
-		 *     })
-		 *   ]
-		 * });
-		 * ```
+		 * This option is deprecated. Use [subpath imports](https://nodejs.org/api/packages.html#subpath-imports) (see [`#lib`]($lib)) instead. Projects that want bundler and TypeScript aliases configured in one place can set [`resolve.tsconfigPaths`](https://vite.dev/config/shared-options#resolve-tsconfigpaths) in their Vite config.
 		 *
 		 * > [!NOTE] You will need to run `npm run dev` to have SvelteKit automatically generate the required alias configuration in `jsconfig.json` or `tsconfig.json`.
+		 * @deprecated
 		 * @default {}
 		 */
 		alias?: Record<string, string>;

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -337,7 +337,7 @@ declare module '@sveltejs/kit' {
 		/**
 		 * An object containing zero or more aliases used to replace values in `import` statements. These aliases are automatically passed to Vite and TypeScript.
 		 *
-		 * This option is deprecated. Use [subpath imports](https://nodejs.org/api/packages.html#subpath-imports) (see [`#lib`]($lib)) instead. Projects that want bundler and TypeScript aliases configured in one place can set [`resolve.tsconfigPaths`](https://vite.dev/config/shared-options#resolve-tsconfigpaths) in their Vite config.
+		 * This option is deprecated. Use [subpath imports](https://nodejs.org/api/packages.html#subpath-imports) (see [`#lib`](https://svelte.dev/docs/kit/$lib)) instead. Projects that want bundler and TypeScript aliases configured in one place can set [`resolve.tsconfigPaths`](https://vite.dev/config/shared-options#resolve-tsconfigpaths) in their Vite config.
 		 *
 		 * > [!NOTE] You will need to run `npm run dev` to have SvelteKit automatically generate the required alias configuration in `jsconfig.json` or `tsconfig.json`.
 		 * @deprecated

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -337,7 +337,7 @@ declare module '@sveltejs/kit' {
 		/**
 		 * An object containing zero or more aliases used to replace values in `import` statements. These aliases are automatically passed to Vite and TypeScript.
 		 *
-		 * This option is deprecated. Use [subpath imports](https://nodejs.org/api/packages.html#subpath-imports) (see [`#lib`](https://svelte.dev/docs/kit/$lib)) instead. Projects that want bundler and TypeScript aliases configured in one place can set [`resolve.tsconfigPaths`](https://vite.dev/config/shared-options#resolve-tsconfigpaths) in their Vite config.
+		 * This option is deprecated. Use [subpath imports](https://svelte.dev/docs/kit/$lib) instead.
 		 *
 		 * > [!NOTE] You will need to run `npm run dev` to have SvelteKit automatically generate the required alias configuration in `jsconfig.json` or `tsconfig.json`.
 		 * @deprecated


### PR DESCRIPTION
closes #16468

Warns but keeps working, same as the v2 `files` deprecation. The docs recommend `resolve.tsconfigPaths` per the issue; its friction with the generated tsconfig is tracked in #16471.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.