### PR TITLE
fix: error when reading non-serialized set-cookie headers in load

### DIFF
--- a/.changeset/quick-cookies-guarded.md
+++ b/.changeset/quick-cookies-guarded.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: error when reading non-serialized `set-cookie` headers via `getSetCookie` in `load`

--- a/packages/kit/src/runtime/server/page/load_data.js
+++ b/packages/kit/src/runtime/server/page/load_data.js
@@ -482,6 +482,21 @@ export function create_universal_fetch(event, state, fetched, csr, resolve_opts)
 
 				return value;
 			};
+
+			const get_set_cookie = response.headers.getSetCookie;
+			response.headers.getSetCookie = () => {
+				const values = get_set_cookie.call(response.headers);
+				for (const value of values) {
+					const included = resolve_opts.filterSerializedResponseHeaders('set-cookie', value);
+					if (!included) {
+						throw new Error(
+							`Failed to get response header "set-cookie" — it must be included by the \`filterSerializedResponseHeaders\` option: https://svelte.dev/docs/kit/hooks#handle (at ${event.route.id})`
+						);
+					}
+				}
+
+				return values;
+			};
 		}
 
 		return proxy;

--- a/packages/kit/src/runtime/server/page/load_data.spec.js
+++ b/packages/kit/src/runtime/server/page/load_data.spec.js
@@ -73,3 +73,15 @@ test('errors when trying to access non-serialized request headers on the server'
 		/Failed to get response header "content-type" — it must be included by the `filterSerializedResponseHeaders` option/
 	);
 });
+
+test('errors when trying to access non-serialized set-cookie headers on the server', async () => {
+	const fetch = create_fetch({
+		// eslint-disable-next-line @typescript-eslint/require-await
+		fetch: async () => new Response('foo', { headers: { 'set-cookie': 'a=1' } })
+	});
+	const response = await fetch('https://domain-a.com');
+	assert.throws(
+		() => response.headers.getSetCookie(),
+		/Failed to get response header "set-cookie" — it must be included by the `filterSerializedResponseHeaders` option/
+	);
+});


### PR DESCRIPTION
`getSetCookie` bypassed the `filterSerializedResponseHeaders` guard, so reads that work during SSR silently return `[]` after hydration. `has()` and iteration still bypass it; a Proxy would cover everything if that's the way to go.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
