### PR TITLE
fix: guard base_expression and origin against data:/about: protocols in iframes

### DIFF
--- a/packages/kit/src/runtime/client/utils.js
+++ b/packages/kit/src/runtime/client/utils.js
@@ -1,7 +1,10 @@
 import { BROWSER, DEV } from 'esm-env';
 import { PRELOAD_PRIORITIES } from './constants.js';
 
-export const origin = BROWSER ? location.origin : '';
+// For data: and about: URLs (e.g. iframe srcdoc), location.origin returns the
+// string "null" which breaks origin comparisons. Fall back to empty string.
+export const origin =
+	BROWSER && location.protocol !== 'data:' && location.protocol !== 'about:' ? location.origin : '';
 
 /** @param {string | URL} url */
 export function resolve_url(url) {

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -121,15 +121,18 @@ export async function render_response({
 
 			base = segments.map(() => '..').join('/') || '.';
 
-			// resolve e.g. '../..' against current location, then remove trailing slash
-			base_expression = `new URL(${s(base)}, location).pathname.slice(0, -1)`;
+			// resolve e.g. '../..' against current location, then remove trailing slash.
+			// Guard against non-http(s) protocols (e.g. data: or about:srcdoc used in iframes)
+			// where new URL(..., location) throws a TypeError during hydration.
+			base_expression = `['about:', 'data:'].includes(location.protocol) ? '' : new URL(${s(base)}, location).pathname.slice(0, -1)`;
 
 			if (!paths.assets || (paths.assets[0] === '/' && paths.assets !== SVELTE_KIT_ASSETS)) {
 				assets = base;
 			}
 		} else if (options.hash_routing) {
-			// we have to assume that we're in the right place
-			base_expression = "new URL('.', location).pathname.slice(0, -1)";
+			// we have to assume that we're in the right place.
+			// Guard against non-http(s) protocols where new URL(..., location) throws.
+			base_expression = "['about:', 'data:'].includes(location.protocol) ? '' : new URL('.', location).pathname.slice(0, -1)";
 		}
 	}
 


### PR DESCRIPTION
SvelteKit apps embedded in `<iframe srcdoc>` or `<iframe src="data:...">` crash on hydration with a `TypeError: Invalid URL` because `new URL(base, location)` throws when `location.protocol` is `data:` or `about:`.

There is a secondary issue: `location.origin` returns the literal string `"null"` for `data:` URLs, which breaks any origin comparison.

A maintainer explicitly invited a fix in the issue thread.

**Changes:**

`packages/kit/src/runtime/server/page/render.js`
- Lines 125 and 132: wrap both `new URL(…, location)` expressions with a protocol guard. Falls back to `''` (same as the server-side default) when running under `data:` or `about:`.

`packages/kit/src/runtime/client/utils.js`
- Line 4: guard the `origin` constant against non-http(s) protocols so it stays `''` instead of the string `"null"`.

Normal `http:`/`https:` behaviour is completely unchanged.

Fixes #13226