### PR TITLE
breaking: remove deprecated `run()` method from live queries

### DIFF
--- a/.changeset/wide-mangos-admire.md
+++ b/.changeset/wide-mangos-admire.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': major
+---
+
+breaking: remove deprecated `.run()` method from live queries

--- a/packages/kit/src/runtime/app/server/remote/query.js
+++ b/packages/kit/src/runtime/app/server/remote/query.js
@@ -575,12 +575,6 @@ function create_live_query_resource(__, payload, event, state, get_generator) {
 
 			return Promise.resolve();
 		},
-		/** @ts-expect-error This method no longer exists */
-		run() {
-			throw new Error(
-				'`.run()` has been removed from live queries. Use `for await (const value of liveQuery())` instead.'
-			);
-		},
 		/** @type {Promise<any>['then']} */
 		then(onfulfilled, onrejected) {
 			return get_promise().then(onfulfilled, onrejected);

--- a/packages/kit/src/runtime/client/remote-functions/query-live/proxy.js
+++ b/packages/kit/src/runtime/client/remote-functions/query-live/proxy.js
@@ -74,16 +74,6 @@ export class LiveQueryProxy {
 		return this.#get_cached_query().done;
 	}
 
-	/**
-	 * @deprecated Use `for await (const value of liveQuery())` instead.
-	 * @returns {AsyncGenerator<T>}
-	 */
-	run() {
-		throw new Error(
-			'`.run()` has been removed from live queries. Use `for await (const value of liveQuery())` instead.'
-		);
-	}
-
 	reconnect() {
 		return this.#get_cached_query().reconnect();
 	}


### PR DESCRIPTION
This is the last TODO comment or deprecation I could find that needs to be addressed before 3.0 — as such, this closes #1247