### PR TITLE
fix: don't attempt to serialize fetch responses when the request body is not a string or TypedArray

### DIFF
--- a/.changeset/quiet-bodies-repeat.md
+++ b/.changeset/quiet-bodies-repeat.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: don't attempt to serialize fetch responses when the request body is not a string or TypedArray

--- a/packages/kit/src/runtime/client/fetcher.js
+++ b/packages/kit/src/runtime/client/fetcher.js
@@ -89,22 +89,24 @@ const cache = new Map();
 export function initial_fetch(resource, opts) {
 	const selector = build_selector(resource, opts);
 
-	const script = document.querySelector(selector);
-	if (script?.textContent) {
-		script.remove(); // In case multiple script tags match the same selector
-		let { body, ...init } = JSON.parse(script.textContent);
+	if (selector) {
+		const script = document.querySelector(selector);
+		if (script?.textContent) {
+			script.remove(); // In case multiple script tags match the same selector
+			let { body, ...init } = JSON.parse(script.textContent);
 
-		const b64 = script.getAttribute('data-b64');
-		if (b64 !== null) {
-			// Can't use native_fetch('data:...;base64,${body}')
-			// csp can block the request
-			body = base64_decode(body);
+			const b64 = script.getAttribute('data-b64');
+			if (b64 !== null) {
+				// Can't use native_fetch('data:...;base64,${body}')
+				// csp can block the request
+				body = base64_decode(body);
+			}
+
+			const ttl = script.getAttribute('data-ttl');
+			if (ttl) cache.set(selector, { body, init, ttl: 1000 * Number(ttl) });
+
+			return Promise.resolve(new Response(body, init));
 		}
-
-		const ttl = script.getAttribute('data-ttl');
-		if (ttl) cache.set(selector, { body, init, ttl: 1000 * Number(ttl) });
-
-		return Promise.resolve(new Response(body, init));
 	}
 
 	return DEV ? dev_fetch(resource, opts) : window.fetch(resource, opts);
@@ -119,7 +121,7 @@ export function initial_fetch(resource, opts) {
 export function subsequent_fetch(resource, resolved, opts) {
 	if (cache.size > 0) {
 		const selector = build_selector(resource, opts);
-		const cached = cache.get(selector);
+		const cached = selector && cache.get(selector);
 		if (cached) {
 			// https://developer.mozilla.org/en-US/docs/Web/API/Request/cache#value
 			if (
@@ -155,6 +157,7 @@ export function dev_fetch(resource, opts) {
  * Build the cache key for a given request
  * @param {URL | RequestInfo} resource
  * @param {RequestInit} [opts]
+ * @returns {string | null} `null` for requests the server never serializes
  */
 function build_selector(resource, opts) {
 	const url = JSON.stringify(resource instanceof Request ? resource.url : resource);
@@ -162,6 +165,13 @@ function build_selector(resource, opts) {
 	let selector = `script[data-sveltekit-fetched][data-url=${url}]`;
 
 	if (opts?.headers || opts?.body) {
+		const body = opts.body;
+
+		if (body && typeof body !== 'string' && !ArrayBuffer.isView(body)) {
+			// the server skips serializing these, so a matching script tag belongs to another request
+			return null;
+		}
+
 		/** @type {import('types').StrictBody[]} */
 		const values = [];
 
@@ -169,8 +179,8 @@ function build_selector(resource, opts) {
 			values.push([...new Headers(opts.headers)].join(','));
 		}
 
-		if (opts.body && (typeof opts.body === 'string' || ArrayBuffer.isView(opts.body))) {
-			values.push(opts.body);
+		if (body) {
+			values.push(/** @type {import('types').StrictBody} */ (body));
 		}
 
 		selector += `[data-hash="${hash(...values)}"]`;

--- a/packages/kit/src/runtime/server/page/load_data.js
+++ b/packages/kit/src/runtime/server/page/load_data.js
@@ -344,7 +344,7 @@ export function create_universal_fetch(event, state, fetched, csr, resolve_opts)
 						typeof request_body !== 'string' &&
 						!ArrayBuffer.isView(request_body)
 					) {
-						// Unhashable request bodies cannot be serialized, so the browser repeats the fetch.
+						// requests whose body can't be hashed aren't serialized — the browser repeats the fetch
 						return;
 					}
 

--- a/packages/kit/src/runtime/server/page/load_data.js
+++ b/packages/kit/src/runtime/server/page/load_data.js
@@ -334,14 +334,24 @@ export function create_universal_fetch(event, state, fetched, csr, resolve_opts)
 						);
 					}
 
+					const request_body =
+						input instanceof Request && cloned_body
+							? await stream_to_string(cloned_body)
+							: init?.body;
+
+					if (
+						request_body &&
+						typeof request_body !== 'string' &&
+						!ArrayBuffer.isView(request_body)
+					) {
+						// Unhashable request bodies cannot be serialized, so the browser repeats the fetch.
+						return;
+					}
+
 					fetched.push({
 						url: same_origin ? url.href.slice(event.url.origin.length) : url.href,
 						method: event.request.method,
-						request_body: /** @type {string | ArrayBufferView | undefined} */ (
-							input instanceof Request && cloned_body
-								? await stream_to_string(cloned_body)
-								: init?.body
-						),
+						request_body: /** @type {string | ArrayBufferView | null | undefined} */ (request_body),
 						request_headers: cloned_headers,
 						response_body: body,
 						response,

--- a/packages/kit/test/apps/basics/src/routes/load/serialization-post-body-collision.json/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/serialization-post-body-collision.json/+server.js
@@ -1,0 +1,9 @@
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export function GET() {
+	return new Response('GET');
+}
+
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export async function POST({ request }) {
+	return new Response(`POST:${await request.text()}`);
+}

--- a/packages/kit/test/apps/basics/src/routes/load/serialization-post-body-collision/+page.js
+++ b/packages/kit/test/apps/basics/src/routes/load/serialization-post-body-collision/+page.js
@@ -1,0 +1,15 @@
+/** @type {import('@sveltejs/kit').Load} */
+export async function load({ fetch }) {
+	// same headers as the GET below, so both requests hash identically without their bodies
+	const headers = { 'x-collision': 'yes' };
+
+	const post = await fetch('/load/serialization-post-body-collision.json', {
+		method: 'POST',
+		headers,
+		body: new URLSearchParams('a=1')
+	});
+
+	const get = await fetch('/load/serialization-post-body-collision.json', { headers });
+
+	return { post: await post.text(), get: await get.text() };
+}

--- a/packages/kit/test/apps/basics/src/routes/load/serialization-post-body-collision/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/serialization-post-body-collision/+page.svelte
@@ -1,0 +1,7 @@
+<script>
+	/** @type {import('./$types').PageProps} */
+	let { data } = $props();
+</script>
+
+<h1>{data.post}</h1>
+<p>{data.get}</p>

--- a/packages/kit/test/apps/basics/src/routes/load/serialization-post-body-object/+page.js
+++ b/packages/kit/test/apps/basics/src/routes/load/serialization-post-body-object/+page.js
@@ -1,0 +1,9 @@
+/** @type {import('@sveltejs/kit').Load} */
+export async function load({ fetch }) {
+	const response = await fetch('/load/serialization-post.json', {
+		method: 'POST',
+		body: new URLSearchParams('a=1')
+	});
+
+	return { body: await response.text() };
+}

--- a/packages/kit/test/apps/basics/src/routes/load/serialization-post-body-object/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/serialization-post-body-object/+page.svelte
@@ -1,0 +1,6 @@
+<script>
+	/** @type {import('./$types').PageProps} */
+	let { data } = $props();
+</script>
+
+<h1>{data.body}</h1>

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -332,6 +332,20 @@ test.describe('Load', () => {
 		}
 	});
 
+	test('POST fetches with non-string bodies do not reuse responses serialized for other requests', async ({
+		page,
+		javaScriptEnabled
+	}) => {
+		await page.goto('/load/serialization-post-body-collision');
+
+		expect(await page.textContent('h1')).toBe('POST:a=1');
+		expect(await page.textContent('p')).toBe('GET');
+
+		if (!javaScriptEnabled) {
+			expect(await page.locator('script[data-sveltekit-fetched]').count()).toBe(1);
+		}
+	});
+
 	test('fetches using an arraybuffer serialized with b64', async ({ page, javaScriptEnabled }) => {
 		await page.goto('/load/fetch-arraybuffer-b64');
 

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -319,6 +319,19 @@ test.describe('Load', () => {
 		}
 	});
 
+	test('POST fetches with non-string bodies are not serialized', async ({
+		page,
+		javaScriptEnabled
+	}) => {
+		await page.goto('/load/serialization-post-body-object');
+
+		expect(await page.textContent('h1')).toBe('A=1');
+
+		if (!javaScriptEnabled) {
+			expect(await page.locator('script[data-sveltekit-fetched]').count()).toBe(0);
+		}
+	});
+
 	test('fetches using an arraybuffer serialized with b64', async ({ page, javaScriptEnabled }) => {
 		await page.goto('/load/fetch-arraybuffer-b64');
 


### PR DESCRIPTION
A universal load `fetch` with a `URLSearchParams`, `FormData` or `Blob` body crashes SSR with `TypeError: value must be a string or TypedArray` when the response would be inlined. #1385 guarded serialization on the request body being a string, #6565 re-pointed the check at the response body, and #9801 removed the throw that had been masking the loss. This restores the guard. The response isn't serialized and the browser repeats the fetch.

The client lookup gets the same rule. It hashed only the headers when it couldn't hash the body, so during hydration such a fetch could resolve with a different same-url request's serialized response instead of being sent.

Both tests fail on the base branch.
