### PR TITLE
fix: error when an adapter tries to delete the SvelteKit build output

### DIFF
--- a/.changeset/hot-jokes-refuse.md
+++ b/.changeset/hot-jokes-refuse.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: error when an adapter tries to delete the SvelteKit build output

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -6,7 +6,7 @@
 import { loadEnv } from 'vite';
 import * as devalue from 'devalue';
 import { createReadStream, createWriteStream, existsSync, statSync } from 'node:fs';
-import { extname, resolve, join, dirname, relative, sep, isAbsolute } from 'node:path';
+import { extname, resolve, join, dirname, relative, isAbsolute } from 'node:path';
 import { pipeline } from 'node:stream';
 import { promisify, styleText } from 'node:util';
 import zlib from 'node:zlib';
@@ -282,7 +282,7 @@ export function create_builder({
  */
 function contains(a, b) {
 	const path = relative(a, b);
-	return path === '' || (path !== '..' && !path.startsWith(`..${sep}`) && !isAbsolute(path));
+	return !path.startsWith('..') && !isAbsolute(path);
 }
 
 /**

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -94,10 +94,7 @@ export function create_builder({
 
 			if (contains(output, target) || contains(target, output)) {
 				throw new Error(
-					`Cannot delete ${target}, because it overlaps with ${output}, which SvelteKit copies the build output from. ` +
-						'Change the directory your adapter writes to (`publish` in netlify.toml, `out` for adapter-node, ' +
-						'`pages`/`assets` for adapter-static, `assets.directory` or `pages_build_output_dir` in your Wrangler config) ' +
-						'so that the two do not overlap.'
+					`Cannot delete ${target}, because it overlaps with ${output}, which SvelteKit copies the build output from`
 				);
 			}
 

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -6,7 +6,7 @@
 import { loadEnv } from 'vite';
 import * as devalue from 'devalue';
 import { createReadStream, createWriteStream, existsSync, statSync } from 'node:fs';
-import { extname, resolve, join, dirname, relative } from 'node:path';
+import { extname, resolve, join, dirname, relative, sep, isAbsolute } from 'node:path';
 import { pipeline } from 'node:stream';
 import { promisify, styleText } from 'node:util';
 import zlib from 'node:zlib';
@@ -87,7 +87,22 @@ export function create_builder({
 
 	return {
 		log,
-		rimraf,
+		/** @param {string} dir */
+		rimraf(dir) {
+			const target = resolve(dir);
+			const output = resolve(config.kit.outDir, 'output');
+
+			if (contains(output, target) || contains(target, output)) {
+				throw new Error(
+					`Cannot delete ${target}, because it overlaps with ${output}, which SvelteKit copies the build output from. ` +
+						'Change the directory your adapter writes to (`publish` in netlify.toml, `out` for adapter-node, ' +
+						'`pages`/`assets` for adapter-static, `assets.directory` or `pages_build_output_dir` in your Wrangler config) ' +
+						'so that the two do not overlap.'
+				);
+			}
+
+			rimraf(target);
+		},
 		mkdirp,
 		copy,
 
@@ -261,6 +276,16 @@ export function create_builder({
 			write(entrypoint, facade);
 		}
 	};
+}
+
+/**
+ * Whether `b` is `a` or lives inside it
+ * @param {string} a
+ * @param {string} b
+ */
+function contains(a, b) {
+	const path = relative(a, b);
+	return path === '' || (path !== '..' && !path.startsWith(`..${sep}`) && !isAbsolute(path));
 }
 
 /**

--- a/packages/kit/src/core/adapt/builder.spec.js
+++ b/packages/kit/src/core/adapt/builder.spec.js
@@ -56,6 +56,17 @@ test('copy files', () => {
 	rmSync(dest, { force: true, recursive: true });
 });
 
+test('refuses to delete the build output', () => {
+	const outDir = join(import.meta.dirname, 'fixtures/basic/.svelte-kit');
+
+	// @ts-expect-error - we don't need the whole config for this test
+	const builder = create_builder({ config: { kit: { outDir } }, route_data: [] });
+
+	expect(() => builder.rimraf(join(outDir, 'output/client'))).toThrow('Cannot delete');
+	expect(() => builder.rimraf(outDir)).toThrow('Cannot delete');
+	expect(() => builder.rimraf(join(outDir, 'netlify-tmp'))).not.toThrow();
+});
+
 test('compress files', async () => {
 	// @ts-expect-error - we don't need the whole config for this test
 	const builder = create_builder({

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -110,7 +110,7 @@ type UnpackValidationError<T> =
 export interface Builder {
 	/** Print messages to the console. `log.info` and `log.minor` are silent unless Vite's `logLevel` is `info`. */
 	log: Logger;
-	/** Remove `dir` and all its contents. */
+	/** Remove `dir` and all its contents. Throws if `dir` overlaps with `${config.kit.outDir}/output`, which `writeClient`, `writeServer` and `writePrerendered` copy from. */
 	rimraf: (dir: string) => void;
 	/** Create `dir` and any required parent directories. */
 	mkdirp: (dir: string) => void;

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -85,7 +85,7 @@ declare module '@sveltejs/kit' {
 	export interface Builder {
 		/** Print messages to the console. `log.info` and `log.minor` are silent unless Vite's `logLevel` is `info`. */
 		log: Logger;
-		/** Remove `dir` and all its contents. */
+		/** Remove `dir` and all its contents. Throws if `dir` overlaps with `${config.kit.outDir}/output`, which `writeClient`, `writeServer` and `writePrerendered` copy from. */
 		rimraf: (dir: string) => void;
 		/** Create `dir` and any required parent directories. */
 		mkdirp: (dir: string) => void;


### PR DESCRIPTION
Fixes #16592

Setting `publish = ".svelte-kit/output/client"` makes adapter-netlify delete the directory it then copies the client assets from, so the build exits 0 and deploys nothing. I originally guarded the `publish` value inside adapter-netlify, then noticed adapter-node (`out`), adapter-static (`pages`/`assets`) and adapter-cloudflare (wrangler `assets.directory`/`pages_build_output_dir`) can be pointed at the same footgun, so the guard now lives on `builder.rimraf` instead: it refuses to delete anything overlapping `${outDir}/output`, the directory adapters copy the build from.
