### PR TITLE
fix: don't invoke handleError for server-handled errors during preload

### DIFF
--- a/.changeset/preload-server-error-handling.md
+++ b/.changeset/preload-server-error-handling.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: do not invoke client `handleError` for errors already handled on the server when the navigation is a preload

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1330,14 +1330,7 @@ async function load_route({ id, invalidating, url, params, route, preload }) {
 					};
 				}
 
-				if (preload && preload_tokens.has(preload)) {
-					return preload_error({
-						error: await handle_error(err, { params, url, route: { id: route.id } }),
-						url,
-						params,
-						route
-					});
-				}
+				const is_preload = !!preload && preload_tokens.has(preload);
 
 				let status = get_status(err);
 				/** @type {App.Error} */
@@ -1351,15 +1344,21 @@ async function load_route({ id, invalidating, url, params, route, preload }) {
 				} else if (err instanceof HttpError) {
 					error = err.body;
 				} else {
-					// Referenced node could have been removed due to redeploy, check
-					const updated = await stores.updated.check();
-					if (updated) {
-						// Before reloading, try to update the service worker if it exists
-						await update_service_worker();
-						return await native_navigation(url);
+					if (!is_preload) {
+						// Referenced node could have been removed due to redeploy, check
+						const updated = await stores.updated.check();
+						if (updated) {
+							// Before reloading, try to update the service worker if it exists
+							await update_service_worker();
+							return await native_navigation(url);
+						}
 					}
 
 					error = await handle_error(err, { params, url, route: { id: route.id } });
+				}
+
+				if (is_preload) {
+					return preload_error({ error, url, params, route });
 				}
 
 				const error_load = await load_nearest_error_page(i, branch, errors);

--- a/packages/kit/test/apps/basics/src/global.d.ts
+++ b/packages/kit/test/apps/basics/src/global.d.ts
@@ -5,6 +5,7 @@ declare global {
 		pageContext: any;
 		mounted: number;
 		fulfil_navigation: (value: any) => void;
+		handle_error_calls: Array<{ status: number; message: string }>;
 		promise: Promise<any>;
 		PUBLIC_DYNAMIC: string;
 	}

--- a/packages/kit/test/apps/basics/src/hooks.client.js
+++ b/packages/kit/test/apps/basics/src/hooks.client.js
@@ -4,6 +4,10 @@ window.PUBLIC_DYNAMIC = env.PUBLIC_DYNAMIC;
 
 /** @type{import("@sveltejs/kit").HandleClientError} */
 export function handleError({ error, event, status, message }) {
+	(window.handle_error_calls ??= []).push({
+		status,
+		message: /** @type {Error} */ (error).message
+	});
 	return event.url.pathname.endsWith('404-fallback')
 		? undefined
 		: { message: `${/** @type {Error} */ (error).message} (${status} ${message})` };

--- a/packages/kit/test/apps/basics/src/routes/preloading/preload-error/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/preloading/preload-error/+page.svelte
@@ -1,0 +1,16 @@
+<script>
+	import { preloadData } from '$app/navigation';
+
+	/** @type {Record<string, any> | null} */
+	let result = null;
+
+	async function preload() {
+		result = await preloadData('/preloading/preload-error/target');
+	}
+</script>
+
+<button on:click={preload}>Preload</button>
+
+{#if result}
+	<pre id="result">{JSON.stringify(result)}</pre>
+{/if}

--- a/packages/kit/test/apps/basics/src/routes/preloading/preload-error/target/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/preloading/preload-error/target/+page.server.js
@@ -1,0 +1,5 @@
+import { error } from '@sveltejs/kit';
+
+export function load() {
+	error(404, 'Not found');
+}

--- a/packages/kit/test/apps/basics/src/routes/preloading/preload-error/target/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/preloading/preload-error/target/+page.svelte
@@ -1,0 +1,1 @@
+<h1>this page never renders successfully</h1>

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -1789,6 +1789,17 @@ test.describe('Shallow routing', () => {
 	});
 });
 
+test.describe('Preloading', () => {
+	test('does not invoke handleError for server load errors during preload', async ({ page }) => {
+		await page.goto('/preloading/preload-error');
+		await page.locator('button').click();
+		await expect(page.locator('#result')).toContainText('"type":"loaded"');
+
+		// the server already handled the error; the client hook must not run
+		expect(await page.evaluate(() => window.handle_error_calls)).toBeUndefined();
+	});
+});
+
 test.describe('reroute', () => {
 	test('Apply reroute during client side navigation', async ({ page, clicknav }) => {
 		await page.goto('/reroute/basic');


### PR DESCRIPTION
closes #16456

When a preloaded route's server `load` throws `error(404)`, the client
`handleError` hook runs with the raw server error node and `status: 500`.
On normal navigation the branch loader skips the client hook for errors
already handled on the server, but the preload path returns before that
guard is reached. As the issue describes, integrations that filter out
4xx by status (like Sentry) then report ordinary server 404s as client
500s, just because a link was hovered instead of clicked.

I moved the error and status computation in front of the preload return,
so preloads go through the same guard as normal navigation. The
`updated.check()` reload logic stays out of the preload path, same as
before. The new test preloads a route whose server load throws
`error(404)` via `preloadData()` and asserts the hook is not invoked —
it fails without the fix and passes with it, in both dev and build modes.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] References an issue: #16456
- [x] This message body illustrates the problems it solves
- [x] Includes a test that fails without this PR but passes with it

### Tests
- [x] `pnpm test` (basics suite) and `pnpm lint` pass; `pnpm check` fails on upstream main itself (pre-existing, unrelated)

### Changesets
- [x] Changeset included (`@sveltejs/kit` patch, `fix:` prefix)

### Edits
- [x] 'Allow edits from maintainers' is checked