### PR TITLE
chore: only check non-build files

### DIFF
--- a/packages/kit/test/prerendering/basics/tsconfig.json
+++ b/packages/kit/test/prerendering/basics/tsconfig.json
@@ -4,5 +4,6 @@
 		"checkJs": true,
 		"noEmit": true
 	},
+	"include": ["src", "test", "vite.config.js", "globalSetup.js"],
 	"extends": "$app/tsconfig"
 }

--- a/packages/kit/test/prerendering/options/tsconfig.json
+++ b/packages/kit/test/prerendering/options/tsconfig.json
@@ -4,5 +4,6 @@
 		"checkJs": true,
 		"noEmit": true
 	},
+	"include": ["src", "test", "vite.config.js"],
 	"extends": "$app/tsconfig"
 }

--- a/packages/kit/test/prerendering/paths-base/tsconfig.json
+++ b/packages/kit/test/prerendering/paths-base/tsconfig.json
@@ -4,5 +4,6 @@
 		"checkJs": true,
 		"noEmit": true
 	},
+	"include": ["src", "test", "vite.config.js"],
 	"extends": "$app/tsconfig"
 }


### PR DESCRIPTION
We need to specify `include` for the prerendering test apps otherwise they type check the build output too. This fixes svelte-ecosystem-ci which is currently timing out because it has to type check all the build output files.