### PR TITLE
fix: expand escape sequences when resolving a route id to a pathname

### DIFF
--- a/.changeset/resolve-route-escape-sequences.md
+++ b/.changeset/resolve-route-escape-sequences.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: expand `[x+nn]` and `[u+nnnn]` escape sequences when resolving a route id to a pathname

--- a/packages/kit/src/utils/routing.js
+++ b/packages/kit/src/utils/routing.js
@@ -4,6 +4,16 @@ const param_pattern = /^(\[)?(\.\.\.)?([\w-]+)(?:=([\w-]+))?(\])?$/;
 
 const root_group_pattern = /^\/\((?:[^)]+)\)$/;
 
+const escape_sequence_pattern = /\[([ux])\+([^\]]+)\]/;
+
+/**
+ * Decodes the codepoints of an `[x+nn]` or `[u+nnnn]` escape sequence
+ * @param {string} code the sequence without its `[x+`/`[u+` prefix or `]` suffix
+ */
+function decode_escape_sequence(code) {
+	return String.fromCharCode(...code.split('-').map((codepoint) => parseInt(codepoint, 16)));
+}
+
 /**
  * Creates the regex pattern, extracts parameter names, and generates types for a route
  * @param {string} id
@@ -51,19 +61,8 @@ export function parse_route_id(id) {
 							const result = parts
 								.map((content, i) => {
 									if (i % 2) {
-										if (content.startsWith('x+')) {
-											return escape(String.fromCharCode(parseInt(content.slice(2), 16)));
-										}
-
-										if (content.startsWith('u+')) {
-											return escape(
-												String.fromCharCode(
-													...content
-														.slice(2)
-														.split('-')
-														.map((code) => parseInt(code, 16))
-												)
-											);
+										if (content.startsWith('x+') || content.startsWith('u+')) {
+											return escape(decode_escape_sequence(content.slice(2)));
 										}
 
 										// We know the match cannot be null in the browser because manifest generation
@@ -262,6 +261,13 @@ function escape(str) {
 
 const basic_param_pattern = /\[(\[)?(\.\.\.)?([\w-]+?)(?:=([\w-]+))?\]\]?/g;
 
+// escape sequences are expanded in the same pass as the params, so that a param
+// value containing `[x+2f]` is not itself expanded
+const segment_pattern = new RegExp(
+	`${escape_sequence_pattern.source}|${basic_param_pattern.source}`,
+	'g'
+);
+
 /**
  * Populate a route ID with params to resolve a pathname.
  * @example
@@ -286,7 +292,9 @@ export function resolve_route(id, params) {
 		'/' +
 		segments
 			.map((segment) =>
-				segment.replace(basic_param_pattern, (_, optional, rest, name) => {
+				segment.replace(segment_pattern, (_, escape_type, escape_code, optional, rest, name) => {
+					if (escape_type) return decode_escape_sequence(escape_code);
+
 					const value = params[name];
 
 					if (value === undefined || value === '') {

--- a/packages/kit/src/utils/routing.js
+++ b/packages/kit/src/utils/routing.js
@@ -15,6 +15,18 @@ function decode_escape_sequence(code) {
 }
 
 /**
+ * Encodes the characters that `decode_pathname` leaves untouched, so that a decoded
+ * escape sequence still matches the pattern `parse_route_id` builds for it
+ * @param {string} str
+ */
+function encode_pathname_chars(str) {
+	return str.replace(
+		/[%/?#]/g,
+		(char) => '%' + char.charCodeAt(0).toString(16).toUpperCase().padStart(2, '0')
+	);
+}
+
+/**
  * Creates the regex pattern, extracts parameter names, and generates types for a route
  * @param {string} id
  */
@@ -293,7 +305,7 @@ export function resolve_route(id, params) {
 		segments
 			.map((segment) =>
 				segment.replace(segment_pattern, (_, escape_type, escape_code, optional, rest, name) => {
-					if (escape_type) return decode_escape_sequence(escape_code);
+					if (escape_type) return encode_pathname_chars(decode_escape_sequence(escape_code));
 
 					const value = params[name];
 

--- a/packages/kit/src/utils/routing.spec.js
+++ b/packages/kit/src/utils/routing.spec.js
@@ -461,6 +461,21 @@ describe('resolve_route', () => {
 			route: '/[...catch-all=some-matcher]',
 			params: { 'catch-all': 'a/b' },
 			expected: '/a/b'
+		},
+		{
+			route: '/[x+2e]well-known/[one]',
+			params: { one: 'one' },
+			expected: '/.well-known/one'
+		},
+		{
+			route: '/[u+0041]/[one]',
+			params: { one: 'one' },
+			expected: '/A/one'
+		},
+		{
+			route: '/blog/[one]',
+			params: { one: '[x+2f]' },
+			expected: '/blog/[x+2f]'
 		}
 	];
 

--- a/packages/kit/src/utils/routing.spec.js
+++ b/packages/kit/src/utils/routing.spec.js
@@ -476,6 +476,16 @@ describe('resolve_route', () => {
 			route: '/blog/[one]',
 			params: { one: '[x+2f]' },
 			expected: '/blog/[x+2f]'
+		},
+		{
+			route: '/[x+2f]/[one]',
+			params: { one: 'one' },
+			expected: '/%2F/one'
+		},
+		{
+			route: '/[x+23]/[one]',
+			params: { one: 'one' },
+			expected: '/%23/one'
 		}
 	];
 


### PR DESCRIPTION
`resolve('/[x+2e]well-known')` returns the route id verbatim instead of `/.well-known`, so a pathname built from an escaped route id does not match the route it came from. `parse_route_id` has expanded `[x+nn]` and `[u+nnnn]` since #7644, but `resolve_route` never has, because `basic_param_pattern` cannot match `x+2e`.

The expansion happens in the same pass as the params rather than a second pass over the result, so a param value that itself contains `[x+2f]` is left alone.

`parse_route_id` output is unchanged. Its `x+` and `u+` branches were already equivalent, since splitting a two character code on `-` is a no-op.
