### PR TITLE
fix: check spelling of hook files

### DIFF
--- a/.changeset/loose-pants-notice.md
+++ b/.changeset/loose-pants-notice.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: warn if hook files are spelled as "hook" instead of "hooks"

--- a/packages/kit/src/core/sync/utils.js
+++ b/packages/kit/src/core/sync/utils.js
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { mkdirp } from '../../utils/filesystem.js';
+import { styleText } from 'node:util';
+import { mkdirp, resolve_entry } from '../../utils/filesystem.js';
 
 /** @type {Map<string, string>} */
 const previous_contents = new Map();
@@ -67,4 +68,23 @@ export function dedent(strings, ...values) {
 	str = str.trim();
 
 	return str;
+}
+
+/**
+ * @param {string} original
+ * @param {string} typo The common misspelling to check for
+ * @param {string} description What was wrong with the filename
+ */
+export function check_spelling(original, typo, description) {
+	const misspelled = resolve_entry(typo);
+	if (!misspelled) return;
+
+	const corrected = path.basename(misspelled).replace(path.basename(typo), path.basename(original));
+
+	console.warn(
+		styleText(
+			['bold', 'yellow'],
+			`${description}. Did you mean ${corrected}?` + ` at ${path.resolve(misspelled)}`
+		)
+	);
 }

--- a/packages/kit/src/core/sync/utils.spec.js
+++ b/packages/kit/src/core/sync/utils.spec.js
@@ -1,0 +1,37 @@
+import path from 'node:path';
+import process from 'node:process';
+import { stripVTControlCharacters } from 'node:util';
+import { afterAll, afterEach, expect, test, vi } from 'vitest';
+import { check_spelling } from './utils.js';
+
+const fixtures = path.join(import.meta.dirname, 'fixtures');
+
+test.describe('check_spelling', () => {
+	const console_warn_spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+	const cwd_spy = vi.spyOn(process, 'cwd').mockReturnValue(fixtures);
+
+	afterEach(() => {
+		console_warn_spy.mockClear();
+		cwd_spy.mockClear();
+	});
+
+	afterAll(() => {
+		console_warn_spy.mockReset();
+		cwd_spy.mockReset();
+	});
+
+	test('does not warn if the misspelled file does not exist', () => {
+		check_spelling('src/hooks.server', path.resolve('src/+hooks.server'), 'Unexpected + prefix');
+
+		expect(console_warn_spy).not.toHaveBeenCalled();
+	});
+
+	test('replaces the last occurrence of the typo in the suggested filename', () => {
+		check_spelling(`src/hooks.server`, path.resolve('src/hook.server'), 'Missing s suffix');
+
+		expect(console_warn_spy).toHaveBeenCalledOnce();
+		expect(stripVTControlCharacters(console_warn_spy.mock.calls[0][0])).toBe(
+			`Missing s suffix. Did you mean hooks.server.js? at ${path.join(fixtures, `src/hook.server.js`)}`
+		);
+	});
+});

--- a/packages/kit/src/core/sync/write_client_manifest.js
+++ b/packages/kit/src/core/sync/write_client_manifest.js
@@ -1,8 +1,6 @@
-import path from 'node:path';
-import { styleText } from 'node:util';
+import { check_spelling, dedent, write_if_changed } from './utils.js';
 import { relative_path, resolve_entry } from '../../utils/filesystem.js';
 import { s } from '../../utils/misc.js';
-import { dedent, write_if_changed } from './utils.js';
 
 /**
  * Writes the client manifest to disk. The manifest is used to power the router. It contains the
@@ -123,15 +121,9 @@ export function write_client_manifest(kit, manifest_data, output, metadata) {
 	const client_hooks_file = resolve_entry(kit.files.hooks.client);
 	const universal_hooks_file = resolve_entry(kit.files.hooks.universal);
 
-	const typo = resolve_entry('src/+hooks.client');
-	if (typo) {
-		console.log(
-			styleText(
-				['bold', 'yellow'],
-				`Unexpected + prefix. Did you mean ${typo.split('/').at(-1)?.slice(1)}?` +
-					` at ${path.resolve(typo)}`
-			)
-		);
+	if (!client_hooks_file) {
+		check_spelling('src/hooks.client', 'src/+hooks.client', 'Unexpected + prefix');
+		check_spelling('src/hooks.client', 'src/hook.client', 'Missing s suffix');
 	}
 
 	// Stringified version of

--- a/packages/kit/src/core/sync/write_server.js
+++ b/packages/kit/src/core/sync/write_server.js
@@ -1,11 +1,10 @@
 import path from 'node:path';
-import { styleText } from 'node:util';
 import { hash } from '../../utils/hash.js';
 import { resolve_entry } from '../../utils/filesystem.js';
 import { posixify } from '../../utils/os.js';
 import { s } from '../../utils/misc.js';
 import { load_error_page, load_template } from '../config/index.js';
-import { write_if_changed } from './utils.js';
+import { check_spelling, write_if_changed } from './utils.js';
 import { escape_html } from '../../utils/escape.js';
 
 /**
@@ -93,15 +92,14 @@ export function write_server(config, output, root) {
 	const server_hooks_file = resolve_entry(config.kit.files.hooks.server);
 	const universal_hooks_file = resolve_entry(config.kit.files.hooks.universal);
 
-	const typo = resolve_entry('src/+hooks.server');
-	if (typo) {
-		console.log(
-			styleText(
-				['bold', 'yellow'],
-				`Unexpected + prefix. Did you mean ${typo.split('/').at(-1)?.slice(1)}?` +
-					` at ${path.resolve(typo)}`
-			)
-		);
+	if (!server_hooks_file) {
+		check_spelling('src/hooks.server', 'src/+hooks.server', 'Unexpected + prefix');
+		check_spelling('src/hooks.server', 'src/hook.server', 'Missing s suffix');
+	}
+
+	if (!universal_hooks_file) {
+		check_spelling('src/hooks', 'src/+hooks', 'Unexpected + prefix');
+		check_spelling('src/hooks', 'src/hook', 'Missing s suffix');
 	}
 
 	/** @param {string} file */


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/14315

This PR adds a utility for checking the spelling of hook files, checks the spelling for the universal hook file, and checks if an s is missing from "hooks". Also, only bothers with the check if the file itself has not been created.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
