### PR TITLE
chore: add type checking to playground vite config

### DIFF
--- a/playgrounds/basic/package.json
+++ b/playgrounds/basic/package.json
@@ -8,7 +8,7 @@
 		"preview": "vite preview",
 		"package": "svelte-kit sync && svelte-package && publint",
 		"prepare": "svelte-kit sync",
-		"prepublishOnly": "npm run package",
+		"prepublishOnly": "pnpm run package",
 		"check": "svelte-kit sync && svelte-check",
 		"check:watch": "svelte-kit sync && svelte-check --watch",
 		"format": "prettier --config ../../.prettierrc --write .",
@@ -50,6 +50,7 @@
 	"svelte": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"imports": {
+		"#lib": "./src/lib/index.js",
 		"#lib/*": "./src/lib/*"
 	}
 }

--- a/playgrounds/basic/tsconfig.json
+++ b/playgrounds/basic/tsconfig.json
@@ -1,5 +1,5 @@
 {
 	"extends": "$app/tsconfig",
-	"include": ["src"],
+	"include": ["src", "vite.config.js"],
 	"exclude": ["src/service-worker"]
 }

--- a/playgrounds/basic/vite.config.js
+++ b/playgrounds/basic/vite.config.js
@@ -1,8 +1,9 @@
 import { enhancedImages } from '@sveltejs/enhanced-img';
 import { sveltekit } from '@sveltejs/kit/vite';
 import adapter from '@sveltejs/adapter-node';
+import { defineConfig } from 'vite';
 
-export default {
+export default defineConfig({
 	plugins: [
 		enhancedImages(),
 		sveltekit({
@@ -23,4 +24,4 @@ export default {
 			allow: ['../../packages/kit']
 		}
 	}
-};
+});


### PR DESCRIPTION
Some playground chores:
- gets rid of the eslint error on the vite config file
- adds autocomplete for vite config settings
- adds the same `#lib` settings from the sveltekit 3 docs