### PR TITLE
chore: require form and error in the Props constructor

### DIFF
--- a/.changeset/thick-melons-invent.md
+++ b/.changeset/thick-melons-invent.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+chore: require `form` and `error` in the `Props` constructor

--- a/.changeset/thick-melons-invent.md
+++ b/.changeset/thick-melons-invent.md
@@ -1,5 +1,0 @@
----
-'@sveltejs/kit': patch
----
-
-chore: require `form` and `error` in the `Props` constructor

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -374,7 +374,7 @@ let invalidation_token;
 const preload_tokens = new Set();
 
 /** @type {Promise<void> | null} */
-export let pending_invalidate;
+let pending_invalidate;
 
 /**
  * @type {Map<string, Map<string, CacheEntry<Query<any>>>>}
@@ -477,7 +477,7 @@ async function _start(_app, _target, data) {
 
 	const tree = new RenderNode(root_layout.component, root_error.component);
 
-	props = new Props(page, tree, (_, reset) => resetters.add(reset));
+	props = new Props(page, tree, undefined, undefined, (_, reset) => resetters.add(reset));
 
 	const history_metadata = get_history_metadata();
 	current_history_index = history_metadata?.historyIndex ?? 0;

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -477,7 +477,13 @@ async function _start(_app, _target, data) {
 
 	const tree = new RenderNode(root_layout.component, root_error.component);
 
-	props = new Props(page, tree, undefined, undefined, (_, reset) => resetters.add(reset));
+	props = new Props({
+		page,
+		tree,
+		form: undefined,
+		error: undefined,
+		onerror: (_, reset) => resetters.add(reset)
+	});
 
 	const history_metadata = get_history_metadata();
 	current_history_index = history_metadata?.historyIndex ?? 0;

--- a/packages/kit/src/runtime/props.svelte.js
+++ b/packages/kit/src/runtime/props.svelte.js
@@ -28,14 +28,15 @@ export class Props {
 	onerror;
 
 	/**
-	 * Every prop must be passed here so a construction site cannot silently omit a new field
-	 * @param {Page} page
-	 * @param {RenderNode} tree
-	 * @param {any} form
-	 * @param {App.Error | undefined} error
-	 * @param {(error: unknown, reset: () => void) => void} onerror
+	 * @param {{
+	 *   page: Page;
+	 *   tree: RenderNode;
+	 *   form: any;
+	 *   error: App.Error | undefined;
+	 *   onerror?: (error: unknown, reset: () => void) => void;
+	 * }} props
 	 */
-	constructor(page, tree, form, error, onerror = noop) {
+	constructor({ page, tree, form, error, onerror = noop }) {
 		this.page = page;
 		this.tree = tree;
 		this.onerror = onerror;

--- a/packages/kit/src/runtime/props.svelte.js
+++ b/packages/kit/src/runtime/props.svelte.js
@@ -28,17 +28,20 @@ export class Props {
 	onerror;
 
 	/**
+	 * Every prop must be passed here so a construction site cannot silently omit a new field
 	 * @param {Page} page
 	 * @param {RenderNode} tree
+	 * @param {any} form
+	 * @param {App.Error | undefined} error
 	 * @param {(error: unknown, reset: () => void) => void} onerror
 	 */
-	constructor(page, tree, onerror = noop) {
+	constructor(page, tree, form, error, onerror = noop) {
 		this.page = page;
 		this.tree = tree;
 		this.onerror = onerror;
 
-		this.form = $state.raw();
-		this.error = $state.raw();
+		this.form = $state.raw(form);
+		this.error = $state.raw(error);
 	}
 }
 

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -147,16 +147,16 @@ export async function render_response({
 			state: {}
 		};
 
-		const props = new Props(
+		const props = new Props({
 			page,
-			new RenderNode(
+			tree: new RenderNode(
 				// TODO tidy up
 				/** @type {Component} */ (await branch[0].node.component?.()),
 				/** @type {Component} */ (error_components?.[1])
 			),
-			form_value,
-			error ?? undefined
-		);
+			form: form_value,
+			error: error ?? undefined
+		});
 
 		let current_node = props.tree;
 		let data = props.page.data;

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -153,11 +153,10 @@ export async function render_response({
 				// TODO tidy up
 				/** @type {Component} */ (await branch[0].node.component?.()),
 				/** @type {Component} */ (error_components?.[1])
-			)
+			),
+			form_value,
+			error ?? undefined
 		);
-
-		props.form = form_value;
-		props.error = error ?? undefined;
 
 		let current_node = props.tree;
 		let data = props.page.data;


### PR DESCRIPTION
`props.form` and `props.error` were each missed on the SSR side during review of #16547 and fixed in follow-up commits. Passing them through the constructor makes the next missed one a type error instead of a silent `undefined` in the rendered page.

`pending_invalidate` lost its `export` since nothing imports it.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
