### PR TITLE
chore: lint vercel files

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -34,6 +34,7 @@ export default [
 			'**/dist',
 			'**/.custom-out-dir',
 			'packages/adapter-*/files',
+			'!packages/adapter-vercel/files',
 			'packages/kit/src/core/config/fixtures/multiple', // dir contains svelte config with multiple extensions tripping eslint
 			'packages/kit/types/index.d.ts', // generated file
 			'packages/*/test/**/build/**',


### PR DESCRIPTION
The Vercel server handler files are in a `files` directory. This directory is where bundled output goes into for all the other adapter packages except for the Vercel adapter. As a result, it was accidentally included in the eslint ignore list.

This PR changes that so it's no longer ignored (alternatively, we should just rename it as `src/`?)