### PR TITLE
fix: correctly decode Unicode escape sequences above ffff

### DIFF
--- a/.changeset/cold-pans-decode.md
+++ b/.changeset/cold-pans-decode.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: decode all numeric character references, including above `ffff`, when crawling prerendered pages

--- a/.changeset/witty-moons-smile.md
+++ b/.changeset/witty-moons-smile.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correctly decode `[u+nnnn]` escape sequences above `ffff`

--- a/packages/kit/src/core/postbuild/entities.js
+++ b/packages/kit/src/core/postbuild/entities.js
@@ -2252,7 +2252,7 @@ export function decode(str) {
 			// mirror the HTML parser, which replaces invalid numeric references with U+FFFD
 			return Number.isInteger(codepoint) && codepoint <= 0x10ffff
 				? String.fromCodePoint(codepoint)
-				: '�';
+				: '\ufffd';
 		})
 		.replace(named, (_match, entity) => entities[entity]);
 }

--- a/packages/kit/src/core/postbuild/entities.js
+++ b/packages/kit/src/core/postbuild/entities.js
@@ -2236,7 +2236,7 @@ const entities = {
 	'zwnj;': '‌'
 };
 
-const numeric = /&#(x)?([0-9a-f]+);/i;
+const numeric = /&#(x)?([0-9a-f]+);/gi;
 const named = new RegExp(
 	`&(${Object.keys(entities)
 		.sort((a, b) => b.length - a.length)
@@ -2247,6 +2247,12 @@ const named = new RegExp(
 /** @param {string} str */
 export function decode(str) {
 	return str
-		.replace(numeric, (_match, hex, code) => String.fromCharCode(hex ? parseInt(code, 16) : +code))
+		.replace(numeric, (_match, hex, code) => {
+			const codepoint = hex ? parseInt(code, 16) : +code;
+			// mirror the HTML parser, which replaces invalid numeric references with U+FFFD
+			return Number.isInteger(codepoint) && codepoint <= 0x10ffff
+				? String.fromCodePoint(codepoint)
+				: '�';
+		})
 		.replace(named, (_match, entity) => entities[entity]);
 }

--- a/packages/kit/src/core/postbuild/entities.spec.js
+++ b/packages/kit/src/core/postbuild/entities.spec.js
@@ -31,7 +31,12 @@ const tests = [
 	{ input: '&#X3a;', output: ':' },
 	{ input: '&#X3A;', output: ':' },
 	{ input: '&>', output: '&>' },
-	{ input: 'id=770&#anchor', output: 'id=770&#anchor' }
+	{ input: 'id=770&#anchor', output: 'id=770&#anchor' },
+	{ input: '/a?x=1&#38;y=2&#38;z=3', output: '/a?x=1&y=2&z=3' },
+	{ input: '&#128512;', output: '😀' },
+	{ input: '&#x1f600;', output: '😀' },
+	{ input: '&#1114112;', output: '�' },
+	{ input: '&#deaf;', output: '�' }
 ];
 
 for (const { input, output } of tests) {

--- a/packages/kit/src/core/sync/create_manifest_data/conflict.js
+++ b/packages/kit/src/core/sync/create_manifest_data/conflict.js
@@ -60,7 +60,7 @@ function normalize_route_id(id) {
 			.replace(/(?<=^|\/)\(.+?\)(?=$|\/)/g, '')
 
 			.replace(/\[[ux]\+([0-9a-f]+)\]/g, (_, x) =>
-				String.fromCharCode(parseInt(x, 16)).replace(/\//g, '%2f')
+				String.fromCodePoint(parseInt(x, 16)).replace(/\//g, '%2f')
 			)
 
 			// replace `[param]` with `<*>`, `[param=x]` with `<x>`, and `[[param]]` with `<?*>`

--- a/packages/kit/src/core/sync/create_manifest_data/index.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.js
@@ -135,7 +135,7 @@ function create_routes_and_nodes(cwd, config, fallback) {
 						);
 					}
 
-					return String.fromCharCode(parseInt(code, 16));
+					return String.fromCodePoint(parseInt(code, 16));
 				}
 			});
 

--- a/packages/kit/src/core/sync/create_manifest_data/index.spec.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.spec.js
@@ -208,6 +208,7 @@ test('succeeds when routes does not exist', () => {
 test('encodes invalid characters', () => {
 	const { nodes, routes } = create('samples/encoding');
 
+	const emoji = { component: 'samples/encoding/[u+1f600]/+page.svelte' };
 	const quote = { component: 'samples/encoding/[x+22]/+page.svelte' };
 	const hash = { component: 'samples/encoding/[x+23]/+page.svelte' };
 	const question_mark = { component: 'samples/encoding/[x+3f]/+page.svelte' };
@@ -217,6 +218,7 @@ test('encodes invalid characters', () => {
 	expect(nodes.map(simplify_node)).toEqual([
 		default_layout,
 		default_error,
+		emoji,
 		quote,
 		hash,
 		question_mark,
@@ -225,8 +227,8 @@ test('encodes invalid characters', () => {
 	]);
 
 	expect(routes.map((p) => p.pattern.toString())).toEqual(
-		[/^\/$/, /^\/\]\/?$/, /^\/\[\/?$/, /^\/%3[Ff]\/?$/, /^\/%23\/?$/, /^\/"\/?$/].map((pattern) =>
-			pattern.toString()
+		[/^\/$/, /^\/\]\/?$/, /^\/\[\/?$/, /^\/%3[Ff]\/?$/, /^\/%23\/?$/, /^\/"\/?$/, /^\/😀\/?$/].map(
+			(pattern) => pattern.toString()
 		)
 	);
 });

--- a/packages/kit/src/utils/routing.js
+++ b/packages/kit/src/utils/routing.js
@@ -12,7 +12,7 @@ const escape_sequence_pattern = /\[([ux])\+([^\]]+)\]/;
  * @param {string} code the sequence without its `[x+`/`[u+` prefix or `]` suffix
  */
 function decode_escape_sequence(code) {
-	return String.fromCharCode(...code.split('-').map((codepoint) => parseInt(codepoint, 16)));
+	return String.fromCodePoint(...code.split('-').map((codepoint) => parseInt(codepoint, 16)));
 }
 
 /**

--- a/packages/kit/src/utils/routing.spec.js
+++ b/packages/kit/src/utils/routing.spec.js
@@ -481,6 +481,11 @@ describe('resolve_route', () => {
 			expected: '/A/one'
 		},
 		{
+			route: '/[u+1f600]/[one]',
+			params: { one: 'one' },
+			expected: '/😀/one'
+		},
+		{
 			route: '/blog/[one]',
 			params: { one: '[x+2f]' },
 			expected: '/blog/[x+2f]'


### PR DESCRIPTION
`[u+1f600]` didn't produce `😀` because `String.fromCharCode` truncates above `ffff`. The docs promise values up to `10ffff`. Also fixes the same truncation in the crawler's entity decoder.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.