### PR TITLE
docs: fix some bad snippets

### DIFF
--- a/documentation/docs/30-advanced/25-errors.md
+++ b/documentation/docs/30-advanced/25-errors.md
@@ -108,6 +108,7 @@ Since SvelteKit 2.54 and Svelte 5.53, you can change this by enabling the experi
 
 ```js
 /// file: svelte.config.js
+// @errors: 2353
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {

--- a/documentation/docs/30-advanced/40-service-workers.md
+++ b/documentation/docs/30-advanced/40-service-workers.md
@@ -13,7 +13,7 @@ Inside the service worker you have access to the [`$service-worker` module]($ser
 The following example caches the built app and any files in `static` eagerly, and caches all other requests as they happen. This would make each page work offline once visited.
 
 ```js
-// @errors: 2688
+// @errors: 2688, 2307
 /// file: src/service-worker.js
 // Disables access to DOM typings like `HTMLElement` which are not available
 // inside a service worker and instantiates the correct globals

--- a/documentation/docs/30-advanced/68-observability.md
+++ b/documentation/docs/30-advanced/68-observability.md
@@ -19,6 +19,7 @@ Both of these features are currently experimental, meaning they are likely to co
 
 ```js
 /// file: svelte.config.js
+// @errors: 2353
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {


### PR DESCRIPTION
this, combined with an upgrade to the latest version of SvelteKit, should hopefully get the preview docs building again