### PR TITLE
chore: remove the dead SSRState.fallback field and make the server state fork explicit

### DIFF
--- a/.changeset/swift-otters-fork.md
+++ b/.changeset/swift-otters-fork.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+chore: remove the dead `SSRState.fallback` field and name the server state fork semantics

--- a/packages/kit/src/runtime/server/fetch.js
+++ b/packages/kit/src/runtime/server/fetch.js
@@ -4,6 +4,7 @@ import { respond } from './respond.js';
 import * as paths from '$app/paths/internal/server';
 import { read_implementation } from './internal.js';
 import { has_prerendered_path } from './utils.js';
+import { fork_state_for_subrequest } from './state.js';
 
 /**
  * @param {{
@@ -198,6 +199,8 @@ function normalize_fetch_input(info, init, url) {
  * @returns {Promise<Response>}
  */
 async function internal_fetch(request, options, manifest, state) {
+	const subrequest_state = fork_state_for_subrequest(state);
+
 	if (request.signal) {
 		if (request.signal.aborted) {
 			throw new DOMException('The operation was aborted.', 'AbortError');
@@ -214,18 +217,12 @@ async function internal_fetch(request, options, manifest, state) {
 		});
 
 		const result = await Promise.race([
-			respond(request, options, manifest, {
-				...state,
-				depth: state.depth + 1
-			}),
+			respond(request, options, manifest, subrequest_state),
 			abort_promise
 		]);
 		remove_abort_listener();
 		return result;
 	} else {
-		return await respond(request, options, manifest, {
-			...state,
-			depth: state.depth + 1
-		});
+		return await respond(request, options, manifest, subrequest_state);
 	}
 }

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -1,4 +1,4 @@
-/** @import { RequestState, SSRNode } from 'types' */
+/** @import { SSRNode } from 'types' */
 import { DEV } from 'esm-env';
 import { json, text } from '@sveltejs/kit';
 import { Redirect, SvelteKitError } from '@sveltejs/kit/internal';
@@ -40,6 +40,7 @@ import { server_data_serializer } from './page/data_serializer.js';
 import { get_remote_id, handle_remote_call } from './remote-functions.js';
 import { record_span } from '../telemetry/record_span.js';
 import { otel } from '../telemetry/otel.js';
+import { create_request_state } from './state.js';
 
 /** @type {import('types').RequiredResolveOptions['transformPageChunk']} */
 const default_transform = ({ html }) => html;
@@ -174,30 +175,7 @@ export async function internal_respond(request, options, manifest, state) {
 		url
 	);
 
-	/** @type {RequestState} */
-	const event_state = {
-		prerendering: state.prerendering,
-		transport: options.hooks.transport,
-		handleValidationError: options.hooks.handleValidationError,
-		tracing: {
-			record_span
-		},
-		remote: {
-			data: null,
-			explicit: null,
-			implicit: null,
-			forms: null,
-			requested: null,
-			batches: null,
-			live_iterators: null
-		},
-		is_in_remote_function: false,
-		is_in_remote_form_or_command: false,
-		is_in_remote_query: false,
-		is_in_remote_prerender: false,
-		is_in_render: false,
-		is_in_universal_load: false
-	};
+	const event_state = create_request_state(state, options.hooks);
 
 	/** @type {import('@sveltejs/kit').RequestEvent} */
 	const event = {

--- a/packages/kit/src/runtime/server/state.js
+++ b/packages/kit/src/runtime/server/state.js
@@ -1,0 +1,43 @@
+/** @import { RequestState, ServerHooks, SSRState } from 'types' */
+import { record_span } from '../telemetry/record_span.js';
+
+/**
+ * @param {SSRState} state
+ * @param {ServerHooks} hooks
+ * @returns {RequestState}
+ */
+export function create_request_state(state, hooks) {
+	// Request state is rebuilt fresh, resetting remote caches and context flags.
+	return {
+		prerendering: state.prerendering,
+		transport: hooks.transport,
+		handleValidationError: hooks.handleValidationError,
+		tracing: {
+			record_span
+		},
+		remote: {
+			data: null,
+			explicit: null,
+			implicit: null,
+			forms: null,
+			requested: null,
+			batches: null,
+			live_iterators: null
+		},
+		is_in_remote_function: false,
+		is_in_remote_form_or_command: false,
+		is_in_remote_query: false,
+		is_in_remote_prerender: false,
+		is_in_render: false,
+		is_in_universal_load: false
+	};
+}
+
+/**
+ * @param {SSRState} state
+ * @returns {SSRState}
+ */
+export function fork_state_for_subrequest(state) {
+	// Sub-requests inherit all server state except for the incremented depth.
+	return { ...state, depth: state.depth + 1 };
+}

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -536,7 +536,6 @@ export interface SSRClientRoute {
 }
 
 export interface SSRState {
-	fallback?: string;
 	getClientAddress(): string;
 	/**
 	 * True if we're currently attempting to render an error page.


### PR DESCRIPTION
First stage of #16519: the dead field and the fork semantics. No behavior change; the new module is the seam later stages merge into.

The dev context half will look different once the Vite middleware approach lands.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
