### PR TITLE
fix: prevent infinite refresh loops

### DIFF
--- a/.changeset/re-refresh-reruns.md
+++ b/.changeset/re-refresh-reruns.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: re-run a server-side query when it is refreshed again before the request completes
+fix: prevent infinite loops when server-side queries refresh each other in a cycle during the single-flight drain

--- a/packages/kit/src/runtime/server/remote-functions.js
+++ b/packages/kit/src/runtime/server/remote-functions.js
@@ -384,6 +384,7 @@ export async function collect_remote_data(data, event, state, options) {
 		const drain = () => {
 			for (const [remote_key, { internals, fn }] of explicit) {
 				explicit.delete(remote_key);
+				if (processed.has(remote_key)) continue;
 				processed.add(remote_key);
 
 				// there were explicit refreshes/reconnects (via `refresh()`/`set()`/`reconnect()`),

--- a/packages/kit/test/apps/async/src/routes/remote/re-refresh/data.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/re-refresh/data.remote.js
@@ -28,9 +28,9 @@ export const bump = command('unchecked', () => {
 	session().value = 10;
 	// Both are refreshed by the command, so both run during `collect_remote_data`.
 	// `get_value` runs (sees 10), and `driver` runs — bumping the value to 11 and
-	// re-refreshing `get_value`. Because collection consumes entries out of
-	// `explicit`, that re-refresh re-inserts `get_value`, which runs again and
-	// serializes 11 rather than the stale 10.
+	// re-refreshing `get_value`. Because `get_value` was already processed this
+	// drain, the re-refresh is cached rather than re-run, so the serialized value
+	// stays 10. This is the same mechanism that breaks A → B → A refresh cycles.
 	get_value().refresh();
 	driver().refresh();
 	return true;

--- a/packages/kit/test/apps/async/src/routes/remote/refresh-cycle/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/refresh-cycle/+page.svelte
@@ -1,0 +1,9 @@
+<script>
+	import { bump, get_a } from './data.remote.js';
+
+	const a = get_a();
+</script>
+
+<p id="value">{await a}</p>
+
+<button id="bump" onclick={() => bump({})}>bump</button>

--- a/packages/kit/test/apps/async/src/routes/remote/refresh-cycle/data.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/refresh-cycle/data.remote.js
@@ -1,0 +1,33 @@
+import { command, getRequestEvent, query } from '$app/server';
+
+// Per-session state so parallel test workers don't clobber each other.
+/** @type {Map<string, { value: number }>} */
+const sessions = new Map();
+
+function session() {
+	const id = getRequestEvent().cookies.get('count_session') ?? 'refresh-cycle-default';
+	let state = sessions.get(id);
+	if (!state) {
+		state = { value: 0 };
+		sessions.set(id, state);
+	}
+	return state;
+}
+
+// A refreshes B, B refreshes A — a cycle. Without cycle detection in
+// `collect_remote_data`'s drain, the command response never settles.
+export const get_a = query(() => {
+	get_b().refresh();
+	return session().value;
+});
+
+export const get_b = query(() => {
+	get_a().refresh();
+	return session().value;
+});
+
+export const bump = command('unchecked', () => {
+	session().value += 1;
+	get_a().refresh();
+	return true;
+});

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -142,20 +142,36 @@ test.describe('remote function mutations', () => {
 		expect(request_count).toBe(1); // only the command itself — no separate refetch of get_b
 	});
 
-	test('a query re-refreshed by another query during collection re-runs', async ({ page }) => {
+	test('a query re-refreshed by another query during collection is cached, not re-run', async ({
+		page
+	}) => {
 		await page.goto('/remote/re-refresh');
 		await expect(page.locator('#value')).toHaveText('0');
 
 		let request_count = 0;
 		page.on('request', (r) => (request_count += r.url().includes('/_app/remote') ? 1 : 0));
 
-		// `bump` refreshes `get_value` (which would see 10) and `driver`. When `driver`
-		// runs during collection it bumps the value to 11 and re-refreshes `get_value`,
-		// which must run *again* and serialize 11 — not the stale 10 from its first run.
+		// `bump` refreshes `get_value` (which sees 10) and `driver`. When `driver`
+		// runs during collection it bumps the value to 11 and re-refreshes `get_value`.
+		// `get_value` has already been processed once this drain, so the re-refresh is
+		// cached rather than re-run — the client keeps the first (10) value. This is
+		// what prevents A → B → A refresh cycles from looping forever.
 		await page.click('#bump');
-		await expect(page.locator('#value')).toHaveText('11');
+		await expect(page.locator('#value')).toHaveText('10');
 		await page.waitForTimeout(100); // allow all requests to finish
-		expect(request_count).toBe(1); // only the command — the re-run rode along in the response
+		expect(request_count).toBe(1); // only the command — no separate refetch
+	});
+
+	test('queries that refresh each other in a cycle do not loop forever', async ({ page }) => {
+		await page.goto('/remote/refresh-cycle');
+		await expect(page.locator('#value')).toHaveText('0');
+
+		// `get_a` refreshes `get_b` and `get_b` refreshes `get_a`. Without cycle
+		// detection in the drain phase the command response would never settle, so
+		// `#value` would stay at 0 and this assertion would time out.
+		await page.click('#bump');
+
+		await expect(page.locator('#value')).toHaveText('1');
 	});
 
 	test('hydrated query errors are reused', async ({ page }) => {


### PR DESCRIPTION
Prevents queries from infinitely looping during the drain phase. This has the side effect of preventing multiple refreshes of the same query during the drain phase, so... don't do that