### PR TITLE
docs: explain what happens when navigating back to a shallow entry

### DIFF
--- a/documentation/docs/30-advanced/67-shallow-routing.md
+++ b/documentation/docs/30-advanced/67-shallow-routing.md
@@ -69,7 +69,7 @@ Once shallow routing is active, `page.shallow` becomes a `{ url, params, route }
 
 A regular `goto` call without `shallow: true`, or a standard link click, exits shallow routing.
 
-Navigating back or forward to a shallow entry restores its `page.state`, and `page.shallow` again describes the entry's URL. `page.url` continues to describe the page that renders, which is the one the user was on when `goto` was called. To have the visible URL drive `load`, call `goto` without `shallow: true`.
+Navigating back or forward to a shallow entry restores its `page.state` and `page.shallow`. The rendered page, and therefore `page.url`, is still the one the user was on when `goto` was called. To navigate to the visible URL, call `goto(page.shallow.url)` without `shallow: true`.
 
 > [!LEGACY]
 > In SvelteKit 2 this functionality was achieved using `pushState` and `replaceState`, which are now deprecated. Use `goto` with `shallow: true` instead, and use the `replace` option when replacing the current history entry.

--- a/documentation/docs/30-advanced/67-shallow-routing.md
+++ b/documentation/docs/30-advanced/67-shallow-routing.md
@@ -69,6 +69,8 @@ Once shallow routing is active, `page.shallow` becomes a `{ url, params, route }
 
 A regular `goto` call without `shallow: true`, or a standard link click, exits shallow routing.
 
+Navigating back or forward to a shallow entry restores its `page.state`, and `page.shallow` again describes the entry's URL. `page.url` continues to describe the page that renders, which is the one the user was on when `goto` was called. To have the visible URL drive `load`, call `goto` without `shallow: true`.
+
 > [!LEGACY]
 > In SvelteKit 2 this functionality was achieved using `pushState` and `replaceState`, which are now deprecated. Use `goto` with `shallow: true` instead, and use the `replace` option when replacing the current history entry.
 


### PR DESCRIPTION
Going back or forward to a shallow entry restores the state and renders the page you were on when you called `goto`, while the address bar keeps the pushed URL. The page documents that split for the live case and for reloads, but not for back/forward, which is where #11465, #11503 and #11671 all landed.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
  * #11465
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
  * docs only

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
  * docs only

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
  * docs only

### Edits
- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
