### PR TITLE
fix: use the status returned from handleError for the static fallback error page

### DIFF
--- a/.changeset/respond-with-error-status.md
+++ b/.changeset/respond-with-error-status.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: respect the status returned from `handleError` on the fallback error page served to error-page sub-requests

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -2,7 +2,7 @@
 /** @import { ActionResult, RequestEvent, SSRManifest } from '@sveltejs/kit' */
 /** @import { PageNodeIndexes, RequestState, RequiredResolveOptions, ServerDataNode, SSRNode, SSROptions, SSRState } from 'types' */
 import { text } from '@sveltejs/kit';
-import { HttpError, Redirect } from '@sveltejs/kit/internal';
+import { Redirect } from '@sveltejs/kit/internal';
 import { compact } from '../../../utils/array.js';
 import { get_status, normalize_error } from '../../../utils/error.js';
 import { noop } from '../../../utils/functions.js';
@@ -386,7 +386,6 @@ export async function render_page(
 			options,
 			manifest,
 			state,
-			status: e instanceof HttpError ? e.status : 500,
 			error: e,
 			resolve_opts
 		});

--- a/packages/kit/src/runtime/server/page/respond_with_error.js
+++ b/packages/kit/src/runtime/server/page/respond_with_error.js
@@ -17,7 +17,6 @@ import { server_data_serializer } from './data_serializer.js';
  *   options: import('types').SSROptions;
  *   manifest: import('@sveltejs/kit').SSRManifest;
  *   state: import('types').SSRState;
- *   status: number;
  *   error: unknown;
  *   resolve_opts: import('types').RequiredResolveOptions;
  * }} opts
@@ -28,14 +27,13 @@ export async function respond_with_error({
 	options,
 	manifest,
 	state,
-	status,
 	error,
 	resolve_opts
 }) {
 	// reroute to the fallback page to prevent an infinite chain of requests.
 	if (event.request.headers.get('x-sveltekit-error')) {
 		const transformed = await handle_error_and_jsonify(event, event_state, options, error);
-		return static_error_page(options, status, transformed.message);
+		return static_error_page(options, transformed.status, transformed.message);
 	}
 
 	/** @type {import('./types.js').Fetched[]} */

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -604,7 +604,6 @@ export async function internal_respond(request, options, manifest, state) {
 					options,
 					manifest,
 					state,
-					status: 400,
 					error: new SvelteKitError(
 						400,
 						'Malformed URI',
@@ -781,7 +780,6 @@ export async function internal_respond(request, options, manifest, state) {
 					options,
 					manifest,
 					state,
-					status: 404,
 					error: new SvelteKitError(404, 'Not Found', `Not found: ${event.url.pathname}`),
 					resolve_opts
 				});

--- a/packages/kit/test/apps/basics/src/hooks.server.js
+++ b/packages/kit/test/apps/basics/src/hooks.server.js
@@ -53,6 +53,10 @@ export const handleError = ({ event, error: e, status, message }) => {
 		};
 	}
 
+	if (event.url.pathname === '/errors/handle-error-status-fallback') {
+		return { status: 503, message };
+	}
+
 	return event.url.pathname.endsWith('404-fallback')
 		? undefined
 		: { message: `${error.message} (${status} ${message})` };

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -507,6 +507,15 @@ test.describe('Endpoints', () => {
 });
 
 test.describe('Errors', () => {
+	test('uses the handleError status for the fallback page served to error-page sub-requests', async ({
+		request
+	}) => {
+		const response = await request.get('/errors/handle-error-status-fallback', {
+			headers: { 'x-sveltekit-error': 'true' }
+		});
+		expect(response.status()).toBe(503);
+	});
+
 	test('invalid route response is handled', async ({ request }) => {
 		const response = await request.get('/errors/invalid-route-response');
 


### PR DESCRIPTION
#16162 made the status returned from `handle_error_and_jsonify` authoritative on two of `respond_with_error`'s three exits. #16374 later turned the `x-sveltekit-error` early return into a hook-calling exit but kept the caller's pre-hook status, so a `handleError` that returns `{ status }` is honored everywhere except there. Using `transformed.status` makes the `status` argument dead, so this also removes it and the three caller-side status arguments.
