### PR TITLE
breaking: deprecate `error(status, {...})` in favour of `error(status, message, {...})`

### DIFF
--- a/.changeset/sixty-words-strive.md
+++ b/.changeset/sixty-words-strive.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': major
+---
+
+breaking: deprecate `error(status, {...})` in favour of `error(status, message, {...})`

--- a/packages/kit/src/exports/index.js
+++ b/packages/kit/src/exports/index.js
@@ -76,6 +76,12 @@ export function error(status, body, properties) {
 		throw new Error(`HTTP error status codes must be between 400 and 599 — ${status} is invalid`);
 	}
 
+	if (DEV && body !== undefined && typeof body !== 'string') {
+		console.warn(
+			'Passing an `App.Error` body as the second argument is deprecated — pass the `message` as the second argument, and any additional properties as the third'
+		);
+	}
+
 	throw new HttpError(status, body, properties);
 }
 

--- a/packages/kit/src/exports/index.js
+++ b/packages/kit/src/exports/index.js
@@ -26,41 +26,35 @@ export { defineParams } from './params.js';
  * When called during request handling, this will cause SvelteKit to
  * return an error response without invoking `handleError`.
  * Make sure you're not catching the thrown error, which would prevent SvelteKit from handling it.
+ * @overload
+ * @param {number} status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). Must be in the range 400-599.
+ * @param {string} [message] The error message.
+ * @return {never}
+ * @throws {import('./public.js').HttpError} This error instructs SvelteKit to initiate HTTP error handling.
+ * @throws {Error} If the provided status is invalid (not between 400 and 599).
+ */
+/**
+ * Throws an error with a HTTP status code and an optional message.
+ * When called during request handling, this will cause SvelteKit to
+ * return an error response without invoking `handleError`.
+ * Make sure you're not catching the thrown error, which would prevent SvelteKit from handling it.
+ * @overload
+ * @param {number} status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). Must be in the range 400-599.
+ * @param {string} message The error message.
+ * @param {{ status: number; message: string } extends App.Error ? never : Omit<App.Error, 'status' | 'message'>} properties Additional properties of the App.Error type.
+ * @return {never}
+ * @throws {import('./public.js').HttpError} This error instructs SvelteKit to initiate HTTP error handling.
+ * @throws {Error} If the provided status is invalid (not between 400 and 599).
+ */
+/**
+ * Throws an error with a HTTP status code and an optional message.
+ * When called during request handling, this will cause SvelteKit to
+ * return an error response without invoking `handleError`.
+ * Make sure you're not catching the thrown error, which would prevent SvelteKit from handling it.
+ * @deprecated Passing an `App.Error` body as the second argument is deprecated — pass the `message` as the second argument, and any additional properties as the third
+ * @overload
  * @param {number} status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). Must be in the range 400-599.
  * @param {Omit<App.Error, 'status'> & { status?: App.Error['status'] }} body An object that conforms to the App.Error type. If a string is passed, it will be used as the message property.
- * @overload
- * @param {number} status
- * @param {Omit<App.Error, 'status'> & { status?: App.Error['status'] }} body
- * @return {never}
- * @throws {import('./public.js').HttpError} This error instructs SvelteKit to initiate HTTP error handling.
- * @throws {Error} If the provided status is invalid (not between 400 and 599).
- */
-/**
- * Throws an error with a HTTP status code and an optional message.
- * When called during request handling, this will cause SvelteKit to
- * return an error response without invoking `handleError`.
- * Make sure you're not catching the thrown error, which would prevent SvelteKit from handling it.
- * @param {number} status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). Must be in the range 400-599.
- * @param {{ status: number; message: string } extends App.Error ? string | void | undefined : never} body The error message.
- * @overload
- * @param {number} status
- * @param {{ status: number; message: string } extends App.Error ? string | void | undefined : never} body
- * @return {never}
- * @throws {import('./public.js').HttpError} This error instructs SvelteKit to initiate HTTP error handling.
- * @throws {Error} If the provided status is invalid (not between 400 and 599).
- */
-/**
- * Throws an error with a HTTP status code and an optional message.
- * When called during request handling, this will cause SvelteKit to
- * return an error response without invoking `handleError`.
- * Make sure you're not catching the thrown error, which would prevent SvelteKit from handling it.
- * @param {number} status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). Must be in the range 400-599.
- * @param {string} body The error message.
- * @param {{ status: number; message: string } extends App.Error ? never : Omit<App.Error, 'status' | 'message'>} properties Additional properties of the App.Error type.
- * @overload
- * @param {number} status
- * @param {string} body
- * @param {{ status: number; message: string } extends App.Error ? never : Omit<App.Error, 'status' | 'message'>} properties
  * @return {never}
  * @throws {import('./public.js').HttpError} This error instructs SvelteKit to initiate HTTP error handling.
  * @throws {Error} If the provided status is invalid (not between 400 and 599).

--- a/packages/kit/src/exports/index.js
+++ b/packages/kit/src/exports/index.js
@@ -90,7 +90,7 @@ export function error(status, message, properties) {
 			);
 		}
 
-		({ message, properties } = message);
+		({ message, ...properties } = message);
 	}
 
 	throw new HttpError({ ...properties, status, message: message ?? `Error: ${status}` });

--- a/packages/kit/src/exports/index.js
+++ b/packages/kit/src/exports/index.js
@@ -26,9 +26,11 @@ export { defineParams } from './params.js';
  * When called during request handling, this will cause SvelteKit to
  * return an error response without invoking `handleError`.
  * Make sure you're not catching the thrown error, which would prevent SvelteKit from handling it.
- * @overload
  * @param {number} status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). Must be in the range 400-599.
  * @param {string} [message] The error message.
+ * @overload
+ * @param {number} status
+ * @param {string} [message]
  * @return {never}
  * @throws {import('./public.js').HttpError} This error instructs SvelteKit to initiate HTTP error handling.
  * @throws {Error} If the provided status is invalid (not between 400 and 599).
@@ -38,10 +40,13 @@ export { defineParams } from './params.js';
  * When called during request handling, this will cause SvelteKit to
  * return an error response without invoking `handleError`.
  * Make sure you're not catching the thrown error, which would prevent SvelteKit from handling it.
- * @overload
  * @param {number} status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). Must be in the range 400-599.
  * @param {string} message The error message.
  * @param {{ status: number; message: string } extends App.Error ? never : Omit<App.Error, 'status' | 'message'>} properties Additional properties of the App.Error type.
+ * @overload
+ * @param {number} status
+ * @param {string} message
+ * @param {{ status: number; message: string } extends App.Error ? never : Omit<App.Error, 'status' | 'message'>} properties
  * @return {never}
  * @throws {import('./public.js').HttpError} This error instructs SvelteKit to initiate HTTP error handling.
  * @throws {Error} If the provided status is invalid (not between 400 and 599).
@@ -52,9 +57,11 @@ export { defineParams } from './params.js';
  * return an error response without invoking `handleError`.
  * Make sure you're not catching the thrown error, which would prevent SvelteKit from handling it.
  * @deprecated Passing an `App.Error` body as the second argument is deprecated — pass the `message` as the second argument, and any additional properties as the third
- * @overload
  * @param {number} status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). Must be in the range 400-599.
  * @param {Omit<App.Error, 'status'> & { status?: App.Error['status'] }} body An object that conforms to the App.Error type. If a string is passed, it will be used as the message property.
+ * @overload
+ * @param {number} status
+ * @param {Omit<App.Error, 'status'> & { status?: App.Error['status'] }} properties
  * @return {never}
  * @throws {import('./public.js').HttpError} This error instructs SvelteKit to initiate HTTP error handling.
  * @throws {Error} If the provided status is invalid (not between 400 and 599).
@@ -65,24 +72,28 @@ export { defineParams } from './params.js';
  * return an error response without invoking `handleError`.
  * Make sure you're not catching the thrown error, which would prevent SvelteKit from handling it.
  * @param {any} status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). Must be in the range 400-599.
- * @param {any} [body] An object that conforms to the App.Error type. If a string is passed, it will be used as the message property.
+ * @param {any} [message] A string, or (deprecated) a partial App.Error object
  * @param {any} [properties] Additional properties of the App.Error type when passing a string message.
  * @return {never}
  * @throws {import('./public.js').HttpError} This error instructs SvelteKit to initiate HTTP error handling.
  * @throws {Error} If the provided status is invalid (not between 400 and 599).
  */
