### PR TITLE
breaking: strip `content-encoding` and `content-length` headers when returning responses created with `fetch`

### DIFF
--- a/.changeset/wild-steaks-visit.md
+++ b/.changeset/wild-steaks-visit.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': major
+---
+
+breaking: strip `content-encoding` and `content-length` headers when returning responses created with `fetch`

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -203,10 +203,15 @@ export class Server {
 
 		if (decoded_responses.has(response)) {
 			// The body was already decoded by `fetch`, so we need to strip
-			// these headers to avoid as `ERR_CONTENT_DECODING_FAILED` error
+			// these headers to avoid as `ERR_CONTENT_DECODING_FAILED` error.
+			// `fetch` only decodes when a `content-encoding` is present, so we
+			// only strip the headers in that case to avoid discarding a valid
+			// `content-length` (e.g. for uncompressed or 206 range responses).
 			const headers = new Headers(response.headers);
-			headers.delete('content-encoding');
-			headers.delete('content-length');
+			if (headers.has('content-encoding')) {
+				headers.delete('content-encoding');
+				headers.delete('content-length');
+			}
 
 			return new Response(response.body, {
 				status: response.status,

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -13,6 +13,26 @@ let init_promise;
 /** @type {Promise<void> | null} */
 let current = null;
 
+/**
+ * Responses that were created with our monkey-patched `fetch`, which may need
+ * to have their `content-encoding` and `content-length` headers removed
+ * if returned directly (i.e. `fetch` is being used to proxy a request)
+ * @type {WeakSet<Response>}
+ */
+const decoded_responses = new WeakSet();
+
+const fetch = globalThis.fetch;
+
+/**
+ * @param {RequestInfo | URL} info
+ * @param {RequestInit} [init]
+ */
+globalThis.fetch = async (info, init) => {
+	const response = await fetch(info, init);
+	decoded_responses.add(response);
+	return response;
+};
+
 export class Server {
 	/** @type {import('types').SSROptions} */
 	#options;
@@ -174,11 +194,27 @@ export class Server {
 	 * @param {Request} request
 	 * @param {import('types').RequestOptions} options
 	 */
-	respond(request, options) {
-		return respond(request, this.#options, this.#manifest, {
+	async respond(request, options) {
+		const response = await respond(request, this.#options, this.#manifest, {
 			...options,
 			error: false,
 			depth: 0
 		});
+
+		if (decoded_responses.has(response)) {
+			// The body was already decoded by `fetch`, so we need to strip
+			// these headers to avoid as `ERR_CONTENT_DECODING_FAILED` error
+			const headers = new Headers(response.headers);
+			headers.delete('content-encoding');
+			headers.delete('content-length');
+
+			return new Response(response.body, {
+				status: response.status,
+				statusText: response.statusText,
+				headers
+			});
+		}
+
+		return response;
 	}
 }


### PR DESCRIPTION
This is my best attempt to fix #12197. It captures the `return fetch(...)` case, and I _think_ that's the only one we need to worry about. It does mean that the body is sent uncompressed to the client — we're not attempting to reëncode, and in fact we're _preventing_ platforms like Cloudflare Workers (which take the existence of a `Content-Encoding: gzip` header as an invitation to apply said compression) from doing so. But this seems like the safest, most realistic and least invasive solution.

TODO add a test

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
