### PR TITLE
fix: log errors caught by the Vite dev server handler

### DIFF
--- a/.changeset/tangy-flies-pay.md
+++ b/.changeset/tangy-flies-pay.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: log errors caught by the Vite dev server handler

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -637,6 +637,7 @@ export async function dev(vite, vite_config, svelte_config, get_remotes, root, s
 				const error = coalesce_to_error(e);
 				res.statusCode = 500;
 				fix_stack_trace(error);
+				console.error(styleText(['bold', 'red'], String(error)));
 				res.end(error.stack || error.message); // handle `stackless` errors
 			}
 		});


### PR DESCRIPTION
split out from https://github.com/sveltejs/kit/pull/16464

Errors that happen in the [main Vite dev server middleware](https://github.com/sveltejs/kit/blob/680cc413ea5f4f71b083d2cc306ce73b390439dd/packages/kit/src/exports/vite/dev/index.js#L496) aren't very visible since only its message appears in the browser right now. This PR fixes that by logging the error on the server and its fixed stack trace (if any).

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
