### PR TITLE
fix: don't record a trailing slash for a prerendered root page combined with a base path

### DIFF
--- a/.changeset/famous-otters-relax.md
+++ b/.changeset/famous-otters-relax.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: don't record a trailing slash for a prerendered root page combined with a base path

--- a/packages/kit/.gitignore
+++ b/packages/kit/.gitignore
@@ -4,6 +4,7 @@
 !/src/core/adapt/fixtures/*/.svelte-kit
 !/test/node_modules
 /test/apps/basics/test/errors.json
+/test/prerendering/paths-base/prerendered-paths.json
 /types/*.map
 .custom-out-dir
 

--- a/packages/kit/src/core/postbuild/prerender.js
+++ b/packages/kit/src/core/postbuild/prerender.js
@@ -202,6 +202,14 @@ async function prerender({ hash, out, manifest_path, metadata, verbose, env }) {
 		return file;
 	}
 
+	/**
+	 * @param {string} path
+	 */
+	function strip_base_only_trailing_slash(path) {
+		const base_root = `${config.paths.base}/`;
+		return path === base_root && base_root.length > 1 ? config.paths.base : path;
+	}
+
 	const files = new Set(walk(`${out}/client`).map(posixify));
 	files.add(`${config.appDir}/env.js`);
 
@@ -445,7 +453,7 @@ async function prerender({ hash, out, manifest_path, metadata, verbose, env }) {
 							location: resolved
 						});
 
-						prerendered.paths.push(decoded);
+						prerendered.paths.push(strip_base_only_trailing_slash(decoded));
 					}
 				}
 			} else {
@@ -487,7 +495,7 @@ async function prerender({ hash, out, manifest_path, metadata, verbose, env }) {
 				});
 			}
 
-			prerendered.paths.push(decoded);
+			prerendered.paths.push(strip_base_only_trailing_slash(decoded));
 		} else if (response_type !== OK) {
 			handle_http_error({ status: response.status, path: decoded, referrer, referenceType });
 		}

--- a/packages/kit/src/exports/env/index.js
+++ b/packages/kit/src/exports/env/index.js
@@ -1,5 +1,8 @@
 /** @import { EnvVarConfig } from '@sveltejs/kit' */
 
+// tsc otherwise reports EnvVarConfig as unused since it's only referenced in a @template bound
+export {};
+
 /**
  * Utility for defining [environment variables](https://svelte.dev/docs/kit/environment-variables),
  * which are made available via `$app/env/public` and `$app/env/private`.

--- a/packages/kit/test/prerendering/paths-base/svelte.config.js
+++ b/packages/kit/test/prerendering/paths-base/svelte.config.js
@@ -1,9 +1,18 @@
-import adapter from '../../../../adapter-static/index.js';
+import { writeFileSync } from 'node:fs';
+import static_adapter from '../../../../adapter-static/index.js';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
-		adapter: adapter(),
+		adapter: {
+			name: 'test',
+			async adapt(builder) {
+				// capture what adapters actually receive for prerendered paths, so
+				// tests can assert on it directly instead of inferring it from output
+				writeFileSync('./prerendered-paths.json', JSON.stringify(builder.prerendered.paths));
+				await static_adapter().adapt(builder);
+			}
+		},
 
 		paths: {
 			base: '/path-base',

--- a/packages/kit/test/prerendering/paths-base/test/tests.spec.js
+++ b/packages/kit/test/prerendering/paths-base/test/tests.spec.js
@@ -7,6 +7,14 @@ const build = fileURLToPath(new URL('../build', import.meta.url));
 /** @param {string} file */
 const read = (file) => fs.readFileSync(`${build}/${file}`, 'utf-8');
 
+test('root page with a base path is recorded without a trailing slash', () => {
+	const paths = JSON.parse(
+		fs.readFileSync(fileURLToPath(new URL('../prerendered-paths.json', import.meta.url)), 'utf-8')
+	);
+	assert.ok(paths.includes('/path-base'));
+	assert.ok(!paths.includes('/path-base/'));
+});
+
 test('prerenders /path-base', () => {
 	const content = read('index.html');
 	assert.ok(content.includes('favicon.png') && content.includes('nested'));

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -3026,7 +3026,7 @@ declare module '@sveltejs/kit' {
 	}>;
 	export const VERSION: string;
 	class HttpError_1 {
-
+		
 		constructor(status: number, body: {
 			message: string;
 		} extends App.Error ? (App.Error | string | undefined) : App.Error);
@@ -3035,7 +3035,7 @@ declare module '@sveltejs/kit' {
 		toString(): string;
 	}
 	class Redirect_1 {
-
+		
 		constructor(status: 300 | 301 | 302 | 303 | 304 | 305 | 306 | 307 | 308, location: string);
 		status: 300 | 301 | 302 | 303 | 304 | 305 | 306 | 307 | 308;
 		location: string;
@@ -3668,9 +3668,9 @@ declare module '$app/server' {
 		 *
 		 * */
 		function live<Output>(fn: (arg: void) => RemoteLiveQueryUserFunctionReturnType<Output>): RemoteLiveQueryFunction<void, Output>;
-
+		
 		function live<Input, Output>(validate: "unchecked", fn: (arg: Input) => RemoteLiveQueryUserFunctionReturnType<Output>): RemoteLiveQueryFunction<Input, Output>;
-
+		
 		function live<Schema extends StandardSchemaV1, Output>(schema: Schema, fn: (arg: StandardSchemaV1.InferOutput<Schema>) => RemoteLiveQueryUserFunctionReturnType<Output>): RemoteLiveQueryFunction<StandardSchemaV1.InferInput<Schema>, Output, StandardSchemaV1.InferOutput<Schema>>;
 	}
 	/**
@@ -3837,11 +3837,11 @@ declare module '$app/state' {
 
 declare module '$app/stores' {
 	export function getStores(): {
-
+		
 		page: typeof page;
-
+		
 		navigating: typeof navigating;
-
+		
 		updated: typeof updated;
 	};
 	/**


### PR DESCRIPTION
closes #13310

The root route's own path is empty, so when combined with a base path it gets recorded as `base + '/'` in `prerendered.paths`, a trailing slash the type has always documented these paths as not having (`private.d.ts`: "An array of prerendered paths (without trailing slashes...)"). Adapters that build a static-file exclusion list from `prerendered.paths` (e.g. `adapter-netlify`'s `excludedPath`) end up excluding the wrong URL form, so one of `/base-path` or `/base-path/` breaks depending on how the adapter/host then handles the mismatch.

This strips the trailing slash only when the recorded path is exactly `base + '/'`, so `trailingSlash: 'always'` routes elsewhere are untouched (verified against the existing `basics` prerendering fixture, which already asserts a `trailingSlash: 'always'` route keeps its slash).

Verified end-to-end on real Netlify, not just locally: packed a patched `@sveltejs/kit` tarball, built two standalone repro apps (root page prerendered + base path set, deployed with `adapter-netlify`), one against unpatched `@sveltejs/kit`, one against this fix, deployed both:

- Before this fix: https://netlify-before-1.netlify.app/base-path/ works, `/base-path` (no trailing slash) does not.
- After this fix: https://netlify-after-1.netlify.app/base-path/ **and** https://netlify-after-1.netlify.app/base-path both work.

Also includes two unrelated `chore` commits fixing the `lint-all` failures that exist on `main` since #16378. #16438 fixes the same two breakages independently (inlining the import instead of `export {}` for the TS6133 one). Whichever of these two PRs merges first, the other will need a rebase.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.

