### PR TITLE
fix: don't duplicate remote modules in the generated manifest

### DIFF
--- a/.changeset/fresh-dodos-share.md
+++ b/.changeset/fresh-dodos-share.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: don't duplicate remote modules in the generated manifest

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -893,9 +893,9 @@ function kit({ svelte_config }) {
 					file
 				};
 
-				if (!remotes.some((existing) => existing.hash === remote.hash)) remotes.push(remote);
-
 				if (this.environment.config.consumer !== 'client') {
+					remotes.push(remote);
+
 					// we need to add an `await Promise.resolve()` because if the user imports this function
 					// on the client AND in a load function when loading the client module we will trigger
 					// an import during dev. During a link preload, the module can be mistakenly

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -893,7 +893,7 @@ function kit({ svelte_config }) {
 					file
 				};
 
-				remotes.push(remote);
+				if (!remotes.some((existing) => existing.hash === remote.hash)) remotes.push(remote);
 
 				if (this.environment.config.consumer !== 'client') {
 					// we need to add an `await Promise.resolve()` because if the user imports this function

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -893,9 +893,9 @@ function kit({ svelte_config }) {
 					file
 				};
 
-				if (this.environment.config.consumer !== 'client') {
-					remotes.push(remote);
+				if (this.environment.name === 'ssr') remotes.push(remote);
 
+				if (this.environment.config.consumer !== 'client') {
 					// we need to add an `await Promise.resolve()` because if the user imports this function
 					// on the client AND in a load function when loading the client module we will trigger
 					// an import during dev. During a link preload, the module can be mistakenly

--- a/packages/kit/test/apps/async/test/server.test.js
+++ b/packages/kit/test/apps/async/test/server.test.js
@@ -23,6 +23,21 @@ test.describe('remote functions', () => {
 		expect(code.includes('const with_read = prerender(')).toBe(false);
 	});
 
+	test("doesn't duplicate remote modules in the generated manifest", () => {
+		test.skip(!!process.env.DEV, 'only applicable after build');
+		const code = fs.readFileSync(
+			path.join(root, '.svelte-kit', 'output', 'server', 'manifest.js'),
+			'utf8'
+		);
+		const remotes = code.match(/remotes: \{([\s\S]*?)\n\t\t\},/)?.[1] ?? '';
+		const hashes = [
+			...remotes.matchAll(/'([a-z0-9]+)': __memo\(\(\) => import\('\.\/chunks\/remote-/g)
+		].map((match) => match[1]);
+
+		expect(hashes.length).toBeGreaterThan(0);
+		expect(new Set(hashes).size).toBe(hashes.length);
+	});
+
 	test("form doesn't refresh queries when not a remote request", async ({ page }) => {
 		await page.goto(`/remote/form/noop-refresh-non-enhanced/${Date.now()}${Math.random()}`);
 

--- a/packages/kit/test/apps/async/test/server.test.js
+++ b/packages/kit/test/apps/async/test/server.test.js
@@ -29,9 +29,8 @@ test.describe('remote functions', () => {
 			path.join(root, '.svelte-kit', 'output', 'server', 'manifest.js'),
 			'utf8'
 		);
-		const remotes = code.match(/remotes: \{([\s\S]*?)\n\t\t\},/)?.[1] ?? '';
 		const hashes = [
-			...remotes.matchAll(/'([a-z0-9]+)': __memo\(\(\) => import\('\.\/chunks\/remote-/g)
+			...code.matchAll(/'([a-z0-9]+)': __memo\(\(\) => import\('\.\/chunks\/remote-/g)
 		].map((match) => match[1]);
 
 		expect(hashes.length).toBeGreaterThan(0);


### PR DESCRIPTION
closes #16530

v2 was unaffected because the secondary client build re-read the Vite config and created fresh plugin instances, so the extra client-side pushes landed in an array nobody read. #15532 made one instance serve both environments.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
