### PR TITLE
chore: reduce secret and token exposure in the platform tests workflow

### DIFF
--- a/.github/workflows/platform-tests-all.yml
+++ b/.github/workflows/platform-tests-all.yml
@@ -9,7 +9,7 @@ on:
         default: ''
 
 permissions:
-  contents: write
+  contents: read # to fetch code (actions/checkout); `{}` would strip it from the called workflows too
 
 jobs:
   vercel:
@@ -28,11 +28,12 @@ jobs:
     uses: ./.github/workflows/platform-tests-node.yml
     with:
       sha: ${{ inputs.sha }}
-    secrets: inherit
 
   report-status:
     if: always()
     needs: [vercel, netlify, node]
+    permissions:
+      contents: write # to create the repository_dispatch event
     runs-on: ubuntu-latest
     steps:
       - name: Determine outcome


### PR DESCRIPTION
Part of #15529. The node call uses no secrets, and only `report-status` needs `contents: write`.

Vercel and netlify keep `secrets: inherit` for now: explicit `secrets:` blocks only work if those are repo or org secrets rather than environment secrets (actions/runner#4453), and that's only visible in the repo settings. Happy to open a PR once someone confirms.
