### PR TITLE
perf: avoid quadratic remote form issue merging

### DIFF
--- a/.changeset/quick-forms-merge.md
+++ b/.changeset/quick-forms-merge.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+perf: avoid quadratic remote form issue merging

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -39,16 +39,21 @@ import {
  * @returns {InternalRemoteFormIssue[]}
  */
 function merge_with_server_issues(form_data, current_issues, client_issues) {
+	const client_names = new Set(client_issues.map((issue) => issue.name));
+
 	const merged = [
-		...current_issues.filter(
-			(issue) => issue.server && !client_issues.some((i) => i.name === issue.name)
-		),
+		...current_issues.filter((issue) => issue.server && !client_names.has(issue.name)),
 		...client_issues
 	];
 
-	const keys = Array.from(form_data.keys());
+	const positions = new Map();
+	let i = 0;
+	for (const key of form_data.keys()) {
+		if (!positions.has(key)) positions.set(key, i);
+		i++;
+	}
 
-	return merged.sort((a, b) => keys.indexOf(a.name) - keys.indexOf(b.name));
+	return merged.sort((a, b) => (positions.get(a.name) ?? -1) - (positions.get(b.name) ?? -1));
 }
 
 /**

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -46,6 +46,7 @@ function merge_with_server_issues(form_data, current_issues, client_issues) {
 		...client_issues
 	];
 
+	/** @type {Map<string, number>} */
 	const positions = new Map();
 	let i = 0;
 	for (const key of form_data.keys()) {


### PR DESCRIPTION
`merge_with_server_issues` runs whenever preflight validation produces issues, which with the documented `oninput` pattern means on every keystroke while a form has issues. Merging costs O(S·C + M·K·log M) for S server issues, C client issues, M merged issues and K form keys. 🤓 This change drops it to O(S + C + K + M·log M). 🤓

N fields with N issues (half server, half client), Node 22 x64, median of repeated runs:

| fields | before | after | speedup |
| ---: | ---: | ---: | ---: |
| 400 | 1.6 ms | 0.1 ms | 15× |
| 800 | 7.9 ms | 0.3 ms | 27× |
| 1600 | 33.0 ms | 0.8 ms | 42× |
| 3200 | 163.8 ms | 2.2 ms | 76× |

Small forms are at parity or slightly faster, since the old code already allocated the key array.

Output is unchanged: identical issue-object ordering to the previous implementation across 10,000 randomized cases covering duplicated form keys, duplicated issue names, names absent from the form, mixed server and client issues and empty collections. The merge semantics negotiated in #14744/#14759 are preserved.

---

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
