### PR TITLE
perf: use a Set to check element ids when validating fragment links

### DIFF
--- a/.changeset/spotty-pandas-brake.md
+++ b/.changeset/spotty-pandas-brake.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+perf: use a `Set` to check element ids when validating fragment links during prerendering

--- a/packages/kit/src/core/postbuild/prerender.js
+++ b/packages/kit/src/core/postbuild/prerender.js
@@ -265,7 +265,7 @@ async function prerender({ hash, out, manifest_path, metadata, verbose, env, vit
 	/** @type {Map<string, Set<string>>} */
 	const expected_hashlinks = new Map();
 
-	/** @type {Map<string, string[]>} */
+	/** @type {Map<string, Set<string>>} */
 	const actual_hashlinks = new Map();
 
 	/**
@@ -394,7 +394,7 @@ async function prerender({ hash, out, manifest_path, metadata, verbose, env, vit
 				handle_invalid_url({ href, referrer: decoded });
 			}
 
-			actual_hashlinks.set(decoded, ids);
+			actual_hashlinks.set(decoded, new Set(ids));
 
 			/** @param {string} href */
 			const removePrerenderOrigin = (href) => {
@@ -646,7 +646,7 @@ async function prerender({ hash, out, manifest_path, metadata, verbose, env, vit
 		// ignore fragment links to pages that were not prerendered
 		if (!hashlinks) continue;
 
-		if (!hashlinks.includes(id) && !SPECIAL_HASHLINKS.has(id)) {
+		if (!hashlinks.has(id) && !SPECIAL_HASHLINKS.has(id)) {
 			handle_missing_id({ id, path, referrers: Array.from(referrers) });
 		}
 	}


### PR DESCRIPTION
Prerendering validates each expected fragment link with `hashlinks.includes(id)` against the target page's array of element ids, which is O(A*L) for A ids and L inbound fragment links. Storing the crawled ids as a `Set` makes it O(A + L).

Cost for a page with N anchors and N inbound fragment links (Node 22):

| N | array `includes` | `Set` (incl. construction) |
| ---: | ---: | ---: |
| 1,000 | 21 ms | 0.5 ms |
| 4,000 | 123 ms | 0.8 ms |
| 8,000 | 616 ms | 1.7 ms |
| 16,000 | 1,591 ms | 3.8 ms |

This mainly benefits large heavily cross-linked prerendered sites such as generated API references.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 2.0 (major releases only that fix regressions)

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
