### PR TITLE
fix: don't cache preloaded redirect results

### DIFF
--- a/.changeset/preload-redirect-cache.md
+++ b/.changeset/preload-redirect-cache.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: don't cache preloaded redirect results, so navigation re-runs `load` instead of replaying a stale redirect

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -622,8 +622,11 @@ async function _preload_data(intent) {
 			token: preload,
 			promise: load_route({ ...intent, preload }).then((result) => {
 				preload_tokens.delete(preload);
-				if (result.type === 'loaded' && result.state.error) {
-					// Don't cache errors, because they might be transient
+				if (result.type === 'redirect' || (result.type === 'loaded' && result.state.error)) {
+					// Don't cache errors or redirects, because they might be transient.
+					// A cached redirect would be replayed without re-running `load`
+					// until a navigation commits, which can turn a resolvable
+					// redirect chain into a redirect loop
 					discard_load_cache();
 				}
 				return result;

--- a/packages/kit/test/apps/basics/src/routes/data-sveltekit/preload-data/redirect-gate/dashboard/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/data-sveltekit/preload-data/redirect-gate/dashboard/+page.server.js
@@ -1,0 +1,9 @@
+import { redirect } from '@sveltejs/kit';
+import { state } from '../state.js';
+
+export function load() {
+	if (!state.selected) {
+		redirect(303, '/data-sveltekit/preload-data/redirect-gate/select');
+	}
+	return {};
+}

--- a/packages/kit/test/apps/basics/src/routes/data-sveltekit/preload-data/redirect-gate/dashboard/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/data-sveltekit/preload-data/redirect-gate/dashboard/+page.svelte
@@ -1,0 +1,1 @@
+<h1>dashboard</h1>

--- a/packages/kit/test/apps/basics/src/routes/data-sveltekit/preload-data/redirect-gate/select/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/data-sveltekit/preload-data/redirect-gate/select/+page.server.js
@@ -1,0 +1,7 @@
+import { redirect } from '@sveltejs/kit';
+import { state } from '../state.js';
+
+export function load() {
+	state.selected = true;
+	redirect(303, '/data-sveltekit/preload-data/redirect-gate/dashboard');
+}

--- a/packages/kit/test/apps/basics/src/routes/data-sveltekit/preload-data/redirect-gate/start/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/data-sveltekit/preload-data/redirect-gate/start/+page.server.js
@@ -1,0 +1,6 @@
+import { state } from '../state.js';
+
+export function load() {
+	// reset so the test can run repeatedly against the same server
+	state.selected = false;
+}

--- a/packages/kit/test/apps/basics/src/routes/data-sveltekit/preload-data/redirect-gate/start/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/data-sveltekit/preload-data/redirect-gate/start/+page.svelte
@@ -1,0 +1,5 @@
+<a
+	id="gated"
+	href="/data-sveltekit/preload-data/redirect-gate/dashboard"
+	data-sveltekit-preload-data="hover">go to dashboard</a
+>

--- a/packages/kit/test/apps/basics/src/routes/data-sveltekit/preload-data/redirect-gate/state.js
+++ b/packages/kit/test/apps/basics/src/routes/data-sveltekit/preload-data/redirect-gate/state.js
@@ -1,0 +1,1 @@
+export const state = { selected: false };

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -1071,6 +1071,24 @@ test.describe('data-sveltekit attributes', () => {
 		await expect(page).toHaveURL(offline_url);
 	});
 
+	test('preloaded redirect is not replayed on navigation', async ({ page }) => {
+		await page.goto('/data-sveltekit/preload-data/redirect-gate/start');
+
+		// preload /dashboard while its load redirects to /select
+		await page.locator('#gated').hover();
+		await page.locator('#gated').dispatchEvent('touchstart');
+		await Promise.all([
+			page.waitForTimeout(100), // wait for preloading to start
+			page.waitForLoadState('networkidle') // wait for preloading to finish
+		]);
+
+		// navigating must re-run load rather than replay the cached redirect,
+		// otherwise the mutual redirect never resolves and loops
+		await page.locator('#gated').click();
+		await expect(page.locator('h1')).toHaveText('dashboard');
+		await expect(page).toHaveURL(/redirect-gate\/dashboard/);
+	});
+
 	test('data-sveltekit-preload-data error does not block user navigation', async ({
 		page,
 		context,


### PR DESCRIPTION
closes #16484

When a link is preloaded and the target's `load` returns `redirect(...)`,
the client caches that redirect result and replays it on navigation
without re-running `load`. The cache is only cleared once a navigation
commits, and a redirect never commits one. So a preloaded redirect into
a pair of mutually redirecting routes loops until the 20 redirect limit,
even when a fresh evaluation would resolve. The issue has a minimal
repro of an onboarding style gate.

I made `_preload_data` discard the cache when the result is a redirect.
This matches how it already refuses to cache errors, since both are
transient results that have to be re-evaluated at navigation time.

The new test reproduces the gate scenario from the issue. It preloads a
route whose load redirects, then clicks. Without the fix it ends in a
redirect loop, with the fix the navigation resolves. Passes in dev and
build modes.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] References an issue: #16484
- [x] This message body illustrates the problems it solves
- [x] Includes a test that fails without this PR but passes with it

### Tests
- [x] Relevant suites pass (data-sveltekit and redirect blocks, dev and build). `lint-all` currently fails on upstream main itself (pre-existing, unrelated)

### Changesets
- [x] Changeset included (`@sveltejs/kit` patch, `fix:` prefix)

### Edits
- [x] 'Allow edits from maintainers' is checked