### PR TITLE
feat: additional `$app/manifest` goodies, better route typings

### DIFF
--- a/.changeset/manifest-route-capabilities.md
+++ b/.changeset/manifest-route-capabilities.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: add `page` and `endpoint` booleans to `$app/manifest`'s `routes`, and export a `ManifestRoute` type

--- a/.changeset/page-endpoint-route-ids.md
+++ b/.changeset/page-endpoint-route-ids.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: add `PageRouteId` and `EndpointRouteId` to `$app/types`

--- a/documentation/docs/98-reference/22-$app-types.md
+++ b/documentation/docs/98-reference/22-$app-types.md
@@ -10,7 +10,7 @@ This module contains generated types for the routes in your app.
 
 ```js
 // @noErrors
-import type { RouteId, RouteParams, LayoutParams } from '$app/types';
+import type { RouteId, PageRouteId, EndpointRouteId, RouteParams, LayoutParams } from '$app/types';
 ```
 
 ## AssetPath
@@ -27,12 +27,40 @@ type AssetPath = 'favicon.png' | 'robots.txt' | (string & {});
 
 ## RouteId
 
-A union of all the route IDs in your app. Used for `page.route.id` and `event.route.id`.
+A union of all the route IDs in your app — the union of `PageRouteId` and `EndpointRouteId`. Used for `page.route.id` and `event.route.id`.
 
 <div class="ts-block">
 
 ```dts
-type RouteId = '/' | '/my-route' | '/my-other-route/[param]';
+type RouteId = '/' | '/my-route' | '/my-other-route/[param]' | '/my-endpoint';
+```
+
+</div>
+
+## PageRouteId
+
+A union of the route IDs in your app that have a `+page`.
+
+A route ID can be in both `PageRouteId` and `EndpointRouteId`, if its directory contains both a `+page` and a `+server`. In the example below, `/my-route` has both.
+
+<div class="ts-block">
+
+```dts
+type PageRouteId = '/' | '/my-route' | '/my-other-route/[param]';
+```
+
+</div>
+
+## EndpointRouteId
+
+A union of the route IDs in your app that have a `+server`.
+
+A route ID can be in both `PageRouteId` and `EndpointRouteId`, if its directory contains both a `+page` and a `+server`. In the example below, `/my-route` has both.
+
+<div class="ts-block">
+
+```dts
+type EndpointRouteId = '/my-route' | '/my-endpoint';
 ```
 
 </div>
@@ -80,14 +108,12 @@ type RouteParams<T extends RouteId> = { /* generated */ } | Record<string, never
 
 ## LayoutParams
 
-A utility for getting the parameters associated with a given layout, which is similar to `RouteParams` but also includes optional parameters for any child route.
-
-Unlike `RouteId`, this accepts any directory in `src/routes`, since a layout can live in a directory that has no `+page` or `+server` of its own.
+A utility for getting the parameters associated with a given layout, which is similar to `RouteParams` but also includes optional parameters for any child route. It accepts the route ID of any directory containing a layout, including layout-only directories that are not part of `RouteId`.
 
 <div class="ts-block">
 
 ```dts
-type LayoutParams<T extends '/' | '/my-route' | '/my-other-route'> = { /* generated */ };
+type LayoutParams<T extends '/' | '/my-layout' | '/my-other-layout'> = { /* generated */ };
 ```
 
 </div>

--- a/packages/kit/src/core/sync/create_manifest_data/index.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.js
@@ -42,13 +42,31 @@ export default function create_manifest_data({
 }
 
 /**
- * Whether the router can match this route. `manifest_data.routes` also contains an entry for
- * every other directory in `src/routes`, so that layouts and params can be resolved, and those
- * ids never reach `event.route.id`.
+ * Whether this route has a `+page`. Independent of `is_endpoint_route` — a route can be both.
  * @param {import('types').RouteData} route
+ * @returns {boolean}
+ */
+export function is_page_route(route) {
+	return !!route.page;
+}
+
+/**
+ * Whether this route has a `+server`. Independent of `is_page_route` — a route can be both.
+ * @param {import('types').RouteData} route
+ * @returns {boolean}
+ */
+export function is_endpoint_route(route) {
+	return !!route.endpoint;
+}
+
+/**
+ * Whether the router can match this route. `manifest_data.routes` also contains entries for
+ * directories with layouts or errors, which never reach `event.route.id`.
+ * @param {import('types').RouteData} route
+ * @returns {boolean}
  */
 export function is_app_route(route) {
-	return !!(route.page || route.endpoint);
+	return is_page_route(route) || is_endpoint_route(route);
 }
 
 /**

--- a/packages/kit/src/core/sync/write_app_types.js
+++ b/packages/kit/src/core/sync/write_app_types.js
@@ -5,7 +5,7 @@ import { posixify } from '../../utils/os.js';
 import { write_if_changed } from './utils.js';
 import { s } from '../../utils/misc.js';
 import { get_route_segments } from '../../utils/routing.js';
-import { is_app_route } from './create_manifest_data/index.js';
+import { is_app_route, is_endpoint_route, is_page_route } from './create_manifest_data/index.js';
 
 const replace_optional_params = (/** @type {string} */ id) =>
 	id.replace(/\/\[\[[^\]]+\]\]/g, '${string}');
@@ -144,6 +144,12 @@ function generate_app_types(manifest_data, config, dir) {
 	const pathnames = new Set();
 
 	/** @type {string[]} */
+	const page_route_ids = [];
+
+	/** @type {string[]} */
+	const endpoint_route_ids = [];
+
+	/** @type {string[]} */
 	const app_route_ids = [];
 
 	/** @type {string[]} */
@@ -154,15 +160,17 @@ function generate_app_types(manifest_data, config, dir) {
 
 	/** @type {Map<string, Map<string, { optional: boolean, matchers: Set<string> | null }>>} */
 	const layout_params_by_route = new Map(
-		manifest_data.routes.map((route) => [
-			route.id,
-			new Map(
-				route.params.map((p) => [
-					p.name,
-					{ optional: p.optional, matchers: p.matcher ? new Set([p.matcher]) : null }
-				])
-			)
-		])
+		manifest_data.routes
+			.filter((route) => route.layout)
+			.map((route) => [
+				route.id,
+				new Map(
+					route.params.map((p) => [
+						p.name,
+						{ optional: p.optional, matchers: p.matcher ? new Set([p.matcher]) : null }
+					])
+				)
+			])
 	);
 
 	for (const route of manifest_data.routes) {
@@ -196,9 +204,11 @@ function generate_app_types(manifest_data, config, dir) {
 	}
 
 	for (const route of manifest_data.routes) {
-		if (is_app_route(route)) {
-			app_route_ids.push(s(route.id));
-		}
+		const id = s(route.id);
+
+		if (is_page_route(route)) page_route_ids.push(id);
+		if (is_endpoint_route(route)) endpoint_route_ids.push(id);
+		if (is_app_route(route)) app_route_ids.push(id);
 
 		const pathname = remove_group_segments(route.id);
 		let normalized_pathname = pathname.slice(1);
@@ -211,6 +221,7 @@ function generate_app_types(manifest_data, config, dir) {
 				const type = get_matcher_type(p.matcher);
 				return `${/^\w+$/.test(p.name) ? p.name : `'${p.name}'`}${p.optional ? '?:' : ':'} ${type}${p.optional ? ' | undefined' : ''}`;
 			});
+
 			if (is_app_route(route)) {
 				dynamic_routes.push(`${s(route.id)}: { ${params.join('; ')} }`);
 			}
@@ -237,7 +248,7 @@ function generate_app_types(manifest_data, config, dir) {
 			if (params.length > 0) layout_type = `{ ${params} }`;
 		}
 
-		layouts.push(`${s(route.id)}: ${layout_type}`);
+		if (route.layout) layouts.push(`${s(route.id)}: ${layout_type}`);
 	}
 
 	const assets = manifest_data.assets.map((asset) => s(asset.file));
@@ -245,6 +256,8 @@ function generate_app_types(manifest_data, config, dir) {
 	return [
 		'declare module "$app/types" {',
 		'\texport interface AppTypes {',
+		`\t\tPageRouteId(): ${page_route_ids.join(' | ') || 'never'};`,
+		`\t\tEndpointRouteId(): ${endpoint_route_ids.join(' | ') || 'never'};`,
 		`\t\tRouteId(): ${app_route_ids.join(' | ') || 'never'};`,
 		`\t\tRouteParams(): {\n\t\t\t${dynamic_routes.join(';\n\t\t\t')}\n\t\t};`,
 		`\t\tLayoutParams(): {\n\t\t\t${layouts.join(';\n\t\t\t')}\n\t\t};`,

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -5,7 +5,7 @@ import { rimraf, walk, resolve_entry } from '../../../utils/filesystem.js';
 import { compact } from '../../../utils/array.js';
 import { posixify } from '../../../utils/os.js';
 import { ts } from '../ts.js';
-import { is_app_route } from '../create_manifest_data/index.js';
+import { is_page_route } from '../create_manifest_data/index.js';
 const remove_relative_parent_traversals = (/** @type {string} */ path) =>
 	path.replace(/\.\.\//g, '');
 const is_whitespace = (/** @type {string} */ char) => /\s/.test(char);
@@ -279,9 +279,9 @@ function update_types(config, routes, route, root, to_delete = new Set()) {
 		let all_pages_have_load = true;
 		/** @type {import('types').RouteParam[]} */
 		const layout_params = [];
-		// a layout can live in a directory that has no `+page` or `+server`, in which case its
-		// own id is never the matched route
-		const ids = is_app_route(route) ? ['RouteId'] : [];
+		// a layout can live in a directory that has no `+page` of its own, in which case its own id
+		// is never the matched route — a request to a colocated `+server` doesn't execute layouts
+		const ids = is_page_route(route) ? ['RouteId'] : [];
 
 		route.layout.child_pages?.forEach((page) => {
 			const leaf = routes.get(page);

--- a/packages/kit/src/core/sync/write_types/test/app-types/+page.js
+++ b/packages/kit/src/core/sync/write_types/test/app-types/+page.js
@@ -5,6 +5,8 @@ let id;
 id = '/';
 id = '/foo/[bar]/[baz]';
 id = '/(group)/path-a';
+id = '/(group)/path-a/trailing-slash/always/endpoint'; // endpoint-only
+id = '/(group)/path-a/trailing-slash/mixed'; // page and endpoint
 
 // @ts-expect-error
 id = '/nope';
@@ -12,9 +14,104 @@ id = '/nope';
 // @ts-expect-error `/foo` is a directory with no `+page` or `+server`, so it is not a route
 id = '/foo';
 
-// @ts-expect-error a directory with only a `+layout` is not a route
+// @ts-expect-error a directory with only a `+layout` is not a route either
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 id = '/(group)/path-a/trailing-slash/always/layout';
+
+/** @type {import('$app/types').PageRouteId} */
+let page_id;
+
+page_id = '/(group)/path-a'; // okay
+page_id = '/(group)/path-a/trailing-slash/mixed'; // okay, has both a `+page` and a `+server`
+
+// @ts-expect-error `/(group)/path-a/trailing-slash/always/endpoint` only has a `+server`
+page_id = '/(group)/path-a/trailing-slash/always/endpoint';
+
+// @ts-expect-error `/foo` is a directory with no `+page` or `+server`
+page_id = '/foo';
+
+// @ts-expect-error
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+page_id = '/nope';
+
+/** @type {import('$app/types').EndpointRouteId} */
+let endpoint_id;
+
+endpoint_id = '/(group)/path-a/trailing-slash/always/endpoint'; // okay
+endpoint_id = '/(group)/path-a/trailing-slash/mixed'; // okay, has both a `+page` and a `+server`
+
+// @ts-expect-error `/(group)/path-a` only has a `+page`
+endpoint_id = '/(group)/path-a';
+
+// @ts-expect-error `/foo` is a directory with no `+page` or `+server`
+endpoint_id = '/foo';
+
+// @ts-expect-error
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+endpoint_id = '/nope';
+
+// a directory with only a `+layout` is not a route, but `LayoutParams` still accepts it
+/** @type {import('$app/types').LayoutParams<'/(group)/path-a/trailing-slash/always/layout'>} */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const layoutOnlyParams = {};
+
+// endpoints have params too
+/** @type {import('$app/types').RouteParams<'/(group)/path-a/trailing-slash/always/endpoint'>} */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const endpointParams = {};
+
+/** @type {import('$app/manifest').ManifestRoute[]} */
+const manifest_routes = [
+	{ id: '/(group)/path-a', page: true, endpoint: false },
+	{ id: '/(group)/path-a/trailing-slash/always/endpoint', page: false, endpoint: true },
+	{ id: '/(group)/path-a/trailing-slash/mixed', page: true, endpoint: true }
+];
+
+/** @type {import('$app/manifest').ManifestRoute[]} */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const impossible_manifest_routes = [
+	// @ts-expect-error a route always has a page and/or an endpoint
+	{ id: '/(group)/path-a', page: false, endpoint: false },
+	// @ts-expect-error `/(group)/path-a` has no endpoint
+	{ id: '/(group)/path-a', page: true, endpoint: true },
+	// @ts-expect-error the capability booleans are required
+	{ id: '/(group)/path-a' }
+];
+
+for (const route of manifest_routes) {
+	if (route.page && !route.endpoint) {
+		/** @type {Exclude<import('$app/types').PageRouteId, import('$app/types').EndpointRouteId>} */
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		const page_only_id = route.id;
+
+		/** @type {import('$app/types').EndpointRouteId} */
+		// @ts-expect-error a page-only route ID is never an endpoint route ID
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		const not_an_endpoint_id = route.id;
+	} else if (!route.page && route.endpoint) {
+		/** @type {Exclude<import('$app/types').EndpointRouteId, import('$app/types').PageRouteId>} */
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		const endpoint_only_id = route.id;
+
+		/** @type {import('$app/types').PageRouteId} */
+		// @ts-expect-error an endpoint-only route ID is never a page route ID
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		const not_a_page_id = route.id;
+	} else {
+		/** @type {Extract<import('$app/types').PageRouteId, import('$app/types').EndpointRouteId>} */
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		const dual_id = route.id;
+
+		// a dual route ID belongs to both capability unions
+		/** @type {import('$app/types').PageRouteId} */
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		const also_a_page_id = route.id;
+
+		/** @type {import('$app/types').EndpointRouteId} */
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		const also_an_endpoint_id = route.id;
+	}
+}
 
 /** @type {import('$app/types').RouteParams<'/foo/[bar]/[baz]'>} */
 const params = {
@@ -68,10 +165,10 @@ withMatcherLayoutParams.locale = 'en'; // okay
 withMatcherLayoutParams.locale = 'nb'; // okay
 withMatcherLayoutParamsWithUndefined.locale = 'nb'; // okay
 
+// @ts-expect-error `/matcher-test` does not contain a layout
 /** @type {import('$app/types').LayoutParams<'/matcher-test'>} */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const matcherParentLayoutParams = {};
-
-matcherParentLayoutParams.locale = 'fr'; // any string
 
 /** @type {import('$app/types').Path} */
 let pathname;

--- a/packages/kit/src/core/sync/write_types/test/app-types/layout-endpoint/+layout.server.js
+++ b/packages/kit/src/core/sync/write_types/test/app-types/layout-endpoint/+layout.server.js
@@ -1,0 +1,21 @@
+/** @type {import('../.svelte-kit/types/layout-endpoint/$types').LayoutServerLoad} */
+export function load({ route }) {
+	// `/layout-endpoint/child` is the only route that executes this layout — a request to the
+	// colocated `+server.js` doesn't, and `null` is only possible for the root layout
+	/** @type {'/layout-endpoint/child'} */
+	const id = route.id;
+
+	return { id };
+}
+
+/** @type {import('../.svelte-kit/types/layout-endpoint/$types').LayoutServerLoadEvent['route']['id']} */
+let route_id;
+
+route_id = '/layout-endpoint/child'; // okay
+
+// @ts-expect-error requesting the colocated endpoint doesn't execute this layout
+route_id = '/layout-endpoint';
+
+// @ts-expect-error only the root layout is used for the fallback error page, where the ID is null
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+route_id = null;

--- a/packages/kit/src/core/sync/write_types/test/app-types/layout-endpoint/+server.js
+++ b/packages/kit/src/core/sync/write_types/test/app-types/layout-endpoint/+server.js
@@ -1,0 +1,3 @@
+export function GET() {
+	return new Response('a request to this endpoint does not execute the sibling layout');
+}

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -41,12 +41,16 @@ import {
 } from './utils.js';
 import { stackless } from '../../utils/error.js';
 import { write_client_manifest } from '../../core/sync/write_client_manifest.js';
-import { is_app_route } from '../../core/sync/create_manifest_data/index.js';
 import prerender from '../../core/postbuild/prerender.js';
 import analyse from '../../core/postbuild/analyse.js';
 import { s } from '../../utils/misc.js';
 import { hash } from '../../utils/hash.js';
 import { dedent } from '../../core/sync/utils.js';
+import {
+	is_app_route,
+	is_endpoint_route,
+	is_page_route
+} from '../../core/sync/create_manifest_data/index.js';
 import { get_import_aliases, get_hash_import_keys } from '../../utils/imports.js';
 import {
 	app_env_private,
@@ -1571,7 +1575,7 @@ function kit({ svelte_config }) {
 			// the client build and after prerendering respectively.
 			replace_manifest_placeholder_variables(server_chunks, `${out}/server`, {
 				assets: manifest_data.assets.map((asset) => ({ path: asset.file })),
-				routes: manifest_data.routes.map((route) => ({ id: route.id }))
+				routes: get_manifest_routes(manifest_data.routes)
 			});
 
 			const verbose = builder.config.logLevel === 'info';
@@ -1733,7 +1737,7 @@ function kit({ svelte_config }) {
 				replace_manifest_placeholder_variables(client_chunks, `${out}/client`, {
 					immutable,
 					assets: manifest_data.assets.map((asset) => ({ path: asset.file })),
-					routes: manifest_data.routes.map((route) => ({ id: route.id }))
+					routes: get_manifest_routes(manifest_data.routes)
 				});
 
 				// Now that the client build is done, replace the `build` sentinel
@@ -2123,15 +2127,26 @@ function stringify_assets(assets) {
 
 /**
  * @param {RouteData[] | undefined} routes
+ * @returns {Array<{ id: string; page: boolean; endpoint: boolean }>}
+ */
+function get_manifest_routes(routes) {
+	return (
+		routes?.filter(is_app_route).map((route) => ({
+			id: route.id,
+			page: is_page_route(route),
+			endpoint: is_endpoint_route(route)
+		})) ?? []
+	);
+}
+
+/**
+ * @param {RouteData[] | undefined} routes
  * @returns {string}
  */
 function stringify_routes(routes) {
-	return (
-		routes
-			?.filter(is_app_route)
-			.map((route) => s({ id: route.id }))
-			.join(',\n') ?? ''
-	);
+	return get_manifest_routes(routes)
+		.map((route) => s(route))
+		.join(',\n');
 }
 
 /**
@@ -2192,7 +2207,7 @@ const create_manifest_data_module = (is_build, manifest_data) => {
  *   immutable?: Array<{ path: string }>;
  *   assets?: Array<{ path: string }>;
  *   prerendered?: Array<{ path: string }>;
- *   routes?: Array<{ id: string }>;
+ *   routes?: Array<{ id: string; page: boolean; endpoint: boolean }>;
  * }} values
  */
 const replace_manifest_placeholder_variables = (chunks, output_dir, values) => {

--- a/packages/kit/src/types/ambient-private.d.ts
+++ b/packages/kit/src/types/ambient-private.d.ts
@@ -51,5 +51,5 @@ declare module '__sveltekit/manifest-data' {
 	export const immutable: Array<{ path: string }>;
 	export const assets: Array<{ path: string }>;
 	export const prerendered: Array<{ path: string }>;
-	export const routes: Array<{ id: string }>;
+	export const routes: Array<{ id: string; page: boolean; endpoint: boolean }>;
 }

--- a/packages/kit/src/types/ambient.d.ts
+++ b/packages/kit/src/types/ambient.d.ts
@@ -78,8 +78,8 @@ declare module '$app/manifest' {
 	 */
 	export const prerendered: Array<{ path: import('$app/types').Path }>;
 	/**
-	 * A route in your app, along with its capabilities. `page` is `true` if the route has a `+page`,
-	 * `endpoint` is `true` if it has a `+server`. A route that has both has both set to `true`.
+	 * A route in your app, along with its capabilities. `page` indicates the presence of a `+page`,
+	 * while `endpoint` indicates the presence of a `+server`. Both are `true` when both files exist.
 	 */
 	export type ManifestRoute =
 		| {

--- a/packages/kit/src/types/ambient.d.ts
+++ b/packages/kit/src/types/ambient.d.ts
@@ -106,7 +106,6 @@ declare module '$app/manifest' {
 	 * be filtered independently:
 	 *
 	 * ```js
-	 * // @noErrors
 	 * import { routes } from '$app/manifest';
 	 *
 	 * const pages = routes.filter((route) => route.page);

--- a/packages/kit/src/types/ambient.d.ts
+++ b/packages/kit/src/types/ambient.d.ts
@@ -78,9 +78,42 @@ declare module '$app/manifest' {
 	 */
 	export const prerendered: Array<{ path: import('$app/types').Path }>;
 	/**
-	 * An array of objects with an `id` property representing the routes in your app.
+	 * A route in your app, along with its capabilities. `page` is `true` if the route has a `+page`,
+	 * `endpoint` is `true` if it has a `+server`. A route that has both has both set to `true`.
 	 */
-	export const routes: Array<{ id: import('$app/types').RouteId }>;
+	export type ManifestRoute =
+		| {
+				id: Exclude<import('$app/types').PageRouteId, import('$app/types').EndpointRouteId>;
+				page: true;
+				endpoint: false;
+		  }
+		| {
+				id: Exclude<import('$app/types').EndpointRouteId, import('$app/types').PageRouteId>;
+				page: false;
+				endpoint: true;
+		  }
+		| {
+				id: Extract<import('$app/types').PageRouteId, import('$app/types').EndpointRouteId>;
+				page: true;
+				endpoint: true;
+		  };
+	/**
+	 * An array of objects representing the routes in your app. Only routes that the router can match
+	 * are included — directories that merely hold a `+layout` are not routes of their own.
+	 *
+	 * Each object has an `id`, plus `page` and `endpoint` booleans describing whether the route has a
+	 * `+page` and/or a `+server`. Both are `true` for a route that has both, so the capabilities can
+	 * be filtered independently:
+	 *
+	 * ```js
+	 * // @noErrors
+	 * import { routes } from '$app/manifest';
+	 *
+	 * const pages = routes.filter((route) => route.page);
+	 * const endpoints = routes.filter((route) => route.endpoint);
+	 * ```
+	 */
+	export const routes: ManifestRoute[];
 }
 
 /**
@@ -94,6 +127,8 @@ declare module '$app/types' {
 		// These are all functions so that we can leverage function overloads to get the correct type.
 		// Using the return types directly would error with a "not the same type" error.
 		// https://www.typescriptlang.org/docs/handbook/declaration-merging.html#merging-interfaces
+		PageRouteId(): string;
+		EndpointRouteId(): string;
 		RouteId(): string;
 		RouteParams(): Record<string, Record<string, string>>;
 		LayoutParams(): Record<string, Record<string, string>>;
@@ -103,7 +138,21 @@ declare module '$app/types' {
 	}
 
 	/**
-	 * A union of all the route IDs in your app. Used for `page.route.id` and `event.route.id`.
+	 * A union of the route IDs in your app that have a `+page`.
+	 *
+	 * A route ID can be in both `PageRouteId` and `EndpointRouteId`, if its directory contains both a `+page` and a `+server`.
+	 */
+	export type PageRouteId = ReturnType<AppTypes['PageRouteId']>;
+
+	/**
+	 * A union of the route IDs in your app that have a `+server`.
+	 *
+	 * A route ID can be in both `PageRouteId` and `EndpointRouteId`, if its directory contains both a `+page` and a `+server`.
+	 */
+	export type EndpointRouteId = ReturnType<AppTypes['EndpointRouteId']>;
+
+	/**
+	 * A union of all the route IDs in your app — the union of `PageRouteId` and `EndpointRouteId`. Used for `page.route.id` and `event.route.id`.
 	 */
 	export type RouteId = ReturnType<AppTypes['RouteId']>;
 
@@ -120,13 +169,14 @@ declare module '$app/types' {
 		: Record<string, never>;
 
 	/**
-	 * A utility for getting the parameters associated with a given layout, which is similar to `RouteParams` but also includes optional parameters for any child route.
-	 *
-	 * Unlike `RouteId`, this accepts any directory in `src/routes`, since a layout can live in a directory that has no `+page` or `+server` of its own.
+	 * The route IDs accepted by `LayoutParams`. Like `RouteId`, these preserve route groups and `[param]` syntax, but they identify directories containing layouts rather than matchable routes.
 	 */
-	export type LayoutParams<T extends keyof ReturnType<AppTypes['LayoutParams']>> = ReturnType<
-		AppTypes['LayoutParams']
-	>[T];
+	type LayoutParamsId = keyof ReturnType<AppTypes['LayoutParams']>;
+
+	/**
+	 * A utility for getting the parameters associated with a given layout, which is similar to `RouteParams` but also includes optional parameters for any child route.
+	 */
+	export type LayoutParams<T extends LayoutParamsId> = ReturnType<AppTypes['LayoutParams']>[T];
 
 	/**
 	 * A union of all valid paths in your app, relative to the `base` path.

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -785,6 +785,27 @@ test.describe('$app/manifest', () => {
 		expect(ids).not.toContain('/app-manifest/not-a-page');
 	});
 
+	test('exposes route capabilities', async ({ page }) => {
+		await page.goto('/app-manifest');
+		const routes = JSON.parse((await page.textContent('[data-name="routes"] pre')) ?? '');
+
+		// only a `+page.svelte`
+		expect(routes).toContainEqual({ id: '/app-manifest', page: true, endpoint: false });
+		// only a `+server.js`
+		expect(routes).toContainEqual({ id: '/answer.json', page: false, endpoint: true });
+		// both a `+page.svelte` and a `+server.js`
+		expect(routes).toContainEqual({
+			id: '/endpoint-output/fallback-with-page',
+			page: true,
+			endpoint: true
+		});
+
+		// every route has at least one capability
+		for (const route of routes) {
+			expect(route.page || route.endpoint).toBe(true);
+		}
+	});
+
 	test('exposes static assets', async ({ page }) => {
 		await page.goto('/app-manifest');
 		const assets = JSON.parse((await page.textContent('[data-name="assets"] pre')) ?? '');

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -3754,8 +3754,8 @@ declare module '$app/manifest' {
 	 */
 	export const prerendered: Array<{ path: import('$app/types').Path }>;
 	/**
-	 * A route in your app, along with its capabilities. `page` is `true` if the route has a `+page`,
-	 * `endpoint` is `true` if it has a `+server`. A route that has both has both set to `true`.
+	 * A route in your app, along with its capabilities. `page` indicates the presence of a `+page`,
+	 * while `endpoint` indicates the presence of a `+server`. Both are `true` when both files exist.
 	 */
 	export type ManifestRoute =
 		| {

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -3782,7 +3782,6 @@ declare module '$app/manifest' {
 	 * be filtered independently:
 	 *
 	 * ```js
-	 * // @noErrors
 	 * import { routes } from '$app/manifest';
 	 *
 	 * const pages = routes.filter((route) => route.page);

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -3754,9 +3754,42 @@ declare module '$app/manifest' {
 	 */
 	export const prerendered: Array<{ path: import('$app/types').Path }>;
 	/**
-	 * An array of objects with an `id` property representing the routes in your app.
+	 * A route in your app, along with its capabilities. `page` is `true` if the route has a `+page`,
+	 * `endpoint` is `true` if it has a `+server`. A route that has both has both set to `true`.
 	 */
-	export const routes: Array<{ id: import('$app/types').RouteId }>;
+	export type ManifestRoute =
+		| {
+				id: Exclude<import('$app/types').PageRouteId, import('$app/types').EndpointRouteId>;
+				page: true;
+				endpoint: false;
+		  }
+		| {
+				id: Exclude<import('$app/types').EndpointRouteId, import('$app/types').PageRouteId>;
+				page: false;
+				endpoint: true;
+		  }
+		| {
+				id: Extract<import('$app/types').PageRouteId, import('$app/types').EndpointRouteId>;
+				page: true;
+				endpoint: true;
+		  };
+	/**
+	 * An array of objects representing the routes in your app. Only routes that the router can match
+	 * are included — directories that merely hold a `+layout` are not routes of their own.
+	 *
+	 * Each object has an `id`, plus `page` and `endpoint` booleans describing whether the route has a
+	 * `+page` and/or a `+server`. Both are `true` for a route that has both, so the capabilities can
+	 * be filtered independently:
+	 *
+	 * ```js
+	 * // @noErrors
+	 * import { routes } from '$app/manifest';
+	 *
+	 * const pages = routes.filter((route) => route.page);
+	 * const endpoints = routes.filter((route) => route.endpoint);
+	 * ```
+	 */
+	export const routes: ManifestRoute[];
 }
 
 /**
@@ -3770,6 +3803,8 @@ declare module '$app/types' {
 		// These are all functions so that we can leverage function overloads to get the correct type.
 		// Using the return types directly would error with a "not the same type" error.
 		// https://www.typescriptlang.org/docs/handbook/declaration-merging.html#merging-interfaces
+		PageRouteId(): string;
+		EndpointRouteId(): string;
 		RouteId(): string;
 		RouteParams(): Record<string, Record<string, string>>;
 		LayoutParams(): Record<string, Record<string, string>>;
@@ -3779,7 +3814,21 @@ declare module '$app/types' {
 	}
 
 	/**
-	 * A union of all the route IDs in your app. Used for `page.route.id` and `event.route.id`.
+	 * A union of the route IDs in your app that have a `+page`.
+	 *
+	 * A route ID can be in both `PageRouteId` and `EndpointRouteId`, if its directory contains both a `+page` and a `+server`.
+	 */
+	export type PageRouteId = ReturnType<AppTypes['PageRouteId']>;
+
+	/**
+	 * A union of the route IDs in your app that have a `+server`.
+	 *
+	 * A route ID can be in both `PageRouteId` and `EndpointRouteId`, if its directory contains both a `+page` and a `+server`.
+	 */
+	export type EndpointRouteId = ReturnType<AppTypes['EndpointRouteId']>;
+
+	/**
+	 * A union of all the route IDs in your app — the union of `PageRouteId` and `EndpointRouteId`. Used for `page.route.id` and `event.route.id`.
 	 */
 	export type RouteId = ReturnType<AppTypes['RouteId']>;
 
@@ -3796,13 +3845,14 @@ declare module '$app/types' {
 		: Record<string, never>;
 
 	/**
-	 * A utility for getting the parameters associated with a given layout, which is similar to `RouteParams` but also includes optional parameters for any child route.
-	 *
-	 * Unlike `RouteId`, this accepts any directory in `src/routes`, since a layout can live in a directory that has no `+page` or `+server` of its own.
+	 * The route IDs accepted by `LayoutParams`. Like `RouteId`, these preserve route groups and `[param]` syntax, but they identify directories containing layouts rather than matchable routes.
 	 */
-	export type LayoutParams<T extends keyof ReturnType<AppTypes['LayoutParams']>> = ReturnType<
-		AppTypes['LayoutParams']
-	>[T];
+	type LayoutParamsId = keyof ReturnType<AppTypes['LayoutParams']>;
+
+	/**
+	 * A utility for getting the parameters associated with a given layout, which is similar to `RouteParams` but also includes optional parameters for any child route.
+	 */
+	export type LayoutParams<T extends LayoutParamsId> = ReturnType<AppTypes['LayoutParams']>[T];
 
 	/**
 	 * A union of all valid paths in your app, relative to the `base` path.


### PR DESCRIPTION
Based on #16580. Adds a few goodies:

- `PageRouteId` and `EndpointRouteId`, which combine to make up `RouteId` — these make the internal types a bit cleaner and allow you to discriminate between which routes do what if needed
- `page` and `endpoint` booleans on each entry in `$app/manifest.routes`, allowing routes to be filtered by capability; routes containing both `+page` and `+server` have both set to `true`
- A `ManifestRoute` discriminated union that narrows `id` to the corresponding page-only, endpoint-only, or combined route IDs
- A private `LayoutParamsId` alias for the IDs accepted by `LayoutParams`, which now correspond specifically to directories containing layouts
- More accurate layout load types: a colocated endpoint-only route is no longer included in a layout’s possible `event.route.id` values, since endpoint requests do not execute layouts

Layouts only run for page routes, not endpoints. Previously, a directory with both `+layout` and `+server` incorrectly included its endpoint-only ID in the layout’s possible `event.route.id` type, even though that value can never occur at runtime. The change restricts it to page IDs that can actually execute the layout.