### PR TITLE
fix: don't forward a null accept-language header to sub-requests

### DIFF
--- a/.changeset/fetch-accept-language.md
+++ b/.changeset/fetch-accept-language.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: don't set a `null` `accept-language` header on internal `fetch` sub-requests when the incoming request has none

--- a/packages/kit/src/runtime/server/fetch.js
+++ b/packages/kit/src/runtime/server/fetch.js
@@ -142,11 +142,9 @@ export function create_fetch({ event, options, manifest, state, get_cookie_heade
 					request.headers.set('accept', '*/*');
 				}
 
-				if (!request.headers.has('accept-language')) {
-					request.headers.set(
-						'accept-language',
-						/** @type {string} */ (event.request.headers.get('accept-language'))
-					);
+				const accept_language = event.request.headers.get('accept-language');
+				if (accept_language && !request.headers.has('accept-language')) {
+					request.headers.set('accept-language', accept_language);
 				}
 
 				const response = await internal_fetch(request, options, manifest, state);

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -742,6 +742,18 @@ test.describe('Load', () => {
 		await expect(page.locator('p')).toHaveText('1');
 	});
 
+	test('does not forward accept-language to internal fetch when the request has none', async ({
+		request
+	}) => {
+		// unlike browsers and undici, the `request` fixture sends no accept-language header
+		const html = await (await request.get('/load/fetch-request-headers')).text();
+		const headers = JSON.parse(
+			/** @type {RegExpMatchArray} */ (/<pre>(.+?)<\/pre>/s.exec(html))[1]
+		);
+		expect(headers.accept).toBe('*/*');
+		expect(headers['accept-language']).toBeUndefined();
+	});
+
 	test('includes origin header on non-GET internal request', async ({ page, baseURL }) => {
 		await page.goto('/load/fetch-origin-internal');
 		expect(await page.textContent('h1')).toBe(`origin: ${new URL(baseURL).origin}`);


### PR DESCRIPTION
#7722 added `accept-language` inheritance below the `authorization` inheritance without porting its null guard, so when the incoming request has no `Accept-Language` (requests made during prerendering never do), every internal sub-request gets the literal string `null`.
