### PR TITLE
fix: treeshake prerendered remote functions in the right chunks

### DIFF
--- a/.changeset/tidy-remotes-shake.md
+++ b/.changeset/tidy-remotes-shake.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: treeshake prerendered remote functions in the right chunks

--- a/packages/kit/src/exports/vite/build/remote.js
+++ b/packages/kit/src/exports/vite/build/remote.js
@@ -11,6 +11,7 @@ import { posixify } from '../../../utils/os.js';
  * @param {typeof import('vite')} vite
  * @param {string} out
  * @param {Array<{ hash: string, file: string }>} remotes
+ * @param {Map<string, string>} remote_original_by_hash
  * @param {ServerMetadata} metadata
  * @param {string} cwd
  * @param {(Rolldown.OutputAsset | Rolldown.OutputChunk)[]} server_chunks
@@ -20,6 +21,7 @@ export async function treeshake_prerendered_remotes(
 	vite,
 	out,
 	remotes,
+	remote_original_by_hash,
 	metadata,
 	cwd,
 	server_chunks,
@@ -45,11 +47,11 @@ export async function treeshake_prerendered_remotes(
 
 		if (prerendered.length === 0) continue; // nothing to treeshake
 
-		// remove file extension
-		const remote_filename = path.basename(remote.file).split('.').slice(0, -1).join('.');
+		const original_id = remote_original_by_hash.get(remote.hash);
+		if (!original_id) continue;
 
 		const remote_chunk = server_chunks.find((chunk) => {
-			return chunk.name === remote_filename;
+			return chunk.type === 'chunk' && chunk.moduleIds.includes(original_id);
 		});
 
 		if (!remote_chunk) continue;
@@ -116,13 +118,14 @@ export async function treeshake_prerendered_remotes(
 			})
 		);
 
-		for (const output of bundle.output) {
-			if (output.type !== 'chunk' || output.name !== 'treeshaken') return;
-
-			fs.writeFileSync(chunk_path, output.code);
+		const chunk = bundle.output.find(
+			(output) => output.type === 'chunk' && output.name === 'treeshaken'
+		);
+		if (chunk && chunk.type === 'chunk') {
+			fs.writeFileSync(chunk_path, chunk.code);
 
 			const chunk_sourcemap = bundle.output.find(
-				(o) => o.type === 'asset' && o.fileName === output.fileName + '.map'
+				(output) => output.type === 'asset' && output.fileName === chunk.fileName + '.map'
 			);
 			if (chunk_sourcemap && chunk_sourcemap.type === 'asset') {
 				fs.writeFileSync(chunk_path + '.map', chunk_sourcemap.source);

--- a/packages/kit/src/exports/vite/build/remote.js
+++ b/packages/kit/src/exports/vite/build/remote.js
@@ -118,12 +118,11 @@ export async function treeshake_prerendered_remotes(
 			})
 		);
 
-		// the build has a single entry and externalized imports, so its output
-		// is the treeshaken chunk plus, when sourcemaps are enabled, its map
+		// the only possible outputs are the treeshaken chunk and, with sourcemaps, its map
 		for (const output of bundle.output) {
-			if (output.type === 'chunk' && output.name === 'treeshaken') {
+			if (output.type === 'chunk') {
 				fs.writeFileSync(chunk_path, output.code);
-			} else if (output.type === 'asset' && output.fileName.endsWith('.map')) {
+			} else {
 				fs.writeFileSync(chunk_path + '.map', output.source);
 			}
 		}

--- a/packages/kit/src/exports/vite/build/remote.js
+++ b/packages/kit/src/exports/vite/build/remote.js
@@ -118,17 +118,13 @@ export async function treeshake_prerendered_remotes(
 			})
 		);
 
-		const chunk = bundle.output.find(
-			(output) => output.type === 'chunk' && output.name === 'treeshaken'
-		);
-		if (chunk && chunk.type === 'chunk') {
-			fs.writeFileSync(chunk_path, chunk.code);
-
-			const chunk_sourcemap = bundle.output.find(
-				(output) => output.type === 'asset' && output.fileName === chunk.fileName + '.map'
-			);
-			if (chunk_sourcemap && chunk_sourcemap.type === 'asset') {
-				fs.writeFileSync(chunk_path + '.map', chunk_sourcemap.source);
+		// the build has a single entry and externalized imports, so its output
+		// is the treeshaken chunk plus, when sourcemaps are enabled, its map
+		for (const output of bundle.output) {
+			if (output.type === 'chunk' && output.name === 'treeshaken') {
+				fs.writeFileSync(chunk_path, output.code);
+			} else if (output.type === 'asset' && output.fileName.endsWith('.map')) {
+				fs.writeFileSync(chunk_path + '.map', output.source);
 			}
 		}
 	}

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -1943,6 +1943,7 @@ function kit({ svelte_config }) {
 				vite,
 				out,
 				remotes,
+				remote_original_by_hash,
 				metadata,
 				process.cwd(),
 				server_chunks,

--- a/packages/kit/test/apps/async/test/server.test.js
+++ b/packages/kit/test/apps/async/test/server.test.js
@@ -25,17 +25,27 @@ test.describe('remote functions', () => {
 
 	test('non-dynamic prerendered remote functions with colliding basenames are treeshaken', () => {
 		test.skip(!!process.env.DEV, 'only applicable after build');
+
 		const chunks = path.join(root, '.svelte-kit', 'output', 'server', 'chunks');
+
 		const code = fs
-			.readdirSync(chunks)
-			.filter((file) => file.endsWith('.js'))
-			.map((file) => fs.readFileSync(path.join(chunks, file), 'utf8'))
+			.globSync(`${chunks}/*.js`)
+			.map((file) => fs.readFileSync(file, 'utf-8'))
+			.join('\n');
+
+		const maps = fs
+			.globSync(`${chunks}/*.js.map`)
+			.map((file) => fs.readFileSync(file, 'utf-8'))
 			.join('\n');
 
 		expect(code).not.toContain('++invocations');
-		expect(code).not.toContain('() => "hello"');
-  });
-  
+		expect(code).not.toContain("() => 'hello'");
+
+		// check that we didn't accidentally delete the code we're treeshaking
+		expect(maps).toContain('++invocations');
+		expect(maps).toContain("() => 'hello'");
+	});
+
 	test("doesn't duplicate remote modules in the generated manifest", () => {
 		test.skip(!!process.env.DEV, 'only applicable after build');
 		const code = fs.readFileSync(

--- a/packages/kit/test/apps/async/test/server.test.js
+++ b/packages/kit/test/apps/async/test/server.test.js
@@ -23,6 +23,19 @@ test.describe('remote functions', () => {
 		expect(code.includes('const with_read = prerender(')).toBe(false);
 	});
 
+	test('non-dynamic prerendered remote functions with colliding basenames are treeshaken', () => {
+		test.skip(!!process.env.DEV, 'only applicable after build');
+		const chunks = path.join(root, '.svelte-kit', 'output', 'server', 'chunks');
+		const code = fs
+			.readdirSync(chunks)
+			.filter((file) => file.endsWith('.js'))
+			.map((file) => fs.readFileSync(path.join(chunks, file), 'utf8'))
+			.join('\n');
+
+		expect(code).not.toContain('++invocations');
+		expect(code).not.toContain('() => "hello"');
+	});
+
 	test("form doesn't refresh queries when not a remote request", async ({ page }) => {
 		await page.goto(`/remote/form/noop-refresh-non-enhanced/${Date.now()}${Math.random()}`);
 


### PR DESCRIPTION
Two bugs in `treeshake_prerendered_remotes`.

Rolldown keeps `chunk.name` as the source basename even when it deduplicates output `fileName`s, so with several `data.remote.js` files in an app they all match the first `data.remote` chunk (since #15447): that chunk gets stubbed repeatedly while the real ones ship their prerender bodies live. The async app already has this collision, which the new test uses.

The `return` in the rebuild loop (ba614e64f) fires when `build.sourcemap` is set, because the output then also contains the map asset, and every chunk after the first is left stubbed but not re-treeshaken. No test for this half since it needs a user-set `build.sourcemap`; verified by instrumenting a `--sourcemap` build before and after.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
