### PR TITLE
fix: allow generation of $app/tsconfig without TypeScript installed

### DIFF
--- a/.changeset/sparkly-kids-shine.md
+++ b/.changeset/sparkly-kids-shine.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: allow generation of $app/tsconfig without TypeScript installed

--- a/packages/kit/src/core/sync/write_tsconfig/index.js
+++ b/packages/kit/src/core/sync/write_tsconfig/index.js
@@ -2,7 +2,6 @@
 import process from 'node:process';
 import fs from 'node:fs';
 import path from 'node:path';
-import ts from 'typescript';
 import { styleText } from 'node:util';
 import { write_if_changed } from '../utils.js';
 import {
@@ -14,6 +13,14 @@ import {
 	remove_trailing_slashstar,
 	validate_resolved_config
 } from './utils.js';
+
+/** @type {import('typescript')} */
+let ts;
+try {
+	ts = await import('typescript');
+} catch {
+	// The user has not installed TypeScript.
+}
 
 /**
  * Generates the tsconfig that the user's tsconfig inherits from.
@@ -84,6 +91,11 @@ function write_parent_tsconfig(root, dir, id, config, example, transform) {
 	normalized = transform?.(normalized) ?? normalized;
 
 	write_if_changed(out_file, JSON.stringify(normalized, null, '\t'));
+
+	if (!ts) {
+		// The user has not installed TypeScript. Skip validation of config.
+		return;
+	}
 
 	const user_config = load_user_tsconfig(dir);
 


### PR DESCRIPTION
This makes the write_tsconfig script no longer have a hard requirement on TypeScript, which it shouldn't have, because `typescript` is an optional peer dependency. When TS cannot be loaded, the script simply skips validating the user's config.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
