### PR TITLE
fix: preserve remote function types in svelte-package

### DIFF
--- a/.changeset/remote-function-package-types.md
+++ b/.changeset/remote-function-package-types.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/package': patch
+---
+
+fix: preserve remote function types when packaging SvelteKit libraries

--- a/packages/package/src/filesystem.js
+++ b/packages/package/src/filesystem.js
@@ -22,6 +22,16 @@ export function posixify(str) {
 }
 
 /**
+ * Like `path.relative`, but always posixified and with a leading `./` if necessary.
+ * @param {string} from
+ * @param {string} to
+ */
+export function relative_path(from, to) {
+	const result = posixify(path.relative(from, to));
+	return result.startsWith('.') ? result : `./${result}`;
+}
+
+/**
  * Get a list of all files in a directory
  * @param {string} cwd - the directory to walk
  * @param {boolean} [dirs] - whether to include directories in the result

--- a/packages/package/src/index.js
+++ b/packages/package/src/index.js
@@ -60,6 +60,16 @@ async function do_build(options, analyse_code) {
 		);
 	}
 
+	// Temporary tsconfigs can cause declaration emit to mirror the temp path inside itself.
+	const relative_temp = path.relative(options.cwd, temp);
+	const nested_temp_root =
+		relative_temp && !relative_temp.startsWith('..') && !path.isAbsolute(relative_temp)
+			? path.join(temp, relative_temp.split(path.sep)[0])
+			: undefined;
+	if (nested_temp_root && nested_temp_root !== temp && fs.existsSync(nested_temp_root)) {
+		rimraf(nested_temp_root);
+	}
+
 	if (!options.preserve_output) {
 		rimraf(output);
 	}

--- a/packages/package/src/typescript.js
+++ b/packages/package/src/typescript.js
@@ -191,14 +191,14 @@ function find_config_file(input, tsconfig, ts) {
 }
 
 /**
+ * Returns true when `child` is nested inside `parent`.
+ *
  * @param {string} parent
  * @param {string} child
  */
 function is_subpath(parent, child) {
 	const relative = path.relative(parent, child);
-	return (
-		relative === '' || (!!relative && !relative.startsWith('..') && !path.isAbsolute(relative))
-	);
+	return !!relative && !relative.startsWith('..') && !path.isAbsolute(relative);
 }
 
 /**

--- a/packages/package/src/typescript.js
+++ b/packages/package/src/typescript.js
@@ -35,14 +35,23 @@ export async function emit_dts(input, output, final_output, cwd, alias, files, t
 		// Not all version specs are valid semver, e.g. "latest" or "next" or catalog references
 		no_svelte_3 = true;
 	}
-	await emitDts({
-		libRoot: input,
-		svelteShimsPath: no_svelte_3
-			? require.resolve('svelte2tsx/svelte-shims-v4.d.ts')
-			: require.resolve('svelte2tsx/svelte-shims.d.ts'),
-		declarationDir: path.relative(cwd, tmp),
-		tsconfig
-	});
+	const svelte_shims_path = no_svelte_3
+		? require.resolve('svelte2tsx/svelte-shims-v4.d.ts')
+		: require.resolve('svelte2tsx/svelte-shims.d.ts');
+	const package_tsconfig = await create_package_tsconfig(input, cwd, files, tsconfig);
+
+	try {
+		await emitDts({
+			libRoot: input,
+			svelteShimsPath: svelte_shims_path,
+			declarationDir: path.relative(cwd, tmp),
+			tsconfig: package_tsconfig ?? tsconfig
+		});
+	} finally {
+		if (package_tsconfig) {
+			fs.rmSync(package_tsconfig, { force: true });
+		}
+	}
 
 	const handwritten = new Set();
 
@@ -86,6 +95,110 @@ export async function emit_dts(input, output, final_output, cwd, alias, files, t
 	}
 
 	rimraf(tmp);
+}
+
+/**
+ * @param {string} input
+ * @param {string} cwd
+ * @param {import('./types.js').File[]} files
+ * @param {string | undefined} tsconfig
+ */
+async function create_package_tsconfig(input, cwd, files, tsconfig) {
+	const app_types = path.join(cwd, 'node_modules/$app/types/index.d.ts');
+
+	if (!fs.existsSync(app_types) || !uses_app_server(input, files)) {
+		return;
+	}
+
+	const ts = await try_load_ts();
+	const config_filename = find_config_file(input, tsconfig, ts);
+
+	if (!config_filename) {
+		return;
+	}
+
+	const { error, config } = ts.readConfigFile(config_filename, ts.sys.readFile);
+
+	if (error) {
+		return;
+	}
+
+	const { options } = ts.parseJsonConfigFileContent(
+		config,
+		ts.sys,
+		path.dirname(config_filename),
+		{ sourceMap: false },
+		config_filename
+	);
+	const types = Array.from(new Set([...(options.types ?? []), '$app/types']));
+	const relative_config = posixify(path.relative(cwd, config_filename));
+	const package_tsconfig = path.join(
+		cwd,
+		`.svelte-package-${Date.now()}-${Math.random().toString(16).slice(2)}.json`
+	);
+
+	write(
+		package_tsconfig,
+		JSON.stringify(
+			{
+				extends: relative_config.startsWith('.') ? relative_config : `./${relative_config}`,
+				compilerOptions: { types }
+			},
+			null,
+			'\t'
+		)
+	);
+
+	return package_tsconfig;
+}
+
+/**
+ * @param {string} input
+ * @param {import('./types.js').File[]} files
+ */
+function uses_app_server(input, files) {
+	return files.some((file) => {
+		if (!file.is_svelte && !/\.[cm]?[jt]s$/.test(file.name)) {
+			return false;
+		}
+
+		return fs.readFileSync(path.join(input, file.name), 'utf8').includes('$app/server');
+	});
+}
+
+/**
+ * @param {string} input
+ * @param {string | undefined} tsconfig
+ * @param {import('typescript')} ts
+ */
+function find_config_file(input, tsconfig, ts) {
+	if (tsconfig) {
+		return fs.existsSync(tsconfig) ? tsconfig : undefined;
+	}
+
+	const jsconfig_file = ts.findConfigFile(input, ts.sys.fileExists, 'jsconfig.json');
+	const tsconfig_file = ts.findConfigFile(input, ts.sys.fileExists, 'tsconfig.json');
+
+	if (!tsconfig_file) {
+		return jsconfig_file;
+	}
+
+	if (jsconfig_file && is_subpath(path.dirname(tsconfig_file), path.dirname(jsconfig_file))) {
+		return jsconfig_file;
+	}
+
+	return tsconfig_file;
+}
+
+/**
+ * @param {string} parent
+ * @param {string} child
+ */
+function is_subpath(parent, child) {
+	const relative = path.relative(parent, child);
+	return (
+		relative === '' || (!!relative && !relative.startsWith('..') && !path.isAbsolute(relative))
+	);
 }
 
 /**

--- a/packages/package/src/typescript.js
+++ b/packages/package/src/typescript.js
@@ -2,7 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { createRequire } from 'node:module';
 import semver from 'semver';
-import { posixify, mkdirp, rimraf, walk } from './filesystem.js';
+import { posixify, relative_path, mkdirp, rimraf, walk } from './filesystem.js';
 import { resolve_aliases, write } from './utils.js';
 import { emitDts } from 'svelte2tsx';
 import { load_pkg_json } from './config.js';
@@ -45,7 +45,7 @@ export async function emit_dts(input, output, final_output, cwd, alias, files, t
 			libRoot: input,
 			svelteShimsPath: svelte_shims_path,
 			declarationDir: path.relative(cwd, tmp),
-			tsconfig: package_tsconfig ?? tsconfig
+			tsconfig: package_tsconfig ? path.basename(package_tsconfig) : tsconfig
 		});
 	} finally {
 		if (package_tsconfig) {
@@ -104,9 +104,7 @@ export async function emit_dts(input, output, final_output, cwd, alias, files, t
  * @param {string | undefined} tsconfig
  */
 async function create_package_tsconfig(input, cwd, files, tsconfig) {
-	const app_types = path.join(cwd, 'node_modules/$app/types/index.d.ts');
-
-	if (!fs.existsSync(app_types) || !uses_app_server(input, files)) {
+	if (!uses_app_server(input, files)) {
 		return;
 	}
 
@@ -130,8 +128,16 @@ async function create_package_tsconfig(input, cwd, files, tsconfig) {
 		{ sourceMap: false },
 		config_filename
 	);
-	const types = Array.from(new Set([...(options.types ?? []), '$app/types']));
-	const relative_config = posixify(path.relative(cwd, config_filename));
+	const types = Array.from(
+		new Set([
+			...(options.types ?? []).map((type) => {
+				if (!type.startsWith('.')) return type;
+				return relative_path(cwd, path.resolve(path.dirname(config_filename), type));
+			}),
+			'@sveltejs/kit'
+		])
+	);
+	const relative_config = relative_path(cwd, config_filename);
 	const package_tsconfig = path.join(
 		cwd,
 		`.svelte-package-${Date.now()}-${Math.random().toString(16).slice(2)}.json`
@@ -141,7 +147,7 @@ async function create_package_tsconfig(input, cwd, files, tsconfig) {
 		package_tsconfig,
 		JSON.stringify(
 			{
-				extends: relative_config.startsWith('.') ? relative_config : `./${relative_config}`,
+				extends: relative_config,
 				compilerOptions: { types }
 			},
 			null,

--- a/packages/package/test/fixtures/svelte-kit-relative-types/jsconfig.json
+++ b/packages/package/test/fixtures/svelte-kit-relative-types/jsconfig.json
@@ -1,0 +1,5 @@
+{
+	"compilerOptions": {
+		"types": ["./types"]
+	}
+}

--- a/packages/package/test/fixtures/svelte-kit-relative-types/types/index.d.ts
+++ b/packages/package/test/fixtures/svelte-kit-relative-types/types/index.d.ts
@@ -1,0 +1,5 @@
+declare global {
+	const remoteFunctionFixtureType: string;
+}
+
+export {};

--- a/packages/package/test/fixtures/svelte-kit/expected/index.d.ts
+++ b/packages/package/test/fixtures/svelte-kit/expected/index.d.ts
@@ -1,1 +1,2 @@
 export { default as Test } from './Test.svelte';
+export { getCustomEndpoint } from './remote-query.remote.js';

--- a/packages/package/test/fixtures/svelte-kit/expected/index.js
+++ b/packages/package/test/fixtures/svelte-kit/expected/index.js
@@ -1,1 +1,2 @@
 export { default as Test } from './Test.svelte';
+export { getCustomEndpoint } from './remote-query.remote.js';

--- a/packages/package/test/fixtures/svelte-kit/expected/remote-query.remote.d.ts
+++ b/packages/package/test/fixtures/svelte-kit/expected/remote-query.remote.d.ts
@@ -1,0 +1,6 @@
+export const getCustomEndpoint: import('@sveltejs/kit').RemoteQueryFunction<
+	void,
+	{
+		message: string;
+	}
+>;

--- a/packages/package/test/fixtures/svelte-kit/expected/remote-query.remote.js
+++ b/packages/package/test/fixtures/svelte-kit/expected/remote-query.remote.js
@@ -1,0 +1,5 @@
+import { query } from '$app/server';
+
+export const getCustomEndpoint = query(() => {
+	return { message: 'remote response' };
+});

--- a/packages/package/test/fixtures/svelte-kit/package.json
+++ b/packages/package/test/fixtures/svelte-kit/package.json
@@ -5,6 +5,7 @@
 	"type": "module",
 	"description": "SvelteKit library project",
 	"peerDependencies": {
+		"@sveltejs/kit": "^3.0.0",
 		"svelte": "^4.0.0"
 	},
 	"imports": {

--- a/packages/package/test/fixtures/svelte-kit/src/kitlib/index.js
+++ b/packages/package/test/fixtures/svelte-kit/src/kitlib/index.js
@@ -1,1 +1,2 @@
 export { default as Test } from './Test.svelte';
+export { getCustomEndpoint } from './remote-query.remote.js';

--- a/packages/package/test/fixtures/svelte-kit/src/kitlib/remote-query.remote.js
+++ b/packages/package/test/fixtures/svelte-kit/src/kitlib/remote-query.remote.js
@@ -1,0 +1,5 @@
+import { query } from '$app/server';
+
+export const getCustomEndpoint = query(() => {
+	return { message: 'remote response' };
+});

--- a/packages/package/test/index.spec.js
+++ b/packages/package/test/index.spec.js
@@ -166,7 +166,10 @@ test('create package with SvelteComponentTyped for backwards compatibility', asy
 
 test('Custom lib folder with #lib import', async () => {
 	const cwd = join(import.meta.dirname, 'fixtures', 'svelte-kit');
-	await test_make_package('svelte-kit', { input: resolve(cwd, 'src/kitlib') });
+	await test_make_package('svelte-kit', {
+		input: resolve(cwd, 'src/kitlib'),
+		tsconfig: '../svelte-kit-relative-types/jsconfig.json'
+	});
 });
 
 test('create package with declaration map', async () => {


### PR DESCRIPTION
closes #14409

This updates `svelte-package` declaration emit so SvelteKit library packages that export remote functions from custom lib folders still resolve generated `$app/types` during `.d.ts` generation.

Without that ambient module in the emitter program, `query(...)` exports from `$app/server` can be emitted as `any` unless user code adds a manual `@sveltejs/kit` type import. The fix creates a temporary tsconfig wrapper only when package sources import `$app/server` and generated `$app/types` is available, preserving the user config while appending `$app/types` for declaration emit.

The package fixture now covers a custom lib export of a remote query and expects the generated declaration to preserve `RemoteQueryFunction`.

Disclosure: This PR was prepared with AI assistance under human direction and review.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

Focused checks on the rebased branch:
- `pnpm --dir packages/package test`
- `pnpm --dir packages/package check`
- `pnpm --dir packages/package lint`

I also ran `pnpm lint` and `pnpm check` after rebasing. Both currently fail on the latest `version-3` base because `packages/kit/src/runtime/client/client.js` declares unused `warned_on_reset`; this branch does not change that file.

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.