### PR TITLE
fix: avoid caching immutable asset 404s

### DIFF
--- a/.changeset/sixty-clubs-show.md
+++ b/.changeset/sixty-clubs-show.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-cloudflare': patch
+---
+
+fix: avoid caching immutable asset 404s

--- a/packages/adapter-cloudflare/src/worker.js
+++ b/packages/adapter-cloudflare/src/worker.js
@@ -81,6 +81,12 @@ export default {
 			pathname.startsWith(immutable)
 		) {
 			res = await env.ASSETS.fetch(req);
+			// `_headers` applies cache regardless of status, so we need to ensure an
+			// error response does not get cached
+			if (res.status >= 400) {
+				res = new Response(res.body, res); // headers from ASSETS are immutable. see https://developers.cloudflare.com/workers/examples/alter-headers/
+				res.headers.set('cache-control', 'no-store');
+			}
 		} else if (location && prerendered.has(location)) {
 			// trailing slash redirect for prerendered pages
 			if (search) location += search;


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/16615

This only fixes it for Cloudflare Workers since the 404 falls back to running the worker; Cloudflare Pages does not run the worker on static asset 404s.

I don’t think there’s a way to do this without running the worker. Also, Cloudflare probably won’t try to fix this in Cloudflare Pages since they’re fully set on Cloudflare Workers now

EDIT: fun facts:
- Chrome automatically applies `no-store` if it's a 404
- Netlify overrides the header with `max-age: 0` to avoid the bad cache