### PR TITLE
chore: loosen `env` type in `server.init`

### DIFF
--- a/packages/adapter-cloudflare/src/worker.js
+++ b/packages/adapter-cloudflare/src/worker.js
@@ -18,8 +18,7 @@ const version_file = `${app_path}/version.json`;
 let origin;
 
 const initialized = server.init({
-	// @ts-expect-error env contains environment variables and bindings
-	env,
+	env: /** @type {Record<string, string>} */ (env),
 	read: async (file) => {
 		const url = `${origin}/${file}`;
 		const response = await /** @type {{ ASSETS: { fetch: typeof fetch } }} */ (env).ASSETS.fetch(

--- a/packages/adapter-netlify/package.json
+++ b/packages/adapter-netlify/package.json
@@ -52,6 +52,7 @@
 	"devDependencies": {
 		"@netlify/edge-functions": "^3.0.8",
 		"@sveltejs/kit": "workspace:^",
+		"@types/deno": "^2.7.0",
 		"@types/node": "catalog:",
 		"typescript": "catalog:",
 		"vitest": "catalog:"

--- a/packages/adapter-netlify/src/edge.js
+++ b/packages/adapter-netlify/src/edge.js
@@ -1,3 +1,4 @@
+/** @import {} from 'deno' */
 import { Server } from '0SERVER';
 import { manifest } from 'MANIFEST';
 
@@ -11,7 +12,6 @@ const server = new Server(manifest);
 let origin;
 
 const initialized = server.init({
-	// @ts-ignore
 	env: Deno.env.toObject(),
 	read: async (file) => {
 		const url = `${origin}/${file}`;

--- a/packages/adapter-netlify/src/serverless.js
+++ b/packages/adapter-netlify/src/serverless.js
@@ -11,7 +11,7 @@ export function init(manifest) {
 
 	/** @type {Promise<void> | null} */
 	let init_promise = server.init({
-		env: /** @type {Record<string, string>} */ (process.env),
+		env: process.env,
 		read: (file) => createReadableStream(`.netlify/server/${file}`)
 	});
 

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -31,7 +31,7 @@ if (isNaN(body_size_limit)) {
 const asset_dir = `${dir}/client${base}`;
 
 await server.init({
-	env: /** @type {Record<string, string>} */ (process.env),
+	env: process.env,
 	read: (file) => createReadableStream(`${asset_dir}/${file}`)
 });
 

--- a/packages/adapter-vercel/files/serverless.js
+++ b/packages/adapter-vercel/files/serverless.js
@@ -6,7 +6,7 @@ import process from 'node:process';
 const server = new Server(manifest);
 
 await server.init({
-	env: /** @type {Record<string, string>} */ (process.env),
+	env: process.env,
 	read: createReadableStream
 });
 

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -1786,7 +1786,7 @@ export class Server {
 
 export interface ServerInitOptions {
 	/** A map of environment variables. */
-	env: Record<string, string>;
+	env: Record<string, string | undefined>;
 	/** A function that turns an asset filename into a `ReadableStream`. Required for the `read` export from `$app/server` to work. */
 	read?: (file: string) => MaybePromise<ReadableStream | null>;
 }

--- a/packages/kit/src/types/ambient-private.d.ts
+++ b/packages/kit/src/types/ambient-private.d.ts
@@ -25,7 +25,7 @@ declare module '__sveltekit/env' {
 	// exported environment variables are defined in env.d.ts
 
 	/** Populate exported environment variables */
-	export function set_env(environment: Record<string, string>): void;
+	export function set_env(environment: Record<string, string | undefined>): void;
 
 	/** public env vars */
 	export const explicit_public_env: Record<string, any>;

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1367,7 +1367,10 @@ declare module '@sveltejs/kit' {
 	}
 
 	export type Navigation =
-		NavigationExternal | NavigationFormSubmit | NavigationPopState | NavigationLink;
+		| NavigationExternal
+		| NavigationFormSubmit
+		| NavigationPopState
+		| NavigationLink;
 
 	/**
 	 * The argument passed to [`beforeNavigate`](https://svelte.dev/docs/kit/$app-navigation#beforeNavigate) callbacks.
@@ -1472,7 +1475,8 @@ declare module '@sveltejs/kit' {
 	 * A param matcher definition passed to [`defineParams`](https://svelte.dev/docs/kit/@sveltejs-kit#defineParams).
 	 */
 	export type ParamDefinition =
-		((param: string) => ParamValue | undefined) | StandardSchemaV1<string, ParamValue>;
+		| ((param: string) => ParamValue | undefined)
+		| StandardSchemaV1<string, ParamValue>;
 
 	/**
 	 * The return type of [`defineParams`](https://svelte.dev/docs/kit/@sveltejs-kit#defineParams).
@@ -1575,7 +1579,8 @@ declare module '@sveltejs/kit' {
 		};
 
 	export type RequestedResult<Validated, Output> =
-		QueryRequestedResult<Validated, Output> | LiveQueryRequestedResult<Validated, Output>;
+		| QueryRequestedResult<Validated, Output>
+		| LiveQueryRequestedResult<Validated, Output>;
 
 	export interface RequestEvent<
 		Params extends AppLayoutParams<'/'> = AppLayoutParams<'/'>,
@@ -1756,7 +1761,7 @@ declare module '@sveltejs/kit' {
 
 	export interface ServerInitOptions {
 		/** A map of environment variables. */
-		env: Record<string, string>;
+		env: Record<string, string | undefined>;
 		/** A function that turns an asset filename into a `ReadableStream`. Required for the `read` export from `$app/server` to work. */
 		read?: (file: string) => MaybePromise<ReadableStream | null>;
 	}

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1367,10 +1367,7 @@ declare module '@sveltejs/kit' {
 	}
 
 	export type Navigation =
-		| NavigationExternal
-		| NavigationFormSubmit
-		| NavigationPopState
-		| NavigationLink;
+		NavigationExternal | NavigationFormSubmit | NavigationPopState | NavigationLink;
 
 	/**
 	 * The argument passed to [`beforeNavigate`](https://svelte.dev/docs/kit/$app-navigation#beforeNavigate) callbacks.
@@ -1475,8 +1472,7 @@ declare module '@sveltejs/kit' {
 	 * A param matcher definition passed to [`defineParams`](https://svelte.dev/docs/kit/@sveltejs-kit#defineParams).
 	 */
 	export type ParamDefinition =
-		| ((param: string) => ParamValue | undefined)
-		| StandardSchemaV1<string, ParamValue>;
+		((param: string) => ParamValue | undefined) | StandardSchemaV1<string, ParamValue>;
 
 	/**
 	 * The return type of [`defineParams`](https://svelte.dev/docs/kit/@sveltejs-kit#defineParams).
@@ -1579,8 +1575,7 @@ declare module '@sveltejs/kit' {
 		};
 
 	export type RequestedResult<Validated, Output> =
-		| QueryRequestedResult<Validated, Output>
-		| LiveQueryRequestedResult<Validated, Output>;
+		QueryRequestedResult<Validated, Output> | LiveQueryRequestedResult<Validated, Output>;
 
 	export interface RequestEvent<
 		Params extends AppLayoutParams<'/'> = AppLayoutParams<'/'>,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,6 +235,9 @@ importers:
       '@sveltejs/kit':
         specifier: workspace:^
         version: link:../kit
+      '@types/deno':
+        specifier: ^2.7.0
+        version: 2.7.0
       '@types/node':
         specifier: 'catalog:'
         version: 22.19.19
@@ -2826,6 +2829,9 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/deno@2.7.0':
+    resolution: {integrity: sha512-Y6fWcV8KpYeO3Lik/RiYnUxtr/LWqoeACciU0CA+dr1U/45tGgaX3HWQQAPCNN53raN4Rr4Fht4y6qsUH57fDA==}
+
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
@@ -5406,6 +5412,8 @@ snapshots:
       '@types/node': 22.19.19
 
   '@types/deep-eql@4.0.2': {}
+
+  '@types/deno@2.7.0': {}
 
   '@types/esrecurse@4.3.1': {}
 


### PR DESCRIPTION
Change split out from https://github.com/sveltejs/kit/pull/16464

It's pretty common to pass `process.env` into `server.init({ env: process.env })` but it's typed as `Record<string, string | undefined>`. So this PR loosens the type so we don't need to cast it everytime. It also adds Deno globals to the netlify edge handler so we can get the type safety there.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
