### PR TITLE
fix: rerun load functions when the number of values of a tracked search parameter changes

### DIFF
--- a/.changeset/olive-buses-shake.md
+++ b/.changeset/olive-buses-shake.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: rerun load functions when the number of values of a tracked search parameter changes

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1167,12 +1167,12 @@ function diff_search_params(old_url, new_url) {
 	const changed = new Set([...old_url.searchParams.keys(), ...new_url.searchParams.keys()]);
 
 	for (const key of changed) {
-		const old_values = old_url.searchParams.getAll(key);
-		const new_values = new_url.searchParams.getAll(key);
+		const old_values = old_url.searchParams.getAll(key).sort();
+		const new_values = new_url.searchParams.getAll(key).sort();
 
 		if (
-			old_values.every((value) => new_values.includes(value)) &&
-			new_values.every((value) => old_values.includes(value))
+			old_values.length === new_values.length &&
+			old_values.every((value, i) => value === new_values[i])
 		) {
 			changed.delete(key);
 		}

--- a/packages/kit/test/apps/basics/src/routes/load/invalidation/search-params/universal/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/invalidation/search-params/universal/+page.svelte
@@ -6,3 +6,4 @@
 
 <a data-id="tracked" href="?a={data.count + 1}">Change tracked parameter</a>
 <a data-id="untracked" href="?a={data.count}&b={data.count + 1}">Change untracked parameter</a>
+<a data-id="duplicate" href="?a={data.count}&a={data.count}">Duplicate tracked parameter</a>

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -525,6 +525,16 @@ test.describe('Invalidation', () => {
 		expect(await page.textContent('span')).toBe('count: 1');
 	});
 
+	test('load function re-runs when the number of values of a tracked searchParam changes', async ({
+		page,
+		clicknav
+	}) => {
+		await page.goto('/load/invalidation/search-params/universal?a=0');
+		expect(await page.textContent('span')).toBe('count: 0');
+		await clicknav('[data-id="duplicate"]');
+		expect(await page.textContent('span')).toBe('count: 1');
+	});
+
 	test('server-only load functions are re-run following forced invalidation', async ({
 		page,
 		request,


### PR DESCRIPTION
Since #11258, `diff_search_params` compares each key's values as a set, so navigating from `?x=a&x=a` to `?x=a` is treated as unchanged and load functions tracking `x` don't rerun. Comparing the sorted value lists instead catches count changes, still treats reordering as unchanged, and is O(V log V) rather than O(V²).

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 2.0 (major releases only that fix regressions)

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
