### PR TITLE
chore: only generate each route resolution module once when prerendering

### DIFF
--- a/.changeset/lucky-moons-resolve.md
+++ b/.changeset/lucky-moons-resolve.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+chore: only generate each route's resolution module once when prerendering

--- a/packages/kit/src/core/postbuild/fallback.js
+++ b/packages/kit/src/core/postbuild/fallback.js
@@ -39,7 +39,8 @@ async function generate_fallback({ manifest_path, env, out_dir, origin, assets }
 		prerendering: {
 			fallback: true,
 			dependencies: new Map(),
-			remote_responses: new Map()
+			remote_responses: new Map(),
+			resolved_route_ids: new Set()
 		},
 		read: (file) => readFileSync(join(assets, file))
 	});

--- a/packages/kit/src/core/postbuild/prerender.js
+++ b/packages/kit/src/core/postbuild/prerender.js
@@ -262,6 +262,9 @@ async function prerender({ hash, out, manifest_path, metadata, verbose, env, vit
 	/** @type {Map<string, Promise<any>>} */
 	const remote_responses = new Map();
 
+	/** @type {Set<string>} */
+	const resolved_route_ids = new Set();
+
 	/** @type {Map<string, Set<string>>} */
 	const expected_hashlinks = new Map();
 
@@ -307,7 +310,8 @@ async function prerender({ hash, out, manifest_path, metadata, verbose, env, vit
 			},
 			prerendering: {
 				dependencies,
-				remote_responses
+				remote_responses,
+				resolved_route_ids
 			},
 			read: (file) => {
 				// stuff we just wrote

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -402,7 +402,10 @@ export async function render_response({
 			// prerendered route is filtered out of `manifest._.routes` (see `generateManifest`
 			// in core/adapt/builder.js), so on a host with no SvelteKit server there is nothing
 			// left to answer a resolution request for it at runtime.
-			if (route) {
+			// `dependencies` is per-page, so without this we'd regenerate once per prerendered page
+			if (route && !state.prerendering.resolved_route_ids.has(route.id)) {
+				state.prerendering.resolved_route_ids.add(route.id);
+
 				const id_pathname = paths.base + route_id_resolution_pathname(paths.app_dir, route.id);
 
 				state.prerendering.dependencies.set(

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -239,6 +239,8 @@ export interface PrerenderOptions {
 	dependencies: Map<string, PrerenderDependency>;
 	/** Results of remote `prerender` functions, shared across the whole prerender run so that each only executes once */
 	remote_responses: Map<string, Promise<any>>;
+	/** Route IDs whose resolution module has been emitted, shared across the whole prerender run so that each only generates once */
+	resolved_route_ids: Set<string>;
 	/** True for the duration of a call to the `reroute` hook */
 	inside_reroute?: boolean;
 }


### PR DESCRIPTION
Stacked on #16576, per https://github.com/sveltejs/kit/pull/16576#discussion_r3679015025.

`dependencies` is per-`visit()`, so the route-ID module was generated once per prerendered page. On the `prerendering/basics` fixture with `resolution: 'server'`, 31 generations produced 28 files; with this, 28 produce 28, and the output is byte-identical apart from the build version stamp.
