### PR TITLE
fix: read the error status of `App.Error` in the `prerender` and `query.live` remote functions

### DIFF
--- a/.changeset/remote-error-status.md
+++ b/.changeset/remote-error-status.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-chore: read the error status from `App.Error` in the remaining remote-response readers
+fix: read the error status of `App.Error` in the `prerender` and `query.live` remote functions

--- a/.changeset/remote-error-status.md
+++ b/.changeset/remote-error-status.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+chore: read the error status from `App.Error` in the remaining remote-response readers

--- a/packages/kit/src/runtime/app/server/remote/prerender.js
+++ b/packages/kit/src/runtime/app/server/remote/prerender.js
@@ -1,5 +1,5 @@
 /** @import { RemoteResource, RemotePrerenderFunction } from '@sveltejs/kit' */
-/** @import { RemotePrerenderInputsGenerator, RemotePrerenderInternals, MaybePromise } from 'types' */
+/** @import { RemoteFunctionResponse, RemotePrerenderInputsGenerator, RemotePrerenderInternals, MaybePromise } from 'types' */
 /** @import { StandardSchemaV1 } from '@standard-schema/spec' */
 import { json, error } from '@sveltejs/kit';
 import { get_request_store } from '@sveltejs/kit/internal/server';
@@ -109,10 +109,10 @@ export function prerender(validate_or_fn, fn_or_options, maybe_options) {
 						throw new Error('Prerendered response not found');
 					}
 
-					const prerendered = /** @type {RemoteFunctionResponse} */ await response.json();
+					const prerendered = /** @type {RemoteFunctionResponse} */ (await response.json());
 
 					if (prerendered.type === 'error') {
-						error(prerendered.status, prerendered.error);
+						error(prerendered.error.status, prerendered.error);
 					}
 
 					return parse_remote_response(prerendered.data, state.transport)._;

--- a/packages/kit/src/runtime/client/remote-functions/query-live/iterator.js
+++ b/packages/kit/src/runtime/client/remote-functions/query-live/iterator.js
@@ -37,7 +37,10 @@ export async function* create_live_iterator(
 			error: response.statusText
 		}));
 
-		throw new HttpError(result.status ?? response.status ?? 500, result.error);
+		throw new HttpError(
+			result.error?.status ?? result.status ?? response.status ?? 500,
+			result.error
+		);
 	}
 
 	if (response.headers.get('content-type')?.includes('application/json')) {

--- a/packages/kit/src/runtime/client/remote-functions/query-live/iterator.js
+++ b/packages/kit/src/runtime/client/remote-functions/query-live/iterator.js
@@ -1,3 +1,4 @@
+/** @import { RemoteFunctionResponse } from 'types' */
 import { app_dir, base } from '$app/paths/internal/client';
 import { app } from '../../client.js';
 import { notify_version } from '../../state.svelte.js';
@@ -31,16 +32,17 @@ export async function* create_live_iterator(
 	notify_version(response.headers.get('x-sveltekit-version'));
 
 	if (!response.ok) {
+		/** @type {RemoteFunctionResponse} */
 		const result = await response.json().catch(() => ({
 			type: 'error',
-			status: response.status,
-			error: response.statusText
+			error: { status: response.status, message: response.statusText }
 		}));
 
-		throw new HttpError(
-			result.error?.status ?? result.status ?? response.status ?? 500,
-			result.error
-		);
+		if (result.type === 'error') {
+			throw new HttpError(result.error.status, result.error);
+		}
+
+		throw new HttpError(response.status, response.statusText);
 	}
 
 	if (response.headers.get('content-type')?.includes('application/json')) {

--- a/packages/kit/src/runtime/client/remote-functions/query-live/iterator.js
+++ b/packages/kit/src/runtime/client/remote-functions/query-live/iterator.js
@@ -32,17 +32,15 @@ export async function* create_live_iterator(
 	notify_version(response.headers.get('x-sveltekit-version'));
 
 	if (!response.ok) {
-		/** @type {RemoteFunctionResponse} */
-		const result = await response.json().catch(() => ({
-			type: 'error',
-			error: { status: response.status, message: response.statusText }
-		}));
+		/** @type {RemoteFunctionResponse | undefined} */
+		const result = await response.json().catch(() => undefined);
 
-		if (result.type === 'error') {
-			throw new HttpError(result.error.status, result.error);
-		}
+		const error =
+			result?.type === 'error'
+				? result.error
+				: { status: response.status, message: response.statusText };
 
-		throw new HttpError(response.status, response.statusText);
+		throw new HttpError(error.status, error);
 	}
 
 	if (response.headers.get('content-type')?.includes('application/json')) {


### PR DESCRIPTION
#16162 removed `ServerErrorNode.status` (the status now lives on `App.Error`) and updated the readers in `shared.svelte.js`, leaving two behind in `query.live`'s iterator and the prerendered-response reader. This ports them to the same shape and makes the type assertion on the prerendered response actually apply (it was unparenthesized, so the stale read never failed `pnpm check`). The prerendered-error branch still falls into the surrounding catch and re-runs the function, which is a separate issue.
