### PR TITLE
fix: compute the service worker's immutable manifest list like the client's

### DIFF
--- a/.changeset/inline-page-manifest.md
+++ b/.changeset/inline-page-manifest.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: exclude inlined files from the page's `$app/manifest` immutable list

--- a/.changeset/sw-manifest-immutable.md
+++ b/.changeset/sw-manifest-immutable.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: only include `_app/immutable` files in `$app/manifest`'s `immutable` in the service worker

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -1108,9 +1108,10 @@ function kit({ svelte_config }) {
 				]
 			},
 			handler(id) {
-				if (!immutable) {
-					const manifest = vite_client_manifest ?? vite_server_manifest;
-					immutable = collect_immutable(manifest, kit.appDir, `${out}/client`);
+				if (!manifest_data_code) {
+					// the client build computes `immutable`, unless it was skipped
+					// because every route has `csr: false`
+					immutable ??= collect_immutable(vite_server_manifest, kit.appDir, new Set());
 
 					manifest_data_code = dedent`
 					export const immutable = [
@@ -1694,11 +1695,37 @@ function kit({ svelte_config }) {
 					read(`${out}/client/.vite/manifest.json`)
 				));
 
+				/**
+				 * @param {string} entry
+				 * @param {boolean} [add_dynamic_css]
+				 */
+				const deps_of = (entry, add_dynamic_css = false) =>
+					find_deps(vite_manifest, posixify(path.relative(root, entry)), add_dynamic_css, root);
+
+				// the inline bundle and stylesheet are deleted further down, after
+				// being inlined into the page, so they must not appear in `immutable`
+				/** @type {Set<string>} */
+				const inlined = new Set();
+				/** @type {Rolldown.OutputAsset | undefined} */
+				let inline_style;
+
+				if (kit.output.bundleStrategy === 'inline') {
+					inline_style = /** @type {Rolldown.OutputAsset | undefined} */ (
+						client_chunks.find(
+							(chunk) =>
+								chunk.type === 'asset' && chunk.names.length === 1 && chunk.names[0] === 'style.css'
+						)
+					);
+
+					inlined.add(deps_of(`${runtime_directory}/client/bundle.js`).file);
+					if (inline_style) inlined.add(inline_style.fileName);
+				}
+
 				// Replace manifest placeholders in client output. `immutable` is
 				// computed from the Vite client manifest, `assets` and `routes`
 				// from `manifest_data`. `prerendered` is left as a placeholder
 				// for now — it's replaced after prerendering completes.
-				const immutable = collect_immutable(vite_manifest, kit.appDir, `${out}/client`);
+				immutable = collect_immutable(vite_manifest, kit.appDir, inlined);
 
 				replace_manifest_placeholder_variables(client_chunks, `${out}/client`, {
 					immutable,
@@ -1709,13 +1736,6 @@ function kit({ svelte_config }) {
 				// Now that the client build is done, replace the `build` sentinel
 				// in the SSR output with the real build files
 				replace_manifest_placeholder_strings(`${out}/server`, { immutable });
-
-				/**
-				 * @param {string} entry
-				 * @param {boolean} [add_dynamic_css]
-				 */
-				const deps_of = (entry, add_dynamic_css = false) =>
-					find_deps(vite_manifest, posixify(path.relative(root, entry)), add_dynamic_css, root);
 
 				const has_explicit_dynamic_public_env = Object.values(explicit_env_config ?? {}).some(
 					(variable) => variable.public && !variable.static
@@ -1804,25 +1824,16 @@ function kit({ svelte_config }) {
 					};
 
 					if (svelte_config.kit.output.bundleStrategy === 'inline') {
-						const style = /** @type {Rolldown.OutputAsset} */ (
-							client_chunks.find(
-								(chunk) =>
-									chunk.type === 'asset' &&
-									chunk.names.length === 1 &&
-									chunk.names[0] === 'style.css'
-							)
-						);
-
 						build_data.client.inline = {
 							script: read(`${out}/client/${start.file}`),
-							style: /** @type {string | undefined} */ (style?.source)
+							style: /** @type {string | undefined} */ (inline_style?.source)
 						};
 
 						// the bundle and stylesheet are inlined into the page, so the
 						// emitted files are never loaded
 						fs.unlinkSync(`${out}/client/${start.file}`);
 						fs.rmSync(`${out}/client/${start.file}.map`, { force: true });
-						if (style) fs.unlinkSync(`${out}/client/${style.fileName}`);
+						if (inline_style) fs.unlinkSync(`${out}/client/${inline_style.fileName}`);
 					}
 				}
 
@@ -2067,18 +2078,18 @@ function find_overridden_config(config, resolved_config, enforced_config, path, 
  *
  * @param {Manifest} manifest
  * @param {string} app_dir
- * @param {string} client_out
+ * @param {Set<string>} inlined files deleted from the output after being inlined into the page
  * @returns {Array<{ path: string }>}
  */
-const collect_immutable = (manifest, app_dir, client_out) => {
+const collect_immutable = (manifest, app_dir, inlined) => {
 	const prefix = `${app_dir}/immutable`;
 
 	/** @type {Set<string>} */
-	const candidates = new Set();
+	const files = new Set();
 
 	/** @param {string} file */
 	const add = (file) => {
-		if (file.startsWith(prefix)) candidates.add(file);
+		if (file.startsWith(prefix) && !inlined.has(file)) files.add(file);
 	};
 
 	for (const key in manifest) {
@@ -2088,15 +2099,7 @@ const collect_immutable = (manifest, app_dir, client_out) => {
 		if (assets) for (let i = 0; i < assets.length; i++) add(assets[i]);
 	}
 
-	/** @type {Array<{ path: string }>} */
-	const immutable = [];
-
-	for (const path of candidates) {
-		// inlined files are deleted from the output (`bundleStrategy: 'inline'`)
-		if (fs.existsSync(`${client_out}/${path}`)) immutable.push({ path });
-	}
-
-	return immutable;
+	return Array.from(files, (path) => ({ path }));
 };
 
 /**

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -1022,7 +1022,7 @@ function kit({ svelte_config }) {
 	let prerendered;
 
 	/** @type {Set<string>} */
-	let build_files;
+	let immutable;
 	/** @type {string} */
 	let manifest_data_code;
 
@@ -1108,29 +1108,13 @@ function kit({ svelte_config }) {
 				]
 			},
 			handler(id) {
-				if (!build_files) {
-					build_files = new Set();
+				if (!immutable) {
 					const manifest = vite_client_manifest ?? vite_server_manifest;
-					for (const key in manifest) {
-						const { file, css = [], assets = [] } = manifest[key];
-						build_files.add(file);
-						css.forEach((file) => build_files.add(file));
-						assets.forEach((file) => build_files.add(file));
-					}
-
-					if (kit.output.bundleStrategy === 'inline') {
-						// the bundle and stylesheet are inlined into the page and their files
-						// deleted, so they must not appear in the list of cacheable assets
-						for (const file of build_files) {
-							if (!fs.existsSync(`${out}/client/${file}`)) {
-								build_files.delete(file);
-							}
-						}
-					}
+					immutable = collect_immutable(manifest, kit.appDir, `${out}/client`);
 
 					manifest_data_code = dedent`
 					export const immutable = [
-						${Array.from(build_files)
+						${Array.from(immutable)
 							.map((file) => s({ path: file }))
 							.join(',\n')}
 					];
@@ -1716,25 +1700,7 @@ function kit({ svelte_config }) {
 				// computed from the Vite client manifest, `assets` and `routes`
 				// from `manifest_data`. `prerendered` is left as a placeholder
 				// for now — it's replaced after prerendering completes.
-				/** @type {Set<string>} */
-				const immutable = new Set();
-
-				/** @param {string} file */
-				const add_immutable = (file) => {
-					if (
-						file.startsWith(`${kit.appDir}/immutable`) &&
-						fs.existsSync(`${out}/client/${file}`)
-					) {
-						immutable.add(file);
-					}
-				};
-
-				for (const key in vite_manifest) {
-					const { file, css = [], assets = [] } = vite_manifest[key];
-					add_immutable(file);
-					css.forEach(add_immutable);
-					assets.forEach(add_immutable);
-				}
+				const immutable = collect_immutable(vite_manifest, kit.appDir, `${out}/client`);
 
 				replace_manifest_placeholder_variables(client_chunks, `${out}/client`, {
 					immutable: Array.from(immutable).map((file) => ({ path: file })),
@@ -2098,6 +2064,25 @@ function find_overridden_config(config, resolved_config, enforced_config, path, 
 	}
 	return out;
 }
+
+/**
+ * Collects the content-hashed files of a Vite manifest for the `immutable`
+ * export of `$app/manifest`.
+ *
+ * @param {Manifest} manifest
+ * @param {string} app_dir
+ * @param {string} client_out
+ * @returns {Set<string>}
+ */
+const collect_immutable = (manifest, app_dir, client_out) =>
+	new Set(
+		Object.values(manifest)
+			.flatMap(({ file, css = [], assets = [] }) => [file, ...css, ...assets])
+			// inlined files are deleted from the output (`bundleStrategy: 'inline'`)
+			.filter(
+				(file) => file.startsWith(`${app_dir}/immutable`) && fs.existsSync(`${client_out}/${file}`)
+			)
+	);
 
 /**
  * Creates the `$app/manifest` data module. During development, real values

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -1021,7 +1021,7 @@ function kit({ svelte_config }) {
 	/** @type {Prerendered} */
 	let prerendered;
 
-	/** @type {Set<string>} */
+	/** @type {Array<{ path: string }>} */
 	let immutable;
 	/** @type {string} */
 	let manifest_data_code;
@@ -1114,9 +1114,7 @@ function kit({ svelte_config }) {
 
 					manifest_data_code = dedent`
 					export const immutable = [
-						${Array.from(immutable)
-							.map((file) => s({ path: file }))
-							.join(',\n')}
+						${immutable.map((entry) => s(entry)).join(',\n')}
 					];
 
 					export const assets = [
@@ -1703,16 +1701,14 @@ function kit({ svelte_config }) {
 				const immutable = collect_immutable(vite_manifest, kit.appDir, `${out}/client`);
 
 				replace_manifest_placeholder_variables(client_chunks, `${out}/client`, {
-					immutable: Array.from(immutable).map((file) => ({ path: file })),
+					immutable,
 					assets: manifest_data.assets.map((asset) => ({ path: asset.file })),
 					routes: manifest_data.routes.map((route) => ({ id: route.id }))
 				});
 
 				// Now that the client build is done, replace the `build` sentinel
 				// in the SSR output with the real build files
-				replace_manifest_placeholder_strings(`${out}/server`, {
-					immutable: Array.from(immutable).map((file) => ({ path: file }))
-				});
+				replace_manifest_placeholder_strings(`${out}/server`, { immutable });
 
 				/**
 				 * @param {string} entry
@@ -2066,23 +2062,42 @@ function find_overridden_config(config, resolved_config, enforced_config, path, 
 }
 
 /**
- * Collects the content-hashed files of a Vite manifest for the `immutable`
- * export of `$app/manifest`.
+ * Collects the content-hashed files of a Vite manifest, in the shape of
+ * `$app/manifest`'s `immutable` export.
  *
  * @param {Manifest} manifest
  * @param {string} app_dir
  * @param {string} client_out
- * @returns {Set<string>}
+ * @returns {Array<{ path: string }>}
  */
-const collect_immutable = (manifest, app_dir, client_out) =>
-	new Set(
-		Object.values(manifest)
-			.flatMap(({ file, css = [], assets = [] }) => [file, ...css, ...assets])
-			// inlined files are deleted from the output (`bundleStrategy: 'inline'`)
-			.filter(
-				(file) => file.startsWith(`${app_dir}/immutable`) && fs.existsSync(`${client_out}/${file}`)
-			)
-	);
+const collect_immutable = (manifest, app_dir, client_out) => {
+	const prefix = `${app_dir}/immutable`;
+
+	/** @type {Set<string>} */
+	const candidates = new Set();
+
+	/** @param {string} file */
+	const add = (file) => {
+		if (file.startsWith(prefix)) candidates.add(file);
+	};
+
+	for (const key in manifest) {
+		const { file, css, assets } = manifest[key];
+		add(file);
+		if (css) for (let i = 0; i < css.length; i++) add(css[i]);
+		if (assets) for (let i = 0; i < assets.length; i++) add(assets[i]);
+	}
+
+	/** @type {Array<{ path: string }>} */
+	const immutable = [];
+
+	for (const path of candidates) {
+		// inlined files are deleted from the output (`bundleStrategy: 'inline'`)
+		if (fs.existsSync(`${client_out}/${path}`)) immutable.push({ path });
+	}
+
+	return immutable;
+};
 
 /**
  * Creates the `$app/manifest` data module. During development, real values

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -2099,7 +2099,7 @@ const collect_immutable = (manifest, app_dir, inlined) => {
 
 	return Array.from(files, (path) => ({ path }));
 };
-  
+
 /**
  * Normalizes a config value for comparison, since Windows paths may use backslashes
  * and differ in casing (e.g. the drive letter) depending on where they came from.

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -775,6 +775,14 @@ test.describe('$app/manifest', () => {
 		expect(paths.every((/** @type {string} */ f) => f.includes('_app/immutable/'))).toBe(true);
 	});
 
+	test('only exposes immutable chunks to the service worker', async ({ request }) => {
+		test.skip(!!process.env.DEV, 'only known after build');
+		const body = await (await request.get('/service-worker.js')).text();
+		expect(body).toContain('_app/immutable/');
+		// the manifest chunk has a fixed filename and must not be cached as if it were immutable
+		expect(body).not.toContain('_app/manifest.js');
+	});
+
 	test('exposes prerendered paths', async ({ page }) => {
 		test.skip(!!process.env.DEV, 'prerendered paths are only known after build');
 		await page.goto('/app-manifest');

--- a/packages/kit/test/apps/options-3/src/routes/app-manifest/+page.svelte
+++ b/packages/kit/test/apps/options-3/src/routes/app-manifest/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+	import { immutable } from '$app/manifest';
+</script>
+
+<pre>{JSON.stringify(immutable)}</pre>

--- a/packages/kit/test/apps/options-3/test/test.js
+++ b/packages/kit/test/apps/options-3/test/test.js
@@ -29,6 +29,11 @@ test.describe("bundleStrategy: 'inline'", () => {
 		expect(content).not.toMatch(/immutable\/(?:bundle|assets\/style)/);
 	});
 
+	test('omits inlined files from the page manifest', async ({ page }) => {
+		await page.goto('/app-manifest');
+		expect(await page.textContent('pre')).not.toMatch(/immutable\/(?:bundle|assets\/style)/);
+	});
+
 	test('still emits version.json', () => {
 		expect(fs.existsSync(`${client}/_app/version.json`)).toBe(true);
 	});


### PR DESCRIPTION
#16372 added the `_app/immutable` filter when computing `$app/manifest`'s `immutable`, but the serviceWorker environment kept the unfiltered file set it inherited from `$service-worker`'s `build`. That copy includes `_app/manifest.js`, whose filename never changes, so a service worker that caches `immutable` per the docs serves the previous deployment's manifest after a redeploy. Both lists are now computed by one helper; the `bundleStrategy: 'inline'` special case is subsumed by its existence check.

The truthiness checks on `css`/`assets` make the helper robust to the full range of Vite's optional `css?: string[]` field, so a hypothetical `css: null` entry is skipped cleanly instead of crashing the build.

The client-side list was also computed before the `bundleStrategy: 'inline'` deletions it was supposed to reflect, so the page's `immutable` included the deleted bundle and stylesheet while the service worker's, computed after them, did not. The inlined files are now tracked directly and excluded everywhere, instead of checking the filesystem after the fact.

`_app/manifest.js` is no longer precached, so an offline-first app that imports `$app/manifest` in client code only has it cached once a page has fetched it. The precached copy was guaranteed stale after the next deploy anyway; moving the chunk to `assets`, as floated in #16372, would give such apps a correct offline copy.
