### PR TITLE
chore: prevent cursor carryover between preload test phases

### DIFF
--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -939,6 +939,8 @@ test.describe('data-sveltekit attributes', () => {
 		expect(requests.length).toBe(2);
 
 		requests.length = 0;
+		// park the mouse so the previous phase's cursor position can't trigger a preload after hydration
+		await page.mouse.move(0, 0);
 		await page.goto('/data-sveltekit/preload-data');
 		await page.locator('#two').hover();
 		await page.locator('#two').dispatchEvent('touchstart');
@@ -949,6 +951,7 @@ test.describe('data-sveltekit attributes', () => {
 		expect(requests.length).toBe(2);
 
 		requests.length = 0;
+		await page.mouse.move(0, 0);
 		await page.goto('/data-sveltekit/preload-data');
 		await page.locator('#three').hover();
 		await page.locator('#three').dispatchEvent('touchstart');
@@ -959,6 +962,7 @@ test.describe('data-sveltekit attributes', () => {
 		expect(requests.length).toBe(0);
 
 		requests.length = 0;
+		await page.mouse.move(0, 0);
 		await page.goto('/data-sveltekit/preload-data');
 		await page.locator('#tap').hover();
 		await page.locator('#tap').dispatchEvent('touchstart');
@@ -969,6 +973,7 @@ test.describe('data-sveltekit attributes', () => {
 		expect(requests.length).toBe(2);
 
 		requests.length = 0;
+		await page.mouse.move(0, 0);
 		await page.goto('/data-sveltekit/preload-data');
 		await page.locator('#dynamic').hover();
 		await page.locator('#dynamic').dispatchEvent('touchstart');


### PR DESCRIPTION
`data-sveltekit-preload-data` fails intermittently under server-side route resolution, about 1 in 6 locally on `version-3`, and anything that shifts hydration timing makes it worse (a one-line import change on #16308 took it to 3 failed retries in CI).

The test navigates between phases with the cursor still parked over the previous phase's link. When the fresh page hydrates, Chromium fires a mouse event at that position and the router preloads that link's target, so the phase that expects zero requests counts a preload it never triggered. A request timeline shows the target's `__route.js`, node script and `__data.json` all arriving before the phase's `goto` resolves, ahead of any hover.

Parking the mouse before each navigation removes the carryover. 10 of 10 runs green under `ROUTER_RESOLUTION=server` with the change.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
