### PR TITLE
fix: avoid caching immutable asset 404s when configured for Vercel

### DIFF
--- a/.changeset/grumpy-sites-float.md
+++ b/.changeset/grumpy-sites-float.md
@@ -2,4 +2,4 @@
 '@sveltejs/adapter-static': patch
 ---
 
-fix: avoid caching 404s when configuring for Vercel
+fix: avoid caching immutable asset 404s when configuring for Vercel

--- a/.changeset/grumpy-sites-float.md
+++ b/.changeset/grumpy-sites-float.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-static': patch
+---
+
+fix: avoid caching 404s when configuring for Vercel

--- a/packages/adapter-static/platforms.js
+++ b/packages/adapter-static/platforms.js
@@ -72,6 +72,19 @@ function static_vercel_config(builder) {
 			},
 			{
 				handle: 'filesystem'
+			},
+			// Prevent incorrect caching: if a request to /_app/immutable/* doesn't match
+			// a static file, return 404 instead of falling through to dynamic routes.
+			// Otherwise, we could accidentally immutably cache dynamic content served
+			// by the fallback function. `no-store` stops the earlier immutable header
+			// from sticking to this 404, so a missing asset isn't cached for a year.
+			{
+				src: `/${builder.getAppPath()}/immutable/.+`,
+				status: 404,
+				headers: {
+					'cache-control': 'no-store'
+				},
+				continue: false
 			}
 		],
 		overrides


### PR DESCRIPTION
Same as the one that was [fixed in the Vercel adapter](https://github.com/sveltejs/kit/pull/16077) but not in the static adapter