### PR TITLE
chore: replace @netlify/functions with @netlify/types for the Context type

### DIFF
--- a/.changeset/forty-owls-move.md
+++ b/.changeset/forty-owls-move.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/adapter-netlify": patch
+---
+
+chore: replace @netlify/functions with @netlify/types for the Context type

--- a/packages/adapter-netlify/ambient.d.ts
+++ b/packages/adapter-netlify/ambient.d.ts
@@ -1,7 +1,7 @@
 declare global {
 	namespace App {
 		export interface Platform {
-			context: import('@netlify/functions').Context;
+			context: import('@netlify/types').Context;
 		}
 	}
 }

--- a/packages/adapter-netlify/package.json
+++ b/packages/adapter-netlify/package.json
@@ -46,7 +46,7 @@
 	},
 	"dependencies": {
 		"@iarna/toml": "^2.2.5",
-		"@netlify/functions": "^5.3.0",
+		"@netlify/types": "^2.8.0",
 		"rolldown": "^1.2.0"
 	},
 	"devDependencies": {

--- a/packages/adapter-netlify/src/serverless.js
+++ b/packages/adapter-netlify/src/serverless.js
@@ -4,7 +4,7 @@ import process from 'node:process';
 
 /**
  * @param {import('@sveltejs/kit').SSRManifest} manifest
- * @returns {(request: Request, context: import('@netlify/functions').Context) => Promise<Response>}
+ * @returns {(request: Request, context: import('@netlify/types').Context) => Promise<Response>}
  */
 export function init(manifest) {
 	const server = new Server(manifest);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,9 +222,9 @@ importers:
       '@iarna/toml':
         specifier: ^2.2.5
         version: 2.2.5
-      '@netlify/functions':
-        specifier: ^5.3.0
-        version: 5.3.0
+      '@netlify/types':
+        specifier: ^2.8.0
+        version: 2.8.0
       rolldown:
         specifier: ^1.2.0
         version: 1.2.0
@@ -2330,10 +2330,6 @@ packages:
 
   '@netlify/edge-functions@3.0.8':
     resolution: {integrity: sha512-ml1oCDsRTTRmZS2nUj8XRD1b6+foEiZT3lPk7qQ4nv/jnxylHJ20ooPzPDH+cJmGjXFrMeR14/91W1o6D2ftBg==}
-    engines: {node: '>=18.0.0'}
-
-  '@netlify/functions@5.3.0':
-    resolution: {integrity: sha512-FP+xCoZMkMOUsKa4UdG/oiK/2md1/TxuXvqqieaMVMgDbFFMaHI8h0oHCViUY73kPbKV6HyzayaSXGYXKpBSoQ==}
     engines: {node: '>=18.0.0'}
 
   '@netlify/types@2.8.0':
@@ -4954,10 +4950,6 @@ snapshots:
     optional: true
 
   '@netlify/edge-functions@3.0.8':
-    dependencies:
-      '@netlify/types': 2.8.0
-
-  '@netlify/functions@5.3.0':
     dependencies:
       '@netlify/types': 2.8.0
 


### PR DESCRIPTION
## Summary

This PR replaces `@netlify/functions` with `@netlify/types` as a runtime dependency of `adapter-netlify`. The adapter only used `@netlify/functions` for its `Context` type — there are no runtime imports — so the full package (and its transitive dependencies) was being pulled in solely for a type that actually lives in `@netlify/types`.

## Why

- **`@netlify/types` is lighter than `@netlify/functions`** — the latter depends on the former, so referencing the types package directly avoids pulling in `@netlify/functions` for a single type.
- **It makes the shared origin of the `Context` type clearer** — Netlify Functions and Netlify Edge Functions share the same `Context` from `@netlify/types`. Referencing that package directly documents why the same type is used in both contexts, rather than obscuring it behind the higher-level `@netlify/functions` entry point.

## Changes

- ambient.d.ts: import `Context` from `@netlify/types` instead of `@netlify/functions`.
- serverless.js: update the JSDoc `@returns` type to reference `@netlify/types`.
- package.json: replace `@netlify/functions` with `@netlify/types` (`^2.8.0`) in `dependencies`.
- pnpm-lock.yaml: updated accordingly.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.