### PR TITLE
chore: update Cloudflare worker test gitignore

### DIFF
--- a/packages/adapter-cloudflare/test/apps/workers/.gitignore
+++ b/packages/adapter-cloudflare/test/apps/workers/.gitignore
@@ -3,6 +3,5 @@ node_modules
 /.svelte-kit
 
 # Cloudflare
-/.wrangler
+.wrangler
 /dist
-/config

--- a/packages/adapter-cloudflare/test/apps/workers/.gitignore
+++ b/packages/adapter-cloudflare/test/apps/workers/.gitignore
@@ -1,5 +1,8 @@
 .DS_Store
 node_modules
 /.svelte-kit
+
+# Cloudflare
 /.wrangler
 /dist
+/config


### PR DESCRIPTION
The `.wrangler` directory is generated by Cloudflare Wrangler when running the Wrangler worker preview and is placed relative to the wrangler config. This should be ignored no matter where it is, not just the root of the workspace