### PR TITLE
fix: allow handle functions composed with sequence to run without a request store

### DIFF
--- a/.changeset/quiet-pumas-dance.md
+++ b/.changeset/quiet-pumas-dance.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: allow handle functions composed with sequence to run without a request store

--- a/packages/kit/src/exports/hooks/sequence.js
+++ b/packages/kit/src/exports/hooks/sequence.js
@@ -115,17 +115,21 @@ export function sequence(...handlers) {
 								resolve: (event, options) => {
 									/** @type {ResolveOptions} */
 									const merged = {
-										transformPageChunk: async ({ html, done }) => {
-											if (options?.transformPageChunk) {
-												html = (await options.transformPageChunk({ html, done })) ?? '';
-											}
+										transformPageChunk:
+											options?.transformPageChunk || parent_options?.transformPageChunk
+												? async ({ html, done }) => {
+														if (options?.transformPageChunk) {
+															html = (await options.transformPageChunk({ html, done })) ?? '';
+														}
 
-											if (parent_options?.transformPageChunk) {
-												html = (await parent_options.transformPageChunk({ html, done })) ?? '';
-											}
+														if (parent_options?.transformPageChunk) {
+															html =
+																(await parent_options.transformPageChunk({ html, done })) ?? '';
+														}
 
-											return html;
-										},
+														return html;
+													}
+												: undefined,
 										filterSerializedResponseHeaders:
 											parent_options?.filterSerializedResponseHeaders ??
 											options?.filterSerializedResponseHeaders,

--- a/packages/kit/src/exports/hooks/sequence.js
+++ b/packages/kit/src/exports/hooks/sequence.js
@@ -112,28 +112,24 @@ export function sequence(...handlers) {
 							handle({
 								event: traced_event,
 								resolve: (event, options) => {
-									/** @type {ResolveOptions['transformPageChunk']} */
-									const transformPageChunk = async ({ html, done }) => {
-										if (options?.transformPageChunk) {
-											html = (await options.transformPageChunk({ html, done })) ?? '';
-										}
+									/** @type {ResolveOptions} */
+									const merged = {
+										transformPageChunk: async ({ html, done }) => {
+											if (options?.transformPageChunk) {
+												html = (await options.transformPageChunk({ html, done })) ?? '';
+											}
 
-										if (parent_options?.transformPageChunk) {
-											html = (await parent_options.transformPageChunk({ html, done })) ?? '';
-										}
+											if (parent_options?.transformPageChunk) {
+												html = (await parent_options.transformPageChunk({ html, done })) ?? '';
+											}
 
-										return html;
+											return html;
+										},
+										filterSerializedResponseHeaders:
+											parent_options?.filterSerializedResponseHeaders ??
+											options?.filterSerializedResponseHeaders,
+										preload: parent_options?.preload ?? options?.preload
 									};
-
-									/** @type {ResolveOptions['filterSerializedResponseHeaders']} */
-									const filterSerializedResponseHeaders =
-										parent_options?.filterSerializedResponseHeaders ??
-										options?.filterSerializedResponseHeaders;
-
-									/** @type {ResolveOptions['preload']} */
-									const preload = parent_options?.preload ?? options?.preload;
-
-									const merged = { transformPageChunk, filterSerializedResponseHeaders, preload };
 
 									return i < length - 1
 										? apply_handle(i + 1, event, merged)

--- a/packages/kit/src/exports/hooks/sequence.js
+++ b/packages/kit/src/exports/hooks/sequence.js
@@ -85,12 +85,11 @@ const noop_record_span = ({ fn }) => fn(noop_span);
  */
 export function sequence(...handlers) {
 	const length = handlers.length;
-	if (!length) return ({ event, resolve }) => resolve(event);
 
 	return ({ event, resolve }) => {
 		const store = try_get_request_store();
 		const record_span = store?.state.tracing.record_span ?? noop_record_span;
-		return apply_handle(0, event, {});
+		return apply_handle(0, event, undefined);
 
 		/**
 		 * @param {number} i

--- a/packages/kit/src/exports/hooks/sequence.js
+++ b/packages/kit/src/exports/hooks/sequence.js
@@ -99,6 +99,8 @@ export function sequence(...handlers) {
 		 * @returns {Promise<Response>}
 		 */
 		function apply_handle(i, event, parent_options) {
+			if (i === length) return resolve(event, parent_options);
+
 			const handle = handlers[i];
 
 			return record_span({
@@ -131,9 +133,7 @@ export function sequence(...handlers) {
 										preload: parent_options?.preload ?? options?.preload
 									};
 
-									return i < length - 1
-										? apply_handle(i + 1, event, merged)
-										: resolve(event, merged);
+									return apply_handle(i + 1, event, merged);
 								}
 							})
 					);

--- a/packages/kit/src/exports/hooks/sequence.js
+++ b/packages/kit/src/exports/hooks/sequence.js
@@ -133,17 +133,11 @@ export function sequence(...handlers) {
 									/** @type {ResolveOptions['preload']} */
 									const preload = parent_options?.preload ?? options?.preload;
 
+									const merged = { transformPageChunk, filterSerializedResponseHeaders, preload };
+
 									return i < length - 1
-										? apply_handle(i + 1, event, {
-												transformPageChunk,
-												filterSerializedResponseHeaders,
-												preload
-											})
-										: resolve(event, {
-												transformPageChunk,
-												filterSerializedResponseHeaders,
-												preload
-											});
+										? apply_handle(i + 1, event, merged)
+										: resolve(event, merged);
 								}
 							})
 					);

--- a/packages/kit/src/exports/hooks/sequence.js
+++ b/packages/kit/src/exports/hooks/sequence.js
@@ -88,7 +88,7 @@ export function sequence(...handlers) {
 
 	return ({ event, resolve }) => {
 		const store = try_get_request_store();
-		const record_span = store?.state.tracing.record_span ?? noop_record_span;
+		const record_span = store ? store.state.tracing.record_span : noop_record_span;
 		return apply_handle(0, event, undefined);
 
 		/**

--- a/packages/kit/src/exports/hooks/sequence.js
+++ b/packages/kit/src/exports/hooks/sequence.js
@@ -1,9 +1,14 @@
 /** @import { Handle, RequestEvent, ResolveOptions } from '@sveltejs/kit' */
+/** @import { RecordSpan } from 'types' */
 import {
 	merge_tracing,
-	get_request_store,
+	try_get_request_store,
 	with_request_store
 } from '@sveltejs/kit/internal/server';
+import { noop_span } from '../../runtime/telemetry/noop.js';
+
+/** @type {RecordSpan} */
+const noop_record_span = ({ fn }) => fn(noop_span);
 
 /**
  * A helper function for sequencing multiple `handle` calls in a middleware-like manner.
@@ -83,7 +88,8 @@ export function sequence(...handlers) {
 	if (!length) return ({ event, resolve }) => resolve(event);
 
 	return ({ event, resolve }) => {
-		const { state } = get_request_store();
+		const store = try_get_request_store();
+		const record_span = store?.state.tracing.record_span ?? noop_record_span;
 		return apply_handle(0, event, {});
 
 		/**
@@ -95,49 +101,51 @@ export function sequence(...handlers) {
 		function apply_handle(i, event, parent_options) {
 			const handle = handlers[i];
 
-			return state.tracing.record_span({
+			return record_span({
 				name: `sveltekit.handle.sequenced.${handle.name ? handle.name : i}`,
 				attributes: {},
 				fn: async (current) => {
 					const traced_event = merge_tracing(event, current);
-					return await with_request_store({ event: traced_event, state }, () =>
-						handle({
-							event: traced_event,
-							resolve: (event, options) => {
-								/** @type {ResolveOptions['transformPageChunk']} */
-								const transformPageChunk = async ({ html, done }) => {
-									if (options?.transformPageChunk) {
-										html = (await options.transformPageChunk({ html, done })) ?? '';
-									}
+					return await with_request_store(
+						store && { event: traced_event, state: store.state },
+						() =>
+							handle({
+								event: traced_event,
+								resolve: (event, options) => {
+									/** @type {ResolveOptions['transformPageChunk']} */
+									const transformPageChunk = async ({ html, done }) => {
+										if (options?.transformPageChunk) {
+											html = (await options.transformPageChunk({ html, done })) ?? '';
+										}
 
-									if (parent_options?.transformPageChunk) {
-										html = (await parent_options.transformPageChunk({ html, done })) ?? '';
-									}
+										if (parent_options?.transformPageChunk) {
+											html = (await parent_options.transformPageChunk({ html, done })) ?? '';
+										}
 
-									return html;
-								};
+										return html;
+									};
 
-								/** @type {ResolveOptions['filterSerializedResponseHeaders']} */
-								const filterSerializedResponseHeaders =
-									parent_options?.filterSerializedResponseHeaders ??
-									options?.filterSerializedResponseHeaders;
+									/** @type {ResolveOptions['filterSerializedResponseHeaders']} */
+									const filterSerializedResponseHeaders =
+										parent_options?.filterSerializedResponseHeaders ??
+										options?.filterSerializedResponseHeaders;
 
-								/** @type {ResolveOptions['preload']} */
-								const preload = parent_options?.preload ?? options?.preload;
+									/** @type {ResolveOptions['preload']} */
+									const preload = parent_options?.preload ?? options?.preload;
 
-								return i < length - 1
-									? apply_handle(i + 1, event, {
-											transformPageChunk,
-											filterSerializedResponseHeaders,
-											preload
-										})
-									: resolve(event, {
-											transformPageChunk,
-											filterSerializedResponseHeaders,
-											preload
-										});
-							}
-						})
+									return i < length - 1
+										? apply_handle(i + 1, event, {
+												transformPageChunk,
+												filterSerializedResponseHeaders,
+												preload
+											})
+										: resolve(event, {
+												transformPageChunk,
+												filterSerializedResponseHeaders,
+												preload
+											});
+								}
+							})
 					);
 				}
 			});

--- a/packages/kit/src/exports/hooks/sequence.spec.js
+++ b/packages/kit/src/exports/hooks/sequence.spec.js
@@ -1,31 +1,39 @@
 /** @import { RequestEvent } from '@sveltejs/kit' */
-/** @import { RequestState } from 'types' */
-import { assert, expect, test, vi } from 'vitest';
+import { assert, expect, test } from 'vitest';
 import { sequence } from './sequence.js';
-import { noop_span } from '../../runtime/telemetry/noop.js';
 
-const dummy_event = vi.hoisted(
-	() =>
-		/** @type {RequestEvent} */ ({
-			tracing: {
-				root: {}
-			}
-		})
-);
+const dummy_event = /** @type {RequestEvent} */ ({
+	tracing: {
+		root: {}
+	}
+});
 
-vi.mock(import('@sveltejs/kit/internal/server'), async (actualPromise) => {
-	const actual = await actualPromise();
-	return {
-		...actual,
-		get_request_store: () => ({
-			event: dummy_event,
-			state: /** @type {RequestState} */ ({
-				tracing: {
-					record_span: ({ fn }) => fn(noop_span)
-				}
-			})
-		})
-	};
+test('runs without a request store', async () => {
+	/** @type {string[]} */
+	const order = [];
+
+	const handler = sequence(
+		async ({ event, resolve }) => {
+			order.push('1a');
+			const response = await resolve(event);
+			order.push('1b');
+			return response;
+		},
+		async ({ event, resolve }) => {
+			order.push('2a');
+			const response = await resolve(event);
+			order.push('2b');
+			return response;
+		}
+	);
+
+	const response = new Response();
+
+	assert.equal(
+		await handler({ event: dummy_event, resolve: () => Promise.resolve(response) }),
+		response
+	);
+	expect(order).toEqual(['1a', '2a', '2b', '1b']);
 });
 
 test('applies handlers in sequence', async () => {

--- a/packages/kit/src/exports/hooks/sequence.spec.js
+++ b/packages/kit/src/exports/hooks/sequence.spec.js
@@ -9,31 +9,15 @@ const dummy_event = /** @type {RequestEvent} */ ({
 });
 
 test('runs without a request store', async () => {
-	/** @type {string[]} */
-	const order = [];
-
 	const handler = sequence(
-		async ({ event, resolve }) => {
-			order.push('1a');
-			const response = await resolve(event);
-			order.push('1b');
-			return response;
-		},
-		async ({ event, resolve }) => {
-			order.push('2a');
-			const response = await resolve(event);
-			order.push('2b');
-			return response;
-		}
+		async ({ event, resolve }) => resolve(event),
+		async ({ event, resolve }) => resolve(event)
 	);
 
 	const response = new Response();
+	const event = /** @type {RequestEvent} */ ({});
 
-	assert.equal(
-		await handler({ event: dummy_event, resolve: () => Promise.resolve(response) }),
-		response
-	);
-	expect(order).toEqual(['1a', '2a', '2b', '1b']);
+	assert.equal(await handler({ event, resolve: () => Promise.resolve(response) }), response);
 });
 
 test('applies handlers in sequence', async () => {


### PR DESCRIPTION
fixes #14249

Since #13899 the handle returned by `sequence` calls `get_request_store()` before running any handler, so invoking it directly (the unit testing case in the issue) throws. This swaps in `try_get_request_store()` and degrades the way elliott described in the issue thread.

The spec no longer needs to mock `@sveltejs/kit/internal/server` to get past the throw; the tests now run against the real modules.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
