### PR TITLE
chore: use `hydrate(...)` instead of `new Root(...)`

### DIFF
--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -980,14 +980,19 @@ async function get_navigation_result_from_branch({
 		data = current_node.data;
 
 		if (i < branch.length - 1) {
-			const error_loader = errors?.slice(0, i + 2).findLast((x) => x) ?? default_error_loader;
+			const next = branch[i + 1];
 
-			current_node = current_node.child = new RenderNode(
-				branch[i + 1].node.component,
-				(await error_loader()).component
-			);
+			if (next) {
+				console.log(branch, i);
+				const error_loader = errors?.slice(0, i + 2).findLast((x) => x) ?? default_error_loader;
 
-			previous_node = previous_node?.child;
+				current_node = current_node.child = new RenderNode(
+					next.node.component,
+					(await error_loader()).component
+				);
+
+				previous_node = previous_node?.child;
+			}
 		}
 	}
 
@@ -3825,5 +3830,12 @@ function apply_navigation_result(result) {
 	update(result.props.page);
 	props.tree.data = result.props.tree.data;
 	props.tree.child = result.props.tree.child;
-	props.form = result.props.form;
+
+	if ('form' in result.props) {
+		props.form = result.props.form;
+	}
+
+	if ('error' in result.props) {
+		props.error = result.props.error;
+	}
 }

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1,11 +1,11 @@
 /** @import { RouteId } from '$app/types' */
 /** @import { RemoteFunctionDataNode, ServerNodesResponse, ServerRedirectNode } from 'types' */
-/** @import { NavigationIntent } from './types.js' */
+/** @import { NavigationFinished, NavigationIntent } from './types.js' */
 /** @import { CacheEntry } from './remote-functions/cache.svelte.js' */
 /** @import { Query } from './remote-functions/query/instance.svelte.js' */
 /** @import { LiveQuery } from './remote-functions/query-live/instance.svelte.js' */
 import { BROWSER, DEV } from 'esm-env';
-import { settled, tick, fork, onMount } from 'svelte';
+import { settled, tick, fork, onMount, hydrate, mount } from 'svelte';
 import { HttpError, Redirect, SvelteKitError } from '@sveltejs/kit/internal';
 import { decode_pathname, strip_hash, make_trackable, normalize_path } from '../../utils/url.js';
 import { dev_fetch, initial_fetch, lock_fetch, subsequent_fetch, unlock_fetch } from './fetcher.js';
@@ -44,11 +44,8 @@ import { payload } from './payload.js';
 import { add_data_suffix, add_resolution_suffix } from '../pathname.js';
 import { noop_span } from '../telemetry/noop.js';
 import { read_ndjson } from './ndjson.js';
-import RootModern from '../components/root.svelte';
-import { asClassComponent } from 'svelte/legacy';
+import Root from '../components/root.svelte';
 import { Props, RenderNode } from '../props.svelte.js';
-
-const Root = asClassComponent(RootModern);
 
 /**
  * @typedef {{
@@ -430,9 +427,9 @@ set_match_implementation(async (url) => {
 /**
  * @param {import('./types.js').SvelteKitApp} _app
  * @param {HTMLElement} _target
- * @param {Parameters<typeof _hydrate>[1]} [hydrate]
+ * @param {Parameters<typeof _hydrate>[1]} [data]
  */
-export async function start(_app, _target, hydrate) {
+export async function start(_app, _target, data) {
 	if (DEV && _target === document.body) {
 		console.warn(
 			'Placing %sveltekit.body% directly inside <body> is not recommended, as your app may break for users who have certain browser extensions installed.\n\nConsider wrapping it in an element:\n\n<div style="display: contents">\n  %sveltekit.body%\n</div>'
@@ -530,10 +527,10 @@ export async function start(_app, _target, hydrate) {
 		}
 	}
 
-	if (hydrate) {
+	if (data) {
 		restore_scroll();
 
-		await _hydrate(target, hydrate);
+		await _hydrate(target, data);
 	} else {
 		await navigate({
 			type: 'enter',
@@ -615,11 +612,12 @@ async function _invalidate(reset_page_state = true) {
 		navigation_result.props.page.state = prev_state;
 	}
 	navigation_result.props.page.shallow = prev_shallow;
-	update(navigation_result.props.page);
-	update_tree(props.tree, navigation_result.props.tree);
+	apply_navigation_result(navigation_result);
+	// update(navigation_result.props.page);
+	// update_tree(props.tree, navigation_result.props.tree);
 	current = { ...navigation_result.state, nav: current.nav };
 	reset_invalidation();
-	root.$set(navigation_result.props);
+	// root.$set(navigation_result.props);
 
 	// only wait for promises that are connected to queries that still exist
 	/** @type {Promise<any>[]} */
@@ -783,9 +781,10 @@ async function _preload_data(intent) {
 				if (lc === load_cache && result.type === 'loaded') {
 					try {
 						return fork(() => {
-							root.$set(result.props);
-							update(result.props.page);
-							update_tree(props.tree, result.props.tree);
+							apply_navigation_result(result);
+							// root.$set(result.props);
+							// update(result.props.page);
+							// update_tree(props.tree, result.props.tree);
 						});
 					} catch {
 						// if it errors, it's because the experimental flag isn't enabled in Svelte
@@ -819,9 +818,9 @@ async function _preload_code(url) {
 /**
  * @param {import('./types.js').NavigationFinished} result
  * @param {HTMLElement} target
- * @param {boolean} hydrate
+ * @param {boolean} should_hydrate
  */
-async function initialize(result, target, hydrate) {
+async function initialize(result, target, should_hydrate) {
 	if (__SVELTEKIT_DEV__ && result.state.error && document.querySelector('vite-error-overlay'))
 		return;
 
@@ -843,16 +842,14 @@ async function initialize(result, target, hydrate) {
 		if (style) style.remove();
 	}
 
-	update(/** @type {import('@sveltejs/kit').Page} */ (result.props.page));
-	update_tree(props.tree, result.props.tree);
+	apply_navigation_result(result);
 
-	// TODO: use mount()
-	root = new Root({
+	// TODO treeshake `hydrate` in csr mode
+	const render = should_hydrate ? hydrate : mount;
+
+	render(Root, {
 		target,
 		props,
-		hydrate,
-		// Svelte 5 specific: asynchronously instantiate the component, i.e. don't call flushSync
-		sync: false,
 		transformError: /** @param {unknown} e */ async (e) => {
 			const error = await handle_error(e, current.nav);
 			rendering_error = { error, status: error.status };
@@ -866,7 +863,7 @@ async function initialize(result, target, hydrate) {
 	// which causes component script blocks to run asynchronously
 	void (await Promise.resolve());
 
-	if (hydrate) {
+	if (should_hydrate) {
 		/** @type {import('@sveltejs/kit').AfterNavigate} */
 		const navigation = {
 			from: null,
@@ -2097,9 +2094,11 @@ async function navigate({
 			}
 			resetters.clear();
 		} else {
-			rendering_error = null; // TODO this can break with forks, rethink for SvelteKit 3 where we can assume Svelte 5
-			update_tree(props.tree, navigation_result.props.tree);
-			root.$set(navigation_result.props);
+			// rendering_error = null; // TODO this can break with forks, rethink for SvelteKit 3 where we can assume Svelte 5
+
+			apply_navigation_result(navigation_result);
+			// update_tree(props.tree, navigation_result.props.tree);
+			// root.$set(navigation_result.props);
 			// Reset any boundaries that failed on a previous navigation now that the
 			// new props are applied, otherwise the stale `+error.svelte` stays
 			// mounted above the new route's content. See sveltejs/kit#15694.
@@ -2108,9 +2107,9 @@ async function navigate({
 			}
 			resetters.clear();
 			// Check for sync rendering error
-			if (rendering_error) {
-				Object.assign(navigation_result.props.page, rendering_error);
-			}
+			// if (rendering_error) {
+			// 	Object.assign(navigation_result.props.page, rendering_error);
+			// }
 			update(navigation_result.props.page);
 
 			commit_promise = settled();
@@ -2921,15 +2920,17 @@ export async function applyAction(result) {
 		page.status = result.status;
 
 		/** @type {Record<string, any>} */
-		root.$set({
-			// this brings Svelte's view of the world in line with SvelteKit's
-			// after use:enhance reset the form....
-			form: null
-		});
+		// this brings Svelte's view of the world in line with SvelteKit's
+		// after use:enhance reset the form....
+		props.form = null;
+		// root.$set({
+		// 	form: null
+		// });
 
 		// ...so that setting the `form` prop takes effect and isn't ignored
 		await tick();
-		root.$set({ form: result.data });
+		props.form = result.data;
+		// root.$set({ form: result.data });
 
 		if (result.type === 'success') {
 			reset_focus(/** @type {URL} */ (page.url));
@@ -2959,9 +2960,10 @@ export async function set_nearest_error_page(error) {
 
 		current = { ...navigation_result.state, nav: current.nav };
 
-		root.$set(navigation_result.props);
-		update(navigation_result.props.page);
-		update_tree(props.tree, navigation_result.props.tree);
+		// root.$set(navigation_result.props);
+		// update(navigation_result.props.page);
+		// update_tree(props.tree, navigation_result.props.tree);
+		apply_navigation_result(navigation_result);
 
 		void tick().then(() => reset_focus(current.url));
 	}
@@ -3389,7 +3391,7 @@ async function _hydrate(
 
 	/** @type {import('./types.js').NavigationFinished | undefined} */
 	let result;
-	let hydrate = true;
+	let should_hydrate = true;
 
 	try {
 		const branch_promises = node_ids.map(async (n, i) => {
@@ -3455,7 +3457,7 @@ async function _hydrate(
 		});
 
 		target.textContent = '';
-		hydrate = false;
+		should_hydrate = false;
 	}
 
 	// Exit early when we encounter a redirect while loading the root error page.
@@ -3467,7 +3469,7 @@ async function _hydrate(
 		result.props.page.state = history_metadata?.persistState ? history_metadata.state : {};
 	}
 
-	await initialize(result, target, hydrate);
+	await initialize(result, target, should_hydrate);
 }
 
 /**
@@ -3816,6 +3818,12 @@ if (DEV) {
 	}
 }
 
-function update_tree(node, next) {
-	props.tree.child = next.child;
+/**
+ * @param {NavigationFinished} result
+ */
+function apply_navigation_result(result) {
+	update(result.props.page);
+	props.tree.data = result.props.tree.data;
+	props.tree.child = result.props.tree.child;
+	props.form = result.props.form;
 }

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -980,11 +980,16 @@ async function get_navigation_result_from_branch({
 		data = current_node.data;
 
 		if (i < branch.length - 1) {
-			const next = branch[i + 1];
+			let next_index = i + 1;
+			while (next_index < branch.length && !branch[next_index]) {
+				next_index += 1;
+			}
+
+			const next = branch[next_index];
 
 			if (next) {
-				console.log(branch, i);
-				const error_loader = errors?.slice(0, i + 2).findLast((x) => x) ?? default_error_loader;
+				const error_loader =
+					errors?.slice(0, next_index + 1).findLast((x) => x) ?? default_error_loader;
 
 				current_node = current_node.child = new RenderNode(
 					next.node.component,

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -276,14 +276,6 @@ export const prerender_responses = {};
 /** @type {Array<((url: URL) => boolean)>} */
 const invalidated = [];
 
-/**
- * An array of the `+layout.svelte` and `+page.svelte` component instances
- * that currently live on the page — used for capturing and restoring snapshots.
- * It's updated/manipulated through `bind:this` in `Root.svelte`.
- * @type {import('svelte').SvelteComponent[]}
- */
-const components = [];
-
 /** @type {{id: string, token: {}, promise: Promise<import('./types.js').NavigationResult>, fork: Promise<import('svelte').Fork | null> | null} | null} */
 let load_cache = null;
 
@@ -462,12 +454,9 @@ export async function start(_app, _target, data) {
 		default_error_loader()
 	]);
 
-	props = new Props(
-		page,
-		components,
-		(_, reset) => resetters.add(reset),
-		new RenderNode(root_layout.component, root_error.component)
-	);
+	const tree = new RenderNode(root_layout.component, root_error.component);
+
+	props = new Props(page, tree, (_, reset) => resetters.add(reset));
 
 	const history_metadata = get_history_metadata();
 	current_history_index = history_metadata?.historyIndex ?? 0;
@@ -634,15 +623,15 @@ function reset_invalidation() {
 
 /** @param {number} index */
 function capture_snapshot(index) {
-	if (components.some((c) => c?.snapshot)) {
-		snapshots[index] = components.map((c) => c?.snapshot?.capture());
+	if (props.components.some((c) => c?.snapshot)) {
+		snapshots[index] = props.components.map((c) => c?.snapshot?.capture());
 	}
 }
 
 /** @param {number} index */
 function restore_snapshot(index) {
 	snapshots[index]?.forEach((value, i) => {
-		components[i]?.snapshot?.restore(value);
+		props.components[i]?.snapshot?.restore(value);
 	});
 }
 

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1,7 +1,6 @@
 /** @import { RouteId } from '$app/types' */
 /** @import { RemoteFunctionDataNode, ServerNodesResponse, ServerRedirectNode } from 'types' */
 /** @import { NavigationIntent } from './types.js' */
-/** @import { RenderNode } from '../types.js' */
 /** @import { CacheEntry } from './remote-functions/cache.svelte.js' */
 /** @import { Query } from './remote-functions/query/instance.svelte.js' */
 /** @import { LiveQuery } from './remote-functions/query-live/instance.svelte.js' */
@@ -47,6 +46,7 @@ import { noop_span } from '../telemetry/noop.js';
 import { read_ndjson } from './ndjson.js';
 import RootModern from '../components/root.svelte';
 import { asClassComponent } from 'svelte/legacy';
+import { Props, RenderNode } from '../props.svelte.js';
 
 const Root = asClassComponent(RootModern);
 
@@ -101,10 +101,8 @@ const history_info = storage.get(HISTORY_INFO_KEY) ?? {};
  */
 const snapshots = storage.get(SNAPSHOT_KEY) ?? {};
 
-/**
- * @deprecated this is a temporary measure to avoid a regression, replace with nested `RenderNode` classes
- */
-let current_tree = /** @type {RenderNode} */ ({});
+/** @type {Props} */
+let props;
 
 if (DEV && BROWSER) {
 	let warned = false;
@@ -472,8 +470,18 @@ export async function start(_app, _target, hydrate) {
 	// connectivity errors after initialisation don't nuke the app
 	default_layout_loader = _app.nodes[0];
 	default_error_loader = _app.nodes[1];
-	void default_layout_loader();
-	void default_error_loader();
+
+	const [root_layout, root_error] = await Promise.all([
+		default_layout_loader(),
+		default_error_loader()
+	]);
+
+	props = new Props(
+		page,
+		components,
+		(_, reset) => resetters.add(reset),
+		new RenderNode(root_layout.component, root_error.component)
+	);
 
 	const history_metadata = get_history_metadata();
 	current_history_index = history_metadata?.historyIndex ?? 0;
@@ -608,7 +616,7 @@ async function _invalidate(reset_page_state = true) {
 	}
 	navigation_result.props.page.shallow = prev_shallow;
 	update(navigation_result.props.page);
-	current_tree = navigation_result.props.tree;
+	update_tree(props.tree, navigation_result.props.tree);
 	current = { ...navigation_result.state, nav: current.nav };
 	reset_invalidation();
 	root.$set(navigation_result.props);
@@ -777,7 +785,7 @@ async function _preload_data(intent) {
 						return fork(() => {
 							root.$set(result.props);
 							update(result.props.page);
-							current_tree = result.props.tree;
+							update_tree(props.tree, result.props.tree);
 						});
 					} catch {
 						// if it errors, it's because the experimental flag isn't enabled in Svelte
@@ -836,12 +844,12 @@ async function initialize(result, target, hydrate) {
 	}
 
 	update(/** @type {import('@sveltejs/kit').Page} */ (result.props.page));
-	current_tree = result.props.tree;
+	update_tree(props.tree, result.props.tree);
 
 	// TODO: use mount()
 	root = new Root({
 		target,
-		props: { ...result.props, components, onerror: (_, reset) => resetters.add(reset) },
+		props,
 		hydrate,
 		// Svelte 5 specific: asynchronously instantiate the component, i.e. don't call flushSync
 		sync: false,
@@ -950,18 +958,13 @@ async function get_navigation_result_from_branch({
 	let current_node = result.props.tree;
 
 	/** @type {RenderNode | undefined} */
-	let previous_node = current_tree;
+	let previous_node = props.tree;
 
 	for (let i = 0; i < branch.length; i += 1) {
 		const node = branch[i];
 		const prev = current.branch[i];
 
 		if (!node) continue;
-
-		const error_loader = errors?.slice(0, i + 1).findLast((x) => x) ?? default_error_loader;
-
-		current_node.error = (await error_loader()).component;
-		current_node.component = node.node.component;
 
 		if (
 			// if an ancestor node in this path changed, `data_changed` is already true and the
@@ -980,8 +983,12 @@ async function get_navigation_result_from_branch({
 		data = current_node.data;
 
 		if (i < branch.length - 1) {
-			current_node.child = /** @type {import('../types.js').RenderNode} */ ({});
-			current_node = current_node.child;
+			const error_loader = errors?.slice(0, i + 2).findLast((x) => x) ?? default_error_loader;
+
+			current_node = current_node.child = new RenderNode(
+				branch[i + 1].node.component,
+				(await error_loader()).component
+			);
 
 			previous_node = previous_node?.child;
 		}
@@ -2091,8 +2098,8 @@ async function navigate({
 			resetters.clear();
 		} else {
 			rendering_error = null; // TODO this can break with forks, rethink for SvelteKit 3 where we can assume Svelte 5
+			update_tree(props.tree, navigation_result.props.tree);
 			root.$set(navigation_result.props);
-			current_tree = navigation_result.props.tree;
 			// Reset any boundaries that failed on a previous navigation now that the
 			// new props are applied, otherwise the stale `+error.svelte` stays
 			// mounted above the new route's content. See sveltejs/kit#15694.
@@ -2953,8 +2960,8 @@ export async function set_nearest_error_page(error) {
 		current = { ...navigation_result.state, nav: current.nav };
 
 		root.$set(navigation_result.props);
-		current_tree = navigation_result.props.tree;
 		update(navigation_result.props.page);
+		update_tree(props.tree, navigation_result.props.tree);
 
 		void tick().then(() => reset_focus(current.url));
 	}
@@ -3807,4 +3814,8 @@ if (DEV) {
 			}
 		});
 	}
+}
+
+function update_tree(node, next) {
+	props.tree.child = next.child;
 }

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -405,12 +405,33 @@ set_match_implementation(async (url) => {
 	return null;
 });
 
+let embedded_start = Promise.resolve();
+
+/**
+ * TODO this indirection is a grotesque workaround for the fact that multiple apps
+ * can operate on the same shared mutable state. This is fundamentally unsound,
+ * and the `start`/`_start` distinction does not fix it, but it does get the
+ * tests passing. We need to rethink this whole thing but not right now
+ * @param {import('./types.js').SvelteKitApp} _app
+ * @param {HTMLElement} _target
+ * @param {Parameters<typeof _hydrate>[1]} [data]
+ */
+export function start(_app, _target, data) {
+	if (__SVELTEKIT_EMBEDDED__) {
+		const start_promise = embedded_start.then(() => _start(_app, _target, data));
+		embedded_start = start_promise.catch(noop);
+		return start_promise;
+	}
+
+	return _start(_app, _target, data);
+}
+
 /**
  * @param {import('./types.js').SvelteKitApp} _app
  * @param {HTMLElement} _target
  * @param {Parameters<typeof _hydrate>[1]} [data]
  */
-export async function start(_app, _target, data) {
+async function _start(_app, _target, data) {
 	if (DEV && _target === document.body) {
 		console.warn(
 			'Placing %sveltekit.body% directly inside <body> is not recommended, as your app may break for users who have certain browser extensions installed.\n\nConsider wrapping it in an element:\n\n<div style="display: contents">\n  %sveltekit.body%\n</div>'

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2902,14 +2902,10 @@ export async function applyAction(result) {
 		// this brings Svelte's view of the world in line with SvelteKit's
 		// after use:enhance reset the form....
 		props.form = null;
-		// root.$set({
-		// 	form: null
-		// });
 
 		// ...so that setting the `form` prop takes effect and isn't ignored
 		await tick();
 		props.form = result.data;
-		// root.$set({ form: result.data });
 
 		if (result.type === 'success') {
 			reset_focus(/** @type {URL} */ (page.url));

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -39,7 +39,7 @@ import {
 	validate_load_response
 } from '../shared.js';
 import { get_message, get_status } from '../../utils/error.js';
-import { page, update, navigating, updated, notify_version } from './state.svelte.js';
+import { page, navigating, updated, notify_version } from './state.svelte.js';
 import { payload } from './payload.js';
 import { add_data_suffix, add_resolution_suffix } from '../pathname.js';
 import { noop_span } from '../telemetry/noop.js';
@@ -63,14 +63,6 @@ export { load_css };
 const ICON_REL_ATTRIBUTES = new Set(['icon', 'shortcut icon', 'apple-touch-icon']);
 
 let errored = false;
-/**
- * Set via transformError, reset and read at the end of navigate.
- * Necessary because a navigation might succeed loading but during rendering
- * an error occurs, at which point the navigation result needs to be overridden with the error result.
- * TODO this is all very hacky, rethink for SvelteKit 3 where we can assume Svelte 5 and do an overhaul of client.js
- * @type {{ error: App.Error, status: number } | null}
- */
-let rendering_error = null;
 
 /**
  * `reset` functions for `<svelte:boundary>`s in the generated root that have
@@ -348,9 +340,6 @@ let has_navigated = false;
 
 let force_invalidation = false;
 
-/** @type {import('svelte').SvelteComponent} */
-let root;
-
 /** @type {number} keeping track of the history index in order to prevent popstate navigation events if needed */
 let current_history_index;
 
@@ -613,11 +602,8 @@ async function _invalidate(reset_page_state = true) {
 	}
 	navigation_result.props.page.shallow = prev_shallow;
 	apply_navigation_result(navigation_result);
-	// update(navigation_result.props.page);
-	// update_tree(props.tree, navigation_result.props.tree);
 	current = { ...navigation_result.state, nav: current.nav };
 	reset_invalidation();
-	// root.$set(navigation_result.props);
 
 	// only wait for promises that are connected to queries that still exist
 	/** @type {Promise<any>[]} */
@@ -782,9 +768,6 @@ async function _preload_data(intent) {
 					try {
 						return fork(() => {
 							apply_navigation_result(result);
-							// root.$set(result.props);
-							// update(result.props.page);
-							// update_tree(props.tree, result.props.tree);
 						});
 					} catch {
 						// if it errors, it's because the experimental flag isn't enabled in Svelte
@@ -852,9 +835,8 @@ async function initialize(result, target, should_hydrate) {
 		props,
 		transformError: /** @param {unknown} e */ async (e) => {
 			const error = await handle_error(e, current.nav);
-			rendering_error = { error, status: error.status };
 			page.error = error;
-			page.status = rendering_error.status;
+			page.status = error.status;
 			return error;
 		}
 	});
@@ -2104,11 +2086,8 @@ async function navigate({
 			}
 			resetters.clear();
 		} else {
-			// rendering_error = null; // TODO this can break with forks, rethink for SvelteKit 3 where we can assume Svelte 5
-
 			apply_navigation_result(navigation_result);
-			// update_tree(props.tree, navigation_result.props.tree);
-			// root.$set(navigation_result.props);
+
 			// Reset any boundaries that failed on a previous navigation now that the
 			// new props are applied, otherwise the stale `+error.svelte` stays
 			// mounted above the new route's content. See sveltejs/kit#15694.
@@ -2116,11 +2095,6 @@ async function navigate({
 				reset();
 			}
 			resetters.clear();
-			// Check for sync rendering error
-			// if (rendering_error) {
-			// 	Object.assign(navigation_result.props.page, rendering_error);
-			// }
-			update(navigation_result.props.page);
 
 			commit_promise = settled();
 		}
@@ -2138,11 +2112,6 @@ async function navigate({
 		// a new navigation happened while we were waiting for the DOM to update, so abort
 		nav.reject(new Error('navigation aborted'));
 		return;
-	}
-
-	// Check for async rendering error
-	if (navigation_result.props.page && rendering_error) {
-		Object.assign(navigation_result.props.page, rendering_error);
 	}
 
 	reset_scroll_and_focus(url, noscroll ? scroll_state() : popped?.scroll, keepfocus, activeElement);
@@ -2970,9 +2939,6 @@ export async function set_nearest_error_page(error) {
 
 		current = { ...navigation_result.state, nav: current.nav };
 
-		// root.$set(navigation_result.props);
-		// update(navigation_result.props.page);
-		// update_tree(props.tree, navigation_result.props.tree);
 		apply_navigation_result(navigation_result);
 
 		void tick().then(() => reset_focus(current.url));
@@ -3832,7 +3798,8 @@ if (DEV) {
  * @param {NavigationFinished} result
  */
 function apply_navigation_result(result) {
-	update(result.props.page);
+	Object.assign(page, result.props.page);
+
 	props.tree.data = result.props.tree.data;
 	props.tree.child = result.props.tree.child;
 

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -82,9 +82,9 @@ let rendering_error = null;
  * navigation away from a render error would leave the stale `+error.svelte`
  * mounted. The boundary's `onerror` populates this array; `navigate` drains it
  * after applying the new props. See sveltejs/kit#15694.
- * @type {Array<(() => void) | undefined>}
+ * @type {Set<() => void>}
  */
-const resetters = [];
+const resetters = new Set();
 
 // We track information associated with each history entry in sessionStorage,
 // rather than on history.state itself, because when navigation is driven by
@@ -841,7 +841,7 @@ async function initialize(result, target, hydrate) {
 	// TODO: use mount()
 	root = new Root({
 		target,
-		props: { ...result.props, components, resetters },
+		props: { ...result.props, components, onerror: (_, reset) => resetters.add(reset) },
 		hydrate,
 		// Svelte 5 specific: asynchronously instantiate the component, i.e. don't call flushSync
 		sync: false,
@@ -2086,9 +2086,9 @@ async function navigate({
 			// first `await`, so reset any previously-failed boundaries now so the
 			// stale `+error.svelte` is torn down. See sveltejs/kit#15694.
 			for (const reset of resetters) {
-				reset?.();
+				reset();
 			}
-			resetters.length = 0;
+			resetters.clear();
 		} else {
 			rendering_error = null; // TODO this can break with forks, rethink for SvelteKit 3 where we can assume Svelte 5
 			root.$set(navigation_result.props);
@@ -2097,9 +2097,9 @@ async function navigate({
 			// new props are applied, otherwise the stale `+error.svelte` stays
 			// mounted above the new route's content. See sveltejs/kit#15694.
 			for (const reset of resetters) {
-				reset?.();
+				reset();
 			}
-			resetters.length = 0;
+			resetters.clear();
 			// Check for sync rendering error
 			if (rendering_error) {
 				Object.assign(navigation_result.props.page, rendering_error);

--- a/packages/kit/src/runtime/client/state.svelte.js
+++ b/packages/kit/src/runtime/client/state.svelte.js
@@ -100,10 +100,3 @@ if (!DEV && BROWSER) {
 
 	updated.check = check;
 }
-
-/**
- * @param {import('@sveltejs/kit').Page} new_page
- */
-export function update(new_page) {
-	Object.assign(page, new_page);
-}

--- a/packages/kit/src/runtime/client/types.d.ts
+++ b/packages/kit/src/runtime/client/types.d.ts
@@ -1,4 +1,3 @@
-import { SvelteComponent } from 'svelte';
 import {
 	ClientHooks,
 	CSRPageNode,
@@ -10,7 +9,7 @@ import {
 	Uses
 } from 'types';
 import { Page, ParamMatcher } from '@sveltejs/kit';
-import { RenderNode } from '../types.js';
+import { RenderNode } from '../props.svelte.js';
 
 export interface SvelteKitApp {
 	/**

--- a/packages/kit/src/runtime/components/root.svelte
+++ b/packages/kit/src/runtime/components/root.svelte
@@ -7,12 +7,12 @@
 		page: Page;
 		tree: RenderNode;
 		components: any[];
-		resetters: Array<(() => void) | undefined>;
+		onerror: (error: unknown, reset: () => void) => void;
 		form?: any;
 		error?: App.Error;
 	}
 
-	const { page, components, resetters, tree, form, error }: Props = $props();
+	const { page, components, onerror, tree, form, error }: Props = $props();
 
 	let mounted = $state(false);
 	let navigated = $state(false);
@@ -33,7 +33,7 @@
 	{const Error = $derived(n.error)}
 	{const data = $derived(n.data)}
 
-	<svelte:boundary onerror={(_, reset) => (resetters[depth] = reset)}>
+	<svelte:boundary {onerror}>
 		{#if n.child}
 			<!-- svelte-ignore binding_property_non_reactive -->
 			<Component bind:this={components[depth]} {data} {form} params={page.params}>

--- a/packages/kit/src/runtime/components/root.svelte
+++ b/packages/kit/src/runtime/components/root.svelte
@@ -1,16 +1,6 @@
 <script lang="ts">
 	import { afterNavigate } from '$app/navigation';
-	import type { Page } from '@sveltejs/kit';
-	import type { RenderNode } from '../types.js';
-
-	interface Props {
-		page: Page;
-		tree: RenderNode;
-		components: any[];
-		onerror: (error: unknown, reset: () => void) => void;
-		form?: any;
-		error?: App.Error;
-	}
+	import type { Props, RenderNode } from '../props.svelte.js';
 
 	const { page, components, onerror, tree, form, error }: Props = $props();
 
@@ -33,7 +23,11 @@
 	{const Error = $derived(n.error)}
 	{const data = $derived(n.data)}
 
-	<svelte:boundary {onerror}>
+	{#snippet failed(error: unknown)}
+		<Error {error} />
+	{/snippet}
+
+	<svelte:boundary {onerror} failed={n.error ? failed : undefined}>
 		{#if n.child}
 			<!-- svelte-ignore binding_property_non_reactive -->
 			<Component bind:this={components[depth]} {data} {form} params={page.params}>
@@ -43,10 +37,6 @@
 			<!-- svelte-ignore binding_property_non_reactive -->
 			<Component bind:this={components[depth]} {data} {form} params={page.params} {error} />
 		{/if}
-
-		{#snippet failed(error)}
-			<Error {error} />
-		{/snippet}
 	</svelte:boundary>
 {/snippet}
 

--- a/packages/kit/src/runtime/components/root.svelte
+++ b/packages/kit/src/runtime/components/root.svelte
@@ -23,11 +23,7 @@
 	{const Error = $derived(n.error)}
 	{const data = $derived(n.data)}
 
-	{#snippet failed(error: unknown)}
-		<Error {error} />
-	{/snippet}
-
-	<svelte:boundary {onerror} failed={n.error ? failed : undefined}>
+	<svelte:boundary {onerror}>
 		{#if n.child}
 			<!-- svelte-ignore binding_property_non_reactive -->
 			<Component bind:this={components[depth]} {data} {form} params={page.params}>
@@ -37,6 +33,10 @@
 			<!-- svelte-ignore binding_property_non_reactive -->
 			<Component bind:this={components[depth]} {data} {form} params={page.params} {error} />
 		{/if}
+
+		{#snippet failed(error: unknown)}
+			<Error {error} />
+		{/snippet}
 	</svelte:boundary>
 {/snippet}
 

--- a/packages/kit/src/runtime/props.svelte.js
+++ b/packages/kit/src/runtime/props.svelte.js
@@ -11,7 +11,7 @@ export class Props {
 	/** @type {any} */
 	form;
 
-	/** @type {App.Error | null} */
+	/** @type {App.Error | undefined} */
 	error;
 
 	/** @type {RenderNode} */
@@ -29,8 +29,8 @@ export class Props {
 	constructor(page, components, onerror, tree) {
 		this.page = page;
 		this.components = components;
-		this.form = $state.raw(null);
-		this.error = $state.raw(null);
+		this.form = $state.raw();
+		this.error = $state.raw();
 		this.tree = tree;
 
 		this.onerror = onerror;

--- a/packages/kit/src/runtime/props.svelte.js
+++ b/packages/kit/src/runtime/props.svelte.js
@@ -45,10 +45,10 @@ export class RenderNode {
 	error;
 
 	/** @type {Record<string, any>} */
-	data;
+	data = $state.raw({});
 
-	/** @type {RenderNode | null} */
-	child;
+	/** @type {RenderNode | undefined} */
+	child = $state.raw();
 
 	/**
 	 *
@@ -58,8 +58,5 @@ export class RenderNode {
 	constructor(component, error) {
 		this.component = component;
 		this.error = error;
-
-		this.data = $state.raw({});
-		this.child = $state.raw(null);
 	}
 }

--- a/packages/kit/src/runtime/props.svelte.js
+++ b/packages/kit/src/runtime/props.svelte.js
@@ -1,12 +1,19 @@
 /** @import { Component } from 'svelte'; */
 /** @import { Page } from '@sveltejs/kit'; */
 
+import { noop } from '../utils/functions.js';
+
 export class Props {
 	/** @type {Page} */
 	page;
 
-	/** @type {Array<Record<string, any>>} */
-	components;
+	/**
+	 * An array of the `+layout.svelte` and `+page.svelte` component instances
+	 * that currently live on the page — used for capturing and restoring snapshots.
+	 * It's updated/manipulated through `bind:this` in `Root.svelte`.
+	 * @type {Array<Record<string, any>>}
+	 */
+	components = [];
 
 	/** @type {any} */
 	form;
@@ -22,18 +29,16 @@ export class Props {
 
 	/**
 	 * @param {Page} page
-	 * @param {Array<Record<string, any>>} components
-	 * @param {(error: unknown, reset: () => void) => void} onerror
 	 * @param {RenderNode} tree
+	 * @param {(error: unknown, reset: () => void) => void} onerror
 	 */
-	constructor(page, components, onerror, tree) {
+	constructor(page, tree, onerror = noop) {
 		this.page = page;
-		this.components = components;
+		this.tree = tree;
+		this.onerror = onerror;
+
 		this.form = $state.raw();
 		this.error = $state.raw();
-		this.tree = tree;
-
-		this.onerror = onerror;
 	}
 }
 

--- a/packages/kit/src/runtime/props.svelte.js
+++ b/packages/kit/src/runtime/props.svelte.js
@@ -1,0 +1,65 @@
+/** @import { Component } from 'svelte'; */
+/** @import { Page } from '@sveltejs/kit'; */
+
+export class Props {
+	/** @type {Page} */
+	page;
+
+	/** @type {Array<Record<string, any>>} */
+	components;
+
+	/** @type {any} */
+	form;
+
+	/** @type {App.Error | null} */
+	error;
+
+	/** @type {RenderNode} */
+	tree;
+
+	/** @type {(error: unknown, reset: () => void) => void} */
+	onerror;
+
+	/**
+	 * @param {Page} page
+	 * @param {Array<Record<string, any>>} components
+	 * @param {(error: unknown, reset: () => void) => void} onerror
+	 * @param {RenderNode} tree
+	 */
+	constructor(page, components, onerror, tree) {
+		this.page = page;
+		this.components = components;
+		this.form = $state.raw(null);
+		this.error = $state.raw(null);
+		this.tree = tree;
+
+		this.onerror = onerror;
+	}
+}
+
+export class RenderNode {
+	/** @type {Component} */
+	component;
+
+	/** @type {Component | undefined} */
+	error;
+
+	/** @type {Record<string, any>} */
+	data;
+
+	/** @type {RenderNode | null} */
+	child;
+
+	/**
+	 *
+	 * @param {Component} component
+	 * @param {Component} error
+	 */
+	constructor(component, error) {
+		this.component = component;
+		this.error = error;
+
+		this.data = $state.raw({});
+		this.child = $state.raw(null);
+	}
+}

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -167,7 +167,7 @@ export async function render_response({
 			if (i < branch.length - 1) {
 				current_node = current_node.child = new RenderNode(
 					await branch[i + 1].node.component?.(), // TODO tidy up
-					error_components[i + 2]
+					error_components?.slice(0, i + 2).findLast((x) => x)
 				);
 			}
 		}

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -1,4 +1,3 @@
-/** @import { RenderNode } from '../../types.js' */
 import * as devalue from 'devalue';
 import { DEV } from 'esm-env';
 import { isRedirect, text } from '@sveltejs/kit';
@@ -20,6 +19,7 @@ import * as env from '__sveltekit/env';
 import { collect_remote_data } from '../remote-functions.js';
 import Root from '../../components/root.svelte';
 import { render } from 'svelte/server';
+import { RenderNode } from '../../props.svelte.js';
 
 // TODO rename this function/module
 
@@ -139,7 +139,7 @@ export async function render_response({
 			components: [],
 			resetters: [],
 			form: form_value,
-			tree: /** @type {RenderNode} */ ({}),
+			tree: new RenderNode(await branch[0].node.component(), error_components[1]), // TODO tidy up
 			error,
 			page: {
 				error,
@@ -162,16 +162,13 @@ export async function render_response({
 
 			data = { ...data, ...node.data };
 
-			// TODO this is undefined sometimes... where does the default error component come from?
-			const error = error_components?.slice(0, i + 1).findLast((x) => x);
-
-			current_node.error = error;
-			current_node.component = await node.node.component?.();
 			current_node.data = data;
 
 			if (i < branch.length - 1) {
-				current_node.child = /** @type {import('../../types.js').RenderNode} */ ({});
-				current_node = current_node.child;
+				current_node = current_node.child = new RenderNode(
+					await branch[i + 1].node.component?.(), // TODO tidy up
+					error_components[i + 2]
+				);
 			}
 		}
 

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -1,3 +1,4 @@
+/** @import { Component } from 'svelte'; */
 import * as devalue from 'devalue';
 import { DEV } from 'esm-env';
 import { isRedirect, text } from '@sveltejs/kit';
@@ -19,7 +20,7 @@ import * as env from '__sveltekit/env';
 import { collect_remote_data } from '../remote-functions.js';
 import Root from '../../components/root.svelte';
 import { render } from 'svelte/server';
-import { RenderNode } from '../../props.svelte.js';
+import { Props, RenderNode } from '../../props.svelte.js';
 
 // TODO rename this function/module
 
@@ -134,25 +135,26 @@ export async function render_response({
 	}
 
 	if (page_config.ssr) {
-		/** @type {Record<string, any>} */
-		const props = {
-			components: [],
-			resetters: [],
-			form: form_value,
-			tree: new RenderNode(await branch[0].node.component(), error_components[1]), // TODO tidy up
+		const page = {
 			error,
-			page: {
-				error,
-				params: /** @type {Record<string, any>} */ (event.params),
-				route: event.route,
-				status,
-				url: event.url,
-				data: {},
-				form: form_value,
-				shallow: null,
-				state: {}
-			}
+			params: /** @type {Record<string, any>} */ (event.params),
+			route: event.route,
+			status,
+			url: event.url,
+			data: {},
+			form: form_value,
+			shallow: null,
+			state: {}
 		};
+
+		const props = new Props(
+			page,
+			new RenderNode(
+				// TODO tidy up
+				/** @type {Component} */ (await branch[0].node.component?.()),
+				/** @type {Component} */ (error_components?.[1])
+			)
+		);
 
 		let current_node = props.tree;
 		let data = props.page.data;
@@ -166,8 +168,9 @@ export async function render_response({
 
 			if (i < branch.length - 1) {
 				current_node = current_node.child = new RenderNode(
-					await branch[i + 1].node.component?.(), // TODO tidy up
-					error_components?.slice(0, i + 2).findLast((x) => x)
+					// TODO tidy up
+					/** @type {Component} */ (await branch[i + 1].node.component?.()),
+					/** @type {Component} */ (error_components?.slice(0, i + 2).findLast((x) => x))
 				);
 			}
 		}

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -156,6 +156,8 @@ export async function render_response({
 			)
 		);
 
+		props.form = form_value;
+
 		let current_node = props.tree;
 		let data = props.page.data;
 

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -157,6 +157,7 @@ export async function render_response({
 		);
 
 		props.form = form_value;
+		props.error = error ?? undefined;
 
 		let current_node = props.tree;
 		let data = props.page.data;

--- a/packages/kit/src/runtime/types.d.ts
+++ b/packages/kit/src/runtime/types.d.ts
@@ -1,8 +1,0 @@
-import { Component } from 'svelte';
-
-export interface RenderNode {
-	component: Component;
-	error: Component;
-	data: Record<string, any>;
-	child?: RenderNode;
-}


### PR DESCRIPTION
we can probably improve further on this by tidying up some of the internal data structures, but this is the important bit