### PR TITLE
fix: don't double-prefix base when checking for prerendered paths in server fetch

### DIFF
--- a/.changeset/fetch-prerendered-base.md
+++ b/.changeset/fetch-prerendered-base.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correctly detect prerendered paths in server `fetch` when `paths.base` is set

--- a/packages/kit/src/runtime/server/fetch.js
+++ b/packages/kit/src/runtime/server/fetch.js
@@ -117,7 +117,7 @@ export function create_fetch({ event, options, manifest, state, get_cookie_heade
 					return await fetch(request);
 				}
 
-				if (has_prerendered_path(manifest, paths.base + decoded)) {
+				if (has_prerendered_path(manifest, decoded)) {
 					// The path of something prerendered could match a different route
 					// that is still in the manifest, leading to the wrong route being loaded.
 					// We therefore bail early here. The prerendered logic is different for

--- a/packages/kit/test/apps/options-2/src/routes/fetch-prerendered/+page.server.js
+++ b/packages/kit/test/apps/options-2/src/routes/fetch-prerendered/+page.server.js
@@ -1,0 +1,9 @@
+export async function load({ fetch }) {
+	const response = await fetch('/basepath/fetch-prerendered/shadowed/static');
+	const text = await response.text();
+
+	return {
+		status: response.status,
+		found: text.includes('this page was prerendered')
+	};
+}

--- a/packages/kit/test/apps/options-2/src/routes/fetch-prerendered/+page.server.js
+++ b/packages/kit/test/apps/options-2/src/routes/fetch-prerendered/+page.server.js
@@ -1,3 +1,4 @@
+/** @type {import('./$types').PageServerLoad} */
 export async function load({ fetch }) {
 	const response = await fetch('/basepath/fetch-prerendered/shadowed/static');
 	const text = await response.text();

--- a/packages/kit/test/apps/options-2/src/routes/fetch-prerendered/+page.svelte
+++ b/packages/kit/test/apps/options-2/src/routes/fetch-prerendered/+page.svelte
@@ -1,0 +1,6 @@
+<script>
+	/** @type {import('./$types').PageProps} */
+	let { data } = $props();
+</script>
+
+<h1>{data.status} {data.found}</h1>

--- a/packages/kit/test/apps/options-2/src/routes/fetch-prerendered/shadowed/[...rest]/+page.svelte
+++ b/packages/kit/test/apps/options-2/src/routes/fetch-prerendered/shadowed/[...rest]/+page.svelte
@@ -1,0 +1,1 @@
+<h1>catch-all</h1>

--- a/packages/kit/test/apps/options-2/src/routes/fetch-prerendered/shadowed/static/+page.js
+++ b/packages/kit/test/apps/options-2/src/routes/fetch-prerendered/shadowed/static/+page.js
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/packages/kit/test/apps/options-2/src/routes/fetch-prerendered/shadowed/static/+page.svelte
+++ b/packages/kit/test/apps/options-2/src/routes/fetch-prerendered/shadowed/static/+page.svelte
@@ -1,0 +1,1 @@
+<h1>this page was prerendered</h1>

--- a/packages/kit/test/apps/options-2/test/test.js
+++ b/packages/kit/test/apps/options-2/test/test.js
@@ -61,6 +61,11 @@ test.describe('paths', () => {
 		expect(new URL(page.url()).pathname).toBe('/basepath/hello');
 	});
 
+	test('serves a prerendered page for a server-side fetch of its path', async ({ page }) => {
+		await page.goto('/basepath/fetch-prerendered');
+		expect(await page.textContent('h1')).toBe('200 true');
+	});
+
 	test('query remote function from client accounts for base path', async ({
 		page,
 		javaScriptEnabled


### PR DESCRIPTION
`has_prerendered_path` expects a base-inclusive pathname (its JSDoc says so, and the `respond` call site passes one), but the `fetch` call site prepends `base` to a pathname that already contains it, so the prerendered bail-out never matches when `paths.base` is set. #13575 extracted the helper out of this check and added a second caller in `respond.js`, prefixing `base` here in the same hunk; before that, `fetch` checked `prerendered_routes.has(decoded)` directly. With the bail-out firing, base-path apps also stop forwarding cookies and auth headers on these sub-requests, matching what apps without a base already do.
