### PR TITLE
breaking: refresh all load functions/queries when clicking a link to the current URL

### DIFF
--- a/.changeset/breezy-bananas-divide.md
+++ b/.changeset/breezy-bananas-divide.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': major
+---
+
+breaking: refresh all load functions/queries when clicking a link to the current URL

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -661,7 +661,7 @@ function persist_state() {
 
 /**
  * @param {string | URL} url
- * @param {{ type?: import('@sveltejs/kit').NavigationType; replace?: boolean; reset?: boolean; refreshAll?: boolean; invalidate?: Array<string | URL | ((url: URL) => boolean)>; state?: Record<string, any>; persistState?: boolean }} [options]
+ * @param {{ type?: import('@sveltejs/kit').NavigationType; replace?: boolean; reset?: boolean; refreshAll?: boolean; invalidate?: Array<string | URL | ((url: URL) => boolean)>; state?: Record<string, any>; persistState?: boolean; event?: Event }} [options]
  * @param {number} [redirect_count]
  * @param {{}} [nav_token]
  * @param {NavigationIntent | undefined} [intent] navigation intent, when already known by the caller (avoids recomputing it)
@@ -686,6 +686,7 @@ export async function _goto(url, options = {}, redirect_count = 0, nav_token = {
 		replace_state: options.replace,
 		state: options.state,
 		persist_state: options.persistState,
+		event: options.event,
 		redirect_count,
 		nav_token,
 		intent,
@@ -3114,7 +3115,8 @@ function _start_router() {
 			type: 'link',
 			reset: options.reset,
 			replace: options.replace_state ?? !changed,
-			refreshAll: !changed
+			refreshAll: !changed,
+			event
 		});
 	});
 

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -661,13 +661,13 @@ function persist_state() {
 
 /**
  * @param {string | URL} url
- * @param {{ replace?: boolean; reset?: boolean; refreshAll?: boolean; invalidate?: Array<string | URL | ((url: URL) => boolean)>; state?: Record<string, any>; persistState?: boolean }} options
- * @param {number} redirect_count
+ * @param {{ type?: import('@sveltejs/kit').NavigationType; replace?: boolean; reset?: boolean; refreshAll?: boolean; invalidate?: Array<string | URL | ((url: URL) => boolean)>; state?: Record<string, any>; persistState?: boolean }} [options]
+ * @param {number} [redirect_count]
  * @param {{}} [nav_token]
  * @param {NavigationIntent | undefined} [intent] navigation intent, when already known by the caller (avoids recomputing it)
  * @returns {Promise<void>}
  */
-export async function _goto(url, options, redirect_count, nav_token, intent) {
+export async function _goto(url, options = {}, redirect_count = 0, nav_token = {}, intent) {
 	/** @type {Set<string>} */
 	let query_keys;
 	/** @type {Set<string>} */
@@ -680,7 +680,7 @@ export async function _goto(url, options, redirect_count, nav_token, intent) {
 	}
 
 	await navigate({
-		type: 'goto',
+		type: options.type ?? 'goto',
 		url: resolve_url(url),
 		reset: options.reset,
 		replace_state: options.replace,
@@ -1607,7 +1607,7 @@ async function load_root_error_page({ error, url, route }) {
 		// client-side navigation if the root layout loader throws a redirect while
 		// rendering the default error page
 		if (error instanceof Redirect) {
-			await _goto(new URL(error.location, location.href), {}, 0);
+			await _goto(new URL(error.location, location.href));
 			return;
 		}
 
@@ -2892,7 +2892,7 @@ export async function applyAction(result) {
 	if (result.type === 'error') {
 		await set_nearest_error_page(result.error);
 	} else if (result.type === 'redirect') {
-		await _goto(result.location, { refreshAll: true }, 0);
+		await _goto(result.location, { refreshAll: true });
 	} else {
 		page.form = result.data;
 		page.status = result.status;
@@ -3108,12 +3108,13 @@ function _start_router() {
 			setTimeout(fulfil, 100); // fallback for edge case where rAF doesn't fire because e.g. tab was backgrounded
 		});
 
-		await navigate({
+		const changed = url.href !== location.href;
+
+		await _goto(url, {
 			type: 'link',
-			url,
 			reset: options.reset,
-			replace_state: options.replace_state ?? url.href === location.href,
-			event
+			replace: options.replace_state ?? !changed,
+			refreshAll: !changed
 		});
 	});
 

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -262,13 +262,9 @@ export function form(id) {
 
 					if (response.redirect) {
 						// Use internal version to allow redirects to external URLs
-						void _goto(
-							response.redirect,
-							{
-								refreshAll: should_refresh
-							},
-							0
-						);
+						void _goto(response.redirect, {
+							refreshAll: should_refresh
+						});
 						return true;
 					}
 

--- a/packages/kit/src/runtime/client/remote-functions/prerender.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/prerender.svelte.js
@@ -100,7 +100,7 @@ export function prerender(id) {
 
 				if (result.redirect) {
 					// Use internal version to allow redirects to external URLs
-					void _goto(result.redirect, {}, 0);
+					void _goto(result.redirect);
 					return;
 				}
 

--- a/packages/kit/src/runtime/client/remote-functions/query-batch.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query-batch.svelte.js
@@ -50,7 +50,7 @@ export function query_batch(id) {
 
 						if (response.redirect) {
 							// Use internal version to allow redirects to external URLs
-							await _goto(response.redirect, {}, 0);
+							await _goto(response.redirect);
 
 							// settle all batched promises (with `undefined`, like a redirect
 							// from a non-batched query) so that callers don't hang forever

--- a/packages/kit/src/runtime/client/remote-functions/query/index.js
+++ b/packages/kit/src/runtime/client/remote-functions/query/index.js
@@ -30,7 +30,7 @@ export function query(id) {
 
 			if (result.redirect) {
 				// Use internal version to allow redirects to external URLs
-				await _goto(result.redirect, {}, 0);
+				await _goto(result.redirect);
 			}
 		});
 	};

--- a/packages/kit/src/runtime/client/remote-functions/shared.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/shared.svelte.js
@@ -197,7 +197,7 @@ export async function remote_request(url, init) {
 export async function handle_side_channel_response(response) {
 	if (response.type === 'redirect') {
 		// Use internal version to allow redirects to external URLs
-		await _goto(response.location, {}, 0);
+		await _goto(response.location);
 		throw new Redirect(307, response.location);
 	}
 

--- a/packages/kit/test/apps/async/src/routes/remote/link-refresh/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/link-refresh/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+	import { now } from './data.remote.js';
+</script>
+
+<a id="now" href="/remote/link-refresh">{await now()}</a>

--- a/packages/kit/test/apps/async/src/routes/remote/link-refresh/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/link-refresh/+page.svelte
@@ -1,5 +1,8 @@
 <script>
-	import { now } from './data.remote.js';
+	import { increment, get_count, reset } from './data.remote.js';
 </script>
 
-<a id="now" href="/remote/link-refresh">{await now()}</a>
+<button id="reset" onclick={() => reset()}>reset</button>
+<button id="increment" onclick={() => increment()}>increment</button>
+
+<a id="count" href="/remote/link-refresh">{await get_count()}</a>

--- a/packages/kit/test/apps/async/src/routes/remote/link-refresh/data.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/link-refresh/data.remote.js
@@ -1,0 +1,3 @@
+import { query } from '$app/server';
+
+export const now = query(() => Date.now());

--- a/packages/kit/test/apps/async/src/routes/remote/link-refresh/data.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/link-refresh/data.remote.js
@@ -1,3 +1,15 @@
-import { query } from '$app/server';
+import { command, query } from '$app/server';
 
-export const now = query(() => Date.now());
+let count = 0;
+
+export const reset = command(() => {
+	count = 0;
+	get_count().refresh();
+});
+
+export const increment = command(() => {
+	count += 1;
+	// don't refresh!
+});
+
+export const get_count = query(() => count);

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -33,16 +33,17 @@ test.describe('remote functions', () => {
 
 	test('clicking a link to the current page refreshes active queries', async ({ page }) => {
 		await page.goto('/remote/link-refresh');
+		await page.locator('#reset').click();
 
-		const a = page.locator('#now');
+		const a = page.locator('#count');
 
-		const t1 = /** @type {string} */ (await a.textContent());
-		await new Promise((f) => setTimeout(f, 50)); // belt and braces
+		expect(await a.textContent()).toBe('0');
+
+		await page.locator('#increment').click();
+		expect(await a.textContent()).toBe('0');
+
 		await a.click();
-		const t2 = /** @type {string} */ (await a.textContent());
-
-		expect(+t1).not.toBeNaN();
-		expect(+t2).toBeGreaterThan(+t1);
+		expect(await a.textContent()).toBe('1');
 	});
 
 	test('packages can re-export remote functions', async ({ page }) => {

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -41,8 +41,6 @@ test.describe('remote functions', () => {
 		await a.click();
 		const t2 = /** @type {string} */ (await a.textContent());
 
-		console.error({ t1, t2 });
-
 		expect(+t1).not.toBeNaN();
 		expect(+t2).toBeGreaterThan(+t1);
 	});

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -31,6 +31,22 @@ test.describe('remote functions', () => {
 		expect(response.headers()['cache-control']).toBe('private, no-store');
 	});
 
+	test('clicking a link to the current page refreshes active queries', async ({ page }) => {
+		await page.goto('/remote/link-refresh');
+
+		const a = page.locator('#now');
+
+		const t1 = /** @type {string} */ (await a.textContent());
+		await new Promise((f) => setTimeout(f, 5)); // belt and braces
+		await a.click();
+		const t2 = /** @type {string} */ (await a.textContent());
+
+		console.error({ t1, t2 });
+
+		expect(+t1).not.toBeNaN();
+		expect(+t2).toBeGreaterThan(+t1);
+	});
+
 	test('packages can re-export remote functions', async ({ page }) => {
 		await page.goto('/remote-lib');
 		await expect(page.locator('h1')).toHaveText('lib says hello');

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -37,13 +37,13 @@ test.describe('remote functions', () => {
 
 		const a = page.locator('#count');
 
-		expect(await a.textContent()).toBe('0');
+		await expect(a).toHaveText('0');
 
 		await page.locator('#increment').click();
-		expect(await a.textContent()).toBe('0');
+		await expect(a).toHaveText('0');
 
 		await a.click();
-		expect(await a.textContent()).toBe('1');
+		await expect(a).toHaveText('1');
 	});
 
 	test('packages can re-export remote functions', async ({ page }) => {

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -37,7 +37,7 @@ test.describe('remote functions', () => {
 		const a = page.locator('#now');
 
 		const t1 = /** @type {string} */ (await a.textContent());
-		await new Promise((f) => setTimeout(f, 5)); // belt and braces
+		await new Promise((f) => setTimeout(f, 50)); // belt and braces
 		await a.click();
 		const t2 = /** @type {string} */ (await a.textContent());
 


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/10274

In many SPAs, clicking on a link to the current page causes a refresh of all the data, matching what would happen in an MPA. You can see this on sites like https://bsky.app (or https://x.com if you're a person of questionable taste) among many others. This creates a user expectation that they can force a refresh, bypassing whatever client-side caches might be in operation. 

In SvelteKit, clicking on a link to the current page is effectively a noop. This PR changes that. It might seem like a weird special case, but such links are _already_ a special case in that they default to `history.replaceState` instead of `history.pushState` (mirroring MPA behaviour); this feels like a mildly-opinionated-but-defensible extension of that logic.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