-export function error(status, body, properties) {
+export function error(status, message, properties) {
 	if ((!BROWSER || DEV) && (isNaN(status) || status < 400 || status > 599)) {
 		throw new Error(`HTTP error status codes must be between 400 and 599 — ${status} is invalid`);
 	}
 
-	if (DEV && body !== undefined && typeof body !== 'string') {
-		console.warn(
-			'Passing an `App.Error` body as the second argument is deprecated — pass the `message` as the second argument, and any additional properties as the third'
-		);
+	if (message !== undefined && typeof message !== 'string') {
+		if (DEV) {
+			console.warn(
+				'Passing an `App.Error` body as the second argument is deprecated — pass the `message` as the second argument, and any additional properties as the third'
+			);
+		}
+
+		({ message, properties } = message);
 	}
 
-	throw new HttpError(status, body, properties);
+	throw new HttpError(status, message, properties);
 }
 
 /**

--- a/packages/kit/src/exports/index.js
+++ b/packages/kit/src/exports/index.js
@@ -29,8 +29,8 @@ export { defineParams } from './params.js';
  * @param {number} status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). Must be in the range 400-599.
  * @param {string} [message] The error message.
  * @overload
- * @param {number} status
- * @param {string} [message]
+ * @param {{ status: number; message: string } extends App.Error ? number : never} status
+ * @param {{ status: number; message: string } extends App.Error ? string : never} [message]
  * @return {never}
  * @throws {import('./public.js').HttpError} This error instructs SvelteKit to initiate HTTP error handling.
  * @throws {Error} If the provided status is invalid (not between 400 and 599).
@@ -93,7 +93,7 @@ export function error(status, message, properties) {
 		({ message, properties } = message);
 	}
 
-	throw new HttpError(status, message, properties);
+	throw new HttpError({ ...properties, status, message: message ?? `Error: ${status}` });
 }
 
 /**

--- a/packages/kit/src/exports/internal/shared.js
+++ b/packages/kit/src/exports/internal/shared.js
@@ -2,19 +2,11 @@
 
 export class HttpError {
 	/**
-	 * @param {number} status
-	 * @param {Omit<App.Error, 'status'> | string | undefined} body
-	 * @param {Omit<App.Error, 'status' | 'message'>} [properties]
+	 * @param {App.Error} error
 	 */
-	constructor(status, body, properties) {
-		this.status = status;
-		if (typeof body === 'string') {
-			this.body = { ...properties, message: body, status };
-		} else if (body) {
-			this.body = { ...body, status };
-		} else {
-			this.body = { message: `Error: ${status}`, status };
-		}
+	constructor(error) {
+		this.status = error.status;
+		this.body = error;
 	}
 
 	toString() {

--- a/packages/kit/src/runtime/app/server/remote/requested.js
+++ b/packages/kit/src/runtime/app/server/remote/requested.js
@@ -152,10 +152,10 @@ export function requested(query, limit) {
 	for (const payload of skipped) {
 		record_failure(
 			payload,
-			new HttpError(
-				400,
-				`Requested refresh was rejected because it exceeded requested(${__.name}, ${limit}) limit`
-			)
+			new HttpError({
+				status: 400,
+				message: `Requested refresh was rejected because it exceeded requested(${__.name}, ${limit}) limit`
+			})
 		);
 	}
 

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -3487,19 +3487,19 @@ async function load_data(url, invalid) {
 	notify_version(res.headers.get('x-sveltekit-version'));
 
 	if (!res.ok) {
-		// error message is a JSON-stringified string which devalue can't handle at the top level
 		// turn it into a HttpError to not call handleError on the client again (was already handled on the server)
 		// if `__data.json` doesn't exist or the server has an internal error,
 		// avoid parsing the HTML error page as a JSON
-		let message = 'Internal Error';
+		/** @type {App.Error} */
+		let error = { status: res.status, message: 'Internal Error' };
 
 		if (res.headers.get('content-type')?.includes('application/json')) {
-			message = await res.json();
+			error = { status: res.status, ...(await res.json()) };
 		} else if (res.status === 404) {
-			message = 'Not Found';
+			error.message = 'Not Found';
 		}
 
-		throw new HttpError({ status: res.status, message });
+		throw new HttpError(error);
 	}
 
 	return new Promise((resolve, reject) => {

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1401,7 +1401,7 @@ async function load_route({ id, invalidating, url, params, route, preload }) {
 
 		if (server_data_node?.type === 'error') {
 			// rethrow and catch below
-			throw new HttpError(server_data_node.error.status, server_data_node.error);
+			throw new HttpError(server_data_node.error);
 		}
 
 		return load_node({
@@ -3491,16 +3491,15 @@ async function load_data(url, invalid) {
 		// turn it into a HttpError to not call handleError on the client again (was already handled on the server)
 		// if `__data.json` doesn't exist or the server has an internal error,
 		// avoid parsing the HTML error page as a JSON
-		/** @type {string | undefined} */
-		let message;
+		let message = 'Internal Error';
+
 		if (res.headers.get('content-type')?.includes('application/json')) {
 			message = await res.json();
 		} else if (res.status === 404) {
 			message = 'Not Found';
-		} else if (res.status === 500) {
-			message = 'Internal Error';
 		}
-		throw new HttpError(res.status, message);
+
+		throw new HttpError({ status: res.status, message });
 	}
 
 	return new Promise((resolve, reject) => {

--- a/packages/kit/src/runtime/client/remote-functions/instance.unhandled.svelte.spec.js
+++ b/packages/kit/src/runtime/client/remote-functions/instance.unhandled.svelte.spec.js
@@ -69,7 +69,7 @@ describe('reactive consumption never produces unhandled rejections', () => {
 		const tracker = track_unhandled();
 		try {
 			const instance = new LiveQuery('id', 'id/payload', 'payload');
-			instance.fail(new HttpError(500, 'nope'));
+			instance.fail(new HttpError({ status: 500, message: 'nope' }));
 			await flush();
 			expect(instance.error).toEqual({ message: 'nope', status: 500 });
 			expect(tracker.unhandled).toEqual([]);

--- a/packages/kit/src/runtime/client/remote-functions/prerender.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/prerender.svelte.js
@@ -172,7 +172,7 @@ class Prerender {
 				});
 				this.#loading = false;
 				this.#error = error;
-				throw new HttpError(error.status, error); // so that transformError doesn't transform it again
+				throw new HttpError(error); // so that transformError doesn't transform it again
 			}
 		);
 

--- a/packages/kit/src/runtime/client/remote-functions/query-batch.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query-batch.svelte.js
@@ -71,7 +71,7 @@ export function query_batch(id) {
 
 							for (const { resolve, reject } of resolvers) {
 								if (result.type === 'error') {
-									reject(new HttpError(result.error.status, result.error));
+									reject(new HttpError(result.error));
 								} else {
 									resolve(result.data);
 								}

--- a/packages/kit/src/runtime/client/remote-functions/query-live/instance.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query-live/instance.svelte.js
@@ -91,7 +91,7 @@ export class LiveQuery {
 				// the query failed during SSR — seed the failed state (mirroring `fail()`,
 				// minus its terminal `#done`), so the main loop still connects as usual
 				// and the query can recover
-				const error = new HttpError(node.e.status, node.e);
+				const error = new HttpError(node.e);
 				this.#loading = false;
 				this.#error = error.body;
 
@@ -417,7 +417,7 @@ export class LiveQuery {
 			route: { id: null },
 			url: new URL(location.href)
 		});
-		this.fail(new HttpError(error.status, error));
+		this.fail(new HttpError(error));
 	}
 
 	get [Symbol.toStringTag]() {

--- a/packages/kit/src/runtime/client/remote-functions/query-live/iterator.js
+++ b/packages/kit/src/runtime/client/remote-functions/query-live/iterator.js
@@ -37,14 +37,14 @@ export async function* create_live_iterator(
 			error: response.statusText
 		}));
 
-		throw new HttpError(result.status ?? response.status ?? 500, result.error);
+		throw new HttpError(result.error);
 	}
 
 	if (response.headers.get('content-type')?.includes('application/json')) {
 		// we can end up here if we e.g. redirect in `handle`
 		const result = await response.json();
 		await handle_side_channel_response(result);
-		throw new HttpError(500, 'Invalid query.live response');
+		throw new HttpError({ status: 500, message: 'Invalid query.live response' });
 	}
 
 	if (!response.body) {
@@ -63,7 +63,7 @@ export async function* create_live_iterator(
 			}
 
 			await handle_side_channel_response(node);
-			throw new HttpError(500, 'Invalid query.live response');
+			throw new HttpError({ status: 500, message: 'Invalid query.live response' });
 		}
 	} finally {
 		try {

--- a/packages/kit/src/runtime/client/remote-functions/query/instance.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query/instance.svelte.js
@@ -70,7 +70,7 @@ export class Query {
 			delete query_responses[key];
 
 			if (node.e) {
-				this.fail(new HttpError(node.e.status, node.e));
+				this.fail(new HttpError(node.e));
 			} else {
 				this.set(/** @type {T} */ (node.v));
 			}
@@ -152,7 +152,7 @@ export class Query {
 					this.#loading = false;
 				});
 
-				reject(new HttpError(error.status, error)); // so that transformError doesn't transform it again
+				reject(new HttpError(error)); // so that transformError doesn't transform it again
 			});
 
 		return promise;

--- a/packages/kit/src/runtime/client/remote-functions/shared.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/shared.svelte.js
@@ -120,7 +120,10 @@ export async function remote_request(url, init) {
 		const result = await response.json().catch(() => ({
 			type: 'error',
 			status: response.status,
-			error: response.statusText
+			error: {
+				status: response.status,
+				message: response.statusText
+			}
 		}));
 
 		throw new HttpError(result.error);

--- a/packages/kit/src/runtime/client/remote-functions/shared.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/shared.svelte.js
@@ -86,7 +86,7 @@ export function pin_while_resolving(cache_map, cache, id, payload, then) {
  */
 export function unwrap_node(node) {
 	if (node.e) {
-		throw new HttpError(node.e.status, node.e);
+		throw new HttpError(node.e);
 	}
 
 	return node.v;
@@ -123,16 +123,13 @@ export async function remote_request(url, init) {
 			error: response.statusText
 		}));
 
-		throw new HttpError(
-			result.error?.status ?? result.status ?? response.status ?? 500,
-			result.error
-		);
+		throw new HttpError(result.error);
 	}
 
 	const result = /** @type {RemoteFunctionResponse} */ (await response.json());
 
 	if (result.type === 'error') {
-		throw new HttpError(result.error.status, result.error);
+		throw new HttpError(result.error);
 	}
 
 	const data = /** @type {RemoteFunctionData} */ (
@@ -147,7 +144,7 @@ export async function remote_request(url, init) {
 	function refresh(key, entry, result) {
 		if (entry?.resource) {
 			if (result.e) {
-				entry.resource.fail(new HttpError(result.e.status, result.e));
+				entry.resource.fail(new HttpError(result.e));
 			} else {
 				entry.resource.set(result.v);
 			}
@@ -201,7 +198,7 @@ export async function handle_side_channel_response(response) {
 	}
 
 	if (response.type === 'error') {
-		throw new HttpError(response.error.status, response.error);
+		throw new HttpError(response.error);
 	}
 
 	return response;

--- a/packages/kit/src/runtime/client/remote-functions/shared.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/shared.svelte.js
@@ -112,6 +112,7 @@ export function get_remote_request_headers() {
  */
 export async function remote_request(url, init) {
 	const response = await fetch(url, init);
+	const status = response.status;
 
 	// detect new deployments from the response header
 	notify_version(response.headers.get('x-sveltekit-version'));
@@ -119,14 +120,14 @@ export async function remote_request(url, init) {
 	if (!response.ok) {
 		const result = await response.json().catch(() => ({
 			type: 'error',
-			status: response.status,
+			status,
 			error: {
-				status: response.status,
+				status,
 				message: response.statusText
 			}
 		}));
 
-		throw new HttpError(result.error);
+		throw new HttpError({ status, ...result.error });
 	}
 
 	const result = /** @type {RemoteFunctionResponse} */ (await response.json());

--- a/packages/kit/src/runtime/client/remote-functions/shared.transport.spec.js
+++ b/packages/kit/src/runtime/client/remote-functions/shared.transport.spec.js
@@ -51,7 +51,11 @@ describe('remote_request transport error handling', () => {
 				status: 401,
 				statusText: 'Unauthorized',
 				json: () =>
-					Promise.resolve({ type: 'error', status: 401, error: { message: 'unauthorized' } })
+					Promise.resolve({
+						type: 'error',
+						status: 401,
+						error: { status: 401, message: 'unauthorized' }
+					})
 			})
 		);
 

--- a/packages/kit/src/runtime/telemetry/record_span.enabled.spec.js
+++ b/packages/kit/src/runtime/telemetry/record_span.enabled.spec.js
@@ -71,7 +71,7 @@ describe('record_span', () => {
 	});
 
 	test('HttpError sets correct attributes and re-throw, does set status for >=500', async () => {
-		const error = new HttpError(500, 'Found but badly');
+		const error = new HttpError({ status: 500, message: 'Found but badly' });
 		const error_fn = vi.fn(() => Promise.reject(error));
 
 		await expect(
@@ -99,7 +99,7 @@ describe('record_span', () => {
 	});
 
 	test('HttpError sets correct attributes and re-throws, does not set status for <500', async () => {
-		const error = new HttpError(404, 'Not found');
+		const error = new HttpError({ status: 404, message: 'Not found' });
 		const error_fn = vi.fn(() => Promise.reject(error));
 
 		await expect(

--- a/packages/kit/src/utils/error.spec.js
+++ b/packages/kit/src/utils/error.spec.js
@@ -8,7 +8,7 @@ describe('get_status', () => {
 	});
 
 	it('falls back to HttpError status', () => {
-		const error = new HttpError(403, { message: 'forbidden' });
+		const error = new HttpError({ status: 403, message: 'forbidden' });
 		expect(get_status({ message: 'forbidden' }, error)).toBe(403);
 	});
 
@@ -22,7 +22,7 @@ describe('get_status', () => {
 	});
 
 	it('works with a single HttpError argument', () => {
-		const error = new HttpError(418, { message: 'teapot' });
+		const error = new HttpError({ status: 418, message: 'teapot' });
 		expect(get_status(error)).toBe(418);
 	});
 

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2766,6 +2766,8 @@ declare module '@sveltejs/kit' {
 	 * When called during request handling, this will cause SvelteKit to
 	 * return an error response without invoking `handleError`.
 	 * Make sure you're not catching the thrown error, which would prevent SvelteKit from handling it.
+	 * @param status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). Must be in the range 400-599.
+	 * @param message The error message.
 	 * @throws {import('./public.js').HttpError} This error instructs SvelteKit to initiate HTTP error handling.
 	 * @throws {Error} If the provided status is invalid (not between 400 and 599).
 	 */
@@ -2775,6 +2777,9 @@ declare module '@sveltejs/kit' {
 	 * When called during request handling, this will cause SvelteKit to
 	 * return an error response without invoking `handleError`.
 	 * Make sure you're not catching the thrown error, which would prevent SvelteKit from handling it.
+	 * @param status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). Must be in the range 400-599.
+	 * @param message The error message.
+	 * @param properties Additional properties of the App.Error type.
 	 * @throws {import('./public.js').HttpError} This error instructs SvelteKit to initiate HTTP error handling.
 	 * @throws {Error} If the provided status is invalid (not between 400 and 599).
 	 */
@@ -2788,10 +2793,12 @@ declare module '@sveltejs/kit' {
 	 * return an error response without invoking `handleError`.
 	 * Make sure you're not catching the thrown error, which would prevent SvelteKit from handling it.
 	 * @deprecated Passing an `App.Error` body as the second argument is deprecated — pass the `message` as the second argument, and any additional properties as the third
+	 * @param status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). Must be in the range 400-599.
+	 * @param body An object that conforms to the App.Error type. If a string is passed, it will be used as the message property.
 	 * @throws {import('./public.js').HttpError} This error instructs SvelteKit to initiate HTTP error handling.
 	 * @throws {Error} If the provided status is invalid (not between 400 and 599).
 	 */
-	export function error(status: number, body: Omit<App.Error, "status"> & {
+	export function error(status: number, properties: Omit<App.Error, "status"> & {
 		status?: App.Error["status"];
 	}): never;
 	/**

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2766,43 +2766,34 @@ declare module '@sveltejs/kit' {
 	 * When called during request handling, this will cause SvelteKit to
 	 * return an error response without invoking `handleError`.
 	 * Make sure you're not catching the thrown error, which would prevent SvelteKit from handling it.
-	 * @param status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). Must be in the range 400-599.
-	 * @param body An object that conforms to the App.Error type. If a string is passed, it will be used as the message property.
+	 * @throws {import('./public.js').HttpError} This error instructs SvelteKit to initiate HTTP error handling.
+	 * @throws {Error} If the provided status is invalid (not between 400 and 599).
+	 */
+	export function error(status: number, message?: string | undefined): never;
+	/**
+	 * Throws an error with a HTTP status code and an optional message.
+	 * When called during request handling, this will cause SvelteKit to
+	 * return an error response without invoking `handleError`.
+	 * Make sure you're not catching the thrown error, which would prevent SvelteKit from handling it.
+	 * @throws {import('./public.js').HttpError} This error instructs SvelteKit to initiate HTTP error handling.
+	 * @throws {Error} If the provided status is invalid (not between 400 and 599).
+	 */
+	export function error(status: number, message: string, properties: {
+		status: number;
+		message: string;
+	} extends App.Error ? never : Omit<App.Error, "status" | "message">): never;
+	/**
+	 * Throws an error with a HTTP status code and an optional message.
+	 * When called during request handling, this will cause SvelteKit to
+	 * return an error response without invoking `handleError`.
+	 * Make sure you're not catching the thrown error, which would prevent SvelteKit from handling it.
+	 * @deprecated Passing an `App.Error` body as the second argument is deprecated — pass the `message` as the second argument, and any additional properties as the third
 	 * @throws {import('./public.js').HttpError} This error instructs SvelteKit to initiate HTTP error handling.
 	 * @throws {Error} If the provided status is invalid (not between 400 and 599).
 	 */
 	export function error(status: number, body: Omit<App.Error, "status"> & {
 		status?: App.Error["status"];
 	}): never;
-	/**
-	 * Throws an error with a HTTP status code and an optional message.
-	 * When called during request handling, this will cause SvelteKit to
-	 * return an error response without invoking `handleError`.
-	 * Make sure you're not catching the thrown error, which would prevent SvelteKit from handling it.
-	 * @param status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). Must be in the range 400-599.
-	 * @param body The error message.
-	 * @throws {import('./public.js').HttpError} This error instructs SvelteKit to initiate HTTP error handling.
-	 * @throws {Error} If the provided status is invalid (not between 400 and 599).
-	 */
-	export function error(status: number, body: {
-		status: number;
-		message: string;
-	} extends App.Error ? string | void | undefined : never): never;
-	/**
-	 * Throws an error with a HTTP status code and an optional message.
-	 * When called during request handling, this will cause SvelteKit to
-	 * return an error response without invoking `handleError`.
-	 * Make sure you're not catching the thrown error, which would prevent SvelteKit from handling it.
-	 * @param status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). Must be in the range 400-599.
-	 * @param body The error message.
-	 * @param properties Additional properties of the App.Error type.
-	 * @throws {import('./public.js').HttpError} This error instructs SvelteKit to initiate HTTP error handling.
-	 * @throws {Error} If the provided status is invalid (not between 400 and 599).
-	 */
-	export function error(status: number, body: string, properties: {
-		status: number;
-		message: string;
-	} extends App.Error ? never : Omit<App.Error, "status" | "message">): never;
 	/**
 	 * Checks whether this is an error thrown by {@link error}.
 	 * @param status The status to filter for.

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2771,7 +2771,10 @@ declare module '@sveltejs/kit' {
 	 * @throws {import('./public.js').HttpError} This error instructs SvelteKit to initiate HTTP error handling.
 	 * @throws {Error} If the provided status is invalid (not between 400 and 599).
 	 */
-	export function error(status: number, message?: string | undefined): never;
+	export function error(status: {
+		status: number;
+		message: string;
+	} extends App.Error ? number : never, message?: string | undefined): never;
 	/**
 	 * Throws an error with a HTTP status code and an optional message.
 	 * When called during request handling, this will cause SvelteKit to


### PR DESCRIPTION
The TODO from https://github.com/sveltejs/kit/pull/16162#discussion_r3507910819 — `error(status, {...})` is now deprecated in favour of passing any additional properties as the third argument

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
