### PR TITLE
Allows dot character in Kitconfig.paths.base.

### DIFF
--- a/.changeset/ripe-friends-know.md
+++ b/.changeset/ripe-friends-know.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: Allows dot for relative base paths in static pre-renders

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -180,9 +180,9 @@ export const validate_kit_options = object({
 		base: validate('', (input, keypath) => {
 			assert_string(input, keypath);
 
-			if (input !== '' && (input.endsWith('/') || !input.startsWith('/'))) {
+			if (input !== '.' && input !== '' && (input.endsWith('/') || !input.startsWith('/'))) {
 				throw new Error(
-					`${keypath} option must either be the empty string or a root-relative path that starts but doesn't end with '/'. See https://svelte.dev/docs/kit/configuration#paths`
+					`${keypath} option must either be the empty string, a dot for relative paths in prerendered/static site generation or a root-relative path that starts but doesn't end with '/'. See https://svelte.dev/docs/kit/configuration#paths`
 				);
 			}
 

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -647,10 +647,14 @@ export interface KitConfig {
 		 */
 		assets?: '' | `http://${string}` | `https://${string}`;
 		/**
-		 * A root-relative path that must start, but not end with `/` (e.g. `/base-path`), unless it is the empty string. This specifies where your app is served from and allows the app to live on a non-root path. Note that you need to prepend all your root-relative links with the base value or they will point to the root of your domain, not your `base` (this is how the browser works). You can use [`resolve(...)` from `$app/paths`](https://svelte.dev/docs/kit/$app-paths#resolve) for that: `<a href="{resolve('/your-page')}">Link</a>`. If you find yourself writing this often, it may make sense to extract this into a reusable component.
+		 * A path that must either:
+		 *   * Be an empty string
+		 *   * Be a dot character (i.e., `.`) to indicate paths relative from the deploy directory when generating a static site via prerendering.
+		 *   * Start, but not end with `/` (e.g. `/base-path`)
+		 * This specifies where your app is served from and allows the app to live on a non-root path. Note that you need to prepend all your root-relative links with the base value or they will point to the root of your domain, not your `base` (this is how the browser works). You can use [`resolve(...)` from `$app/paths`](https://svelte.dev/docs/kit/$app-paths#resolve) for that: `<a href="{resolve('/your-page')}">Link</a>`. If you find yourself writing this often, it may make sense to extract this into a reusable component.
 		 * @default ""
 		 */
-		base?: '' | `/${string}`;
+		base?: '' | '.' | `/${string}`;
 		/**
 		 * The origin of your app, used for CSRF protection and prerendering.
 		 *

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -619,10 +619,14 @@ declare module '@sveltejs/kit' {
 			 */
 			assets?: '' | `http://${string}` | `https://${string}`;
 			/**
-			 * A root-relative path that must start, but not end with `/` (e.g. `/base-path`), unless it is the empty string. This specifies where your app is served from and allows the app to live on a non-root path. Note that you need to prepend all your root-relative links with the base value or they will point to the root of your domain, not your `base` (this is how the browser works). You can use [`resolve(...)` from `$app/paths`](https://svelte.dev/docs/kit/$app-paths#resolve) for that: `<a href="{resolve('/your-page')}">Link</a>`. If you find yourself writing this often, it may make sense to extract this into a reusable component.
+			 * A path that must either:
+			 *   * Be an empty string
+			 *   * Be a dot character (i.e., `.`) to indicate paths relative from the deploy directory when generating a static site via prerendering.
+			 *   * Start, but not end with `/` (e.g. `/base-path`)
+			 * This specifies where your app is served from and allows the app to live on a non-root path. Note that you need to prepend all your root-relative links with the base value or they will point to the root of your domain, not your `base` (this is how the browser works). You can use [`resolve(...)` from `$app/paths`](https://svelte.dev/docs/kit/$app-paths#resolve) for that: `<a href="{resolve('/your-page')}">Link</a>`. If you find yourself writing this often, it may make sense to extract this into a reusable component.
 			 * @default ""
 			 */
-			base?: '' | `/${string}`;
+			base?: '' | '.' | `/${string}`;
 			/**
 			 * The origin of your app, used for CSRF protection and prerendering.
 			 *
@@ -3494,9 +3498,9 @@ declare module '$app/server' {
 		 *
 		 * */
 		function live<Output>(fn: (arg: void) => RemoteLiveQueryUserFunctionReturnType<Output>): RemoteLiveQueryFunction<void, Output>;
-		
+
 		function live<Input, Output>(validate: "unchecked", fn: (arg: Input) => RemoteLiveQueryUserFunctionReturnType<Output>): RemoteLiveQueryFunction<Input, Output>;
-		
+
 		function live<Schema extends StandardSchemaV1, Output>(schema: Schema, fn: (arg: StandardSchemaV1.InferOutput<Schema>) => RemoteLiveQueryUserFunctionReturnType<Output>): RemoteLiveQueryFunction<StandardSchemaV1.InferInput<Schema>, Output, StandardSchemaV1.InferOutput<Schema>>;
 	}
 	/**


### PR DESCRIPTION
closes #9569<!-- Add the related issue number here. Repeat this line for each additional issue it closes -->

<!-- Explain the goal of the PR, why it is needed, and what has been changed to achieve that goal -->
Allows transpiled entries and chunks to be referenced using relative paths when using pre-rendering to generate a static site.

E.g., note the dot part of `./_app` in these snippets from a generated index.html:
```
<link href="./_app/immutable/entry/start.Czdh_m5m.js" rel="modulepreload">
<link href="./_app/immutable/chunks/yENhGqzA.js" rel="modulepreload">
<link href="./_app/immutable/chunks/4oHaMe2k.js" rel="modulepreload">
<link href="./_app/immutable/entry/app.BBwLnysR.js" rel="modulepreload">
<link href="./_app/immutable/chunks/DYl5dUZ5.js" rel="modulepreload">
<link href="./_app/immutable/chunks/xihTtKlq.js" rel="modulepreload">
<link href="./_app/immutable/nodes/0.CIik5BuF.js" rel="modulepreload">
```
```
					Promise.all([
						import("./_app/immutable/entry/start.Czdh_m5m.js"),
						import("./_app/immutable/entry/app.BBwLnysR.js")
					]).then(([kit, app]) => {
						kit.start(app, element);
					});
```

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
