### PR TITLE
fix: error during dev when adapter doesn't support instrumentation and it exists

### DIFF
--- a/.changeset/upset-cities-vanish.md
+++ b/.changeset/upset-cities-vanish.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: error during development if the adapter does not support instrumentation and it exists

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -479,6 +479,7 @@ export async function dev(vite, vite_config, svelte_config, get_remotes, root, s
 
 	const env = loadEnv(vite_config.mode, svelte_config.kit.env.dir, '');
 	const emulator = await svelte_config.kit.adapter?.emulate?.();
+	const adapter_supports_instrumentation = svelte_config.kit.adapter?.supports?.instrumentation?.();
 
 	/** @type {Promise<void> | undefined} */
 	let init_manifest;
@@ -547,11 +548,19 @@ export async function dev(vite, vite_config, svelte_config, get_remotes, root, s
 					return;
 				}
 
+				// resolve the instrumentation file per request so that changes to it
+				// are picked up on new requests
 				const resolved_instrumentation = resolve_entry(
 					path.join(svelte_config.kit.files.src, 'instrumentation.server')
 				);
 
 				if (resolved_instrumentation) {
+					if (svelte_config.kit.adapter && !adapter_supports_instrumentation) {
+						throw new Error(
+							`${resolved_instrumentation} is unsupported in ${svelte_config.kit.adapter.name}.`
+						);
+					}
+
 					await runner.import(resolved_instrumentation);
 				}
 

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -479,7 +479,6 @@ export async function dev(vite, vite_config, svelte_config, get_remotes, root, s
 
 	const env = loadEnv(vite_config.mode, svelte_config.kit.env.dir, '');
 	const emulator = await svelte_config.kit.adapter?.emulate?.();
-	const adapter_supports_instrumentation = svelte_config.kit.adapter?.supports?.instrumentation?.();
 
 	/** @type {Promise<void> | undefined} */
 	let init_manifest;
@@ -555,7 +554,10 @@ export async function dev(vite, vite_config, svelte_config, get_remotes, root, s
 				);
 
 				if (resolved_instrumentation) {
-					if (svelte_config.kit.adapter && !adapter_supports_instrumentation) {
+					if (
+						svelte_config.kit.adapter &&
+						!svelte_config.kit.adapter.supports?.instrumentation?.()
+					) {
 						throw new Error(
 							`${resolved_instrumentation} is unsupported in ${svelte_config.kit.adapter.name}.`
 						);


### PR DESCRIPTION
extracting changes from https://github.com/sveltejs/kit/pull/16464

We currently only error during build but it would be good to error earlier so folks know their adapter doesn't support instrumentation if they created such a file.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
