### PR TITLE
fix: write the generated tsconfig to `node_modules/$app/tsconfig.json`

### DIFF
--- a/.changeset/violet-planets-tell.md
+++ b/.changeset/violet-planets-tell.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: write generated tsconfig to `node_modules/$app/tsconfig.json` so that tools with simplified tsconfig resolution can find it

--- a/packages/kit/src/cli.js
+++ b/packages/kit/src/cli.js
@@ -75,10 +75,10 @@ if (!command) {
 }
 
 if (command === 'sync') {
-	// create placeholder node_modules/$app/tsconfig/tsconfig.json if necessary, to squelch warnings.
+	// create placeholder node_modules/$app/tsconfig.json if necessary, to squelch warnings.
 	// this isn't bulletproof — if someone has some esoteric config, it will continue
 	// to harmlessly warn — but we handle the 90% case and clean up after ourselves
-	const dir = 'node_modules/$app/tsconfig';
+	const dir = 'node_modules/$app';
 	const base_tsconfig = `${dir}/tsconfig.json`;
 	const base_tsconfig_json = '{}';
 

--- a/packages/kit/src/core/sync/write_tsconfig/index.js
+++ b/packages/kit/src/core/sync/write_tsconfig/index.js
@@ -85,7 +85,8 @@ export function write_tsconfig(kit, root) {
  * @param {ValidatedKitConfig['typescript']['config']} [transform] TODO get rid of this
  */
 function write_parent_tsconfig(root, dir, id, config, example, transform) {
-	const out_file = path.join(root, `node_modules/${id}/tsconfig.json`);
+	// simplified tsconfig resolvers (e.g. Playwright's) only find `${id}.json`, not `${id}/tsconfig.json`
+	const out_file = path.join(root, `node_modules/${id}.json`);
 
 	let normalized = normalize_config(out_file, config);
 	normalized = transform?.(normalized) ?? normalized;

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -862,7 +862,7 @@ export interface KitConfig {
 		 * A function that allows you to edit the generated `tsconfig.json`. You can mutate the config (recommended) or return a new one.
 		 * This is useful for extending a shared `tsconfig.json` in a monorepo root, for example.
 		 *
-		 * Note that any paths configured here should be relative to the generated config file, which is written to `node_modules/$app/tsconfig/tsconfig.json`.
+		 * Note that any paths configured here should be relative to the generated config file, which is written to `node_modules/$app/tsconfig.json`.
 		 *
 		 * @default (config) => config
 		 * @since 1.3.0

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -834,7 +834,7 @@ declare module '@sveltejs/kit' {
 			 * A function that allows you to edit the generated `tsconfig.json`. You can mutate the config (recommended) or return a new one.
 			 * This is useful for extending a shared `tsconfig.json` in a monorepo root, for example.
 			 *
-			 * Note that any paths configured here should be relative to the generated config file, which is written to `node_modules/$app/tsconfig/tsconfig.json`.
+			 * Note that any paths configured here should be relative to the generated config file, which is written to `node_modules/$app/tsconfig.json`.
 			 *
 			 * @default (config) => config
 			 * @since 1.3.0


### PR DESCRIPTION
Neat little find

The cause of [the playwright pin](https://github.com/sveltejs/kit/pull/16538#issuecomment-5092380365) is that [its tsconfig loader](https://github.com/microsoft/playwright/blob/v1.62.0/packages/playwright/src/transform/tsconfig-loader.ts#L54) only ever looks up `node_modules/$app/tsconfig.json`, while [tsc also resolves](https://www.typescriptlang.org/tsconfig/#extends) the directory form we currently generate. Writing the file where both look removes the pin's cause and lets `paths` reach Playwright test files again. Verified against 1.61.1, 1.62.0 and 1.62.1.
