### PR TITLE
chore: bump vite-imagetools

### DIFF
--- a/.changeset/plenty-wasps-hang.md
+++ b/.changeset/plenty-wasps-hang.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/enhanced-img': patch
+---
+
+chore: bump `vite-imagetools` to v11

--- a/packages/enhanced-img/package.json
+++ b/packages/enhanced-img/package.json
@@ -41,7 +41,7 @@
 		"magic-string": "^0.30.21",
 		"sharp": "^0.35.3",
 		"svelte-parse-markup": "^0.1.5",
-		"vite-imagetools": "^10.0.1",
+		"vite-imagetools": "^11.0.0",
 		"zimmerframe": "^1.1.2"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -475,8 +475,8 @@ importers:
         specifier: ^0.1.5
         version: 0.1.5(svelte@5.56.3(@typescript-eslint/types@8.61.1))
       vite-imagetools:
-        specifier: ^10.0.1
-        version: 10.0.1(@types/node@22.19.19)(vite@8.1.5(@types/node@22.19.19)(esbuild@0.28.1)(jiti@2.4.2)(yaml@2.9.0))
+        specifier: ^11.0.0
+        version: 11.0.0(@types/node@22.19.19)(vite@8.1.5(@types/node@22.19.19)(esbuild@0.28.1)(jiti@2.4.2)(yaml@2.9.0))
       zimmerframe:
         specifier: ^1.1.2
         version: 1.1.2
@@ -3396,8 +3396,8 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
-  imagetools-core@10.0.0:
-    resolution: {integrity: sha512-wirG+oESU1QTORt+fqR6DAsVMgW5CXgrRaGgf1lo4hu/3q6269GfHBmYpVWzmMIuHM/H01QcaWrHR6kHCC7bOw==}
+  imagetools-core@11.0.0:
+    resolution: {integrity: sha512-BaNX7im/o7PqGmck3/wElRx4xugnJYIMtPfOIAHEd2ZV1ZyalewE0H9nm/czZcjdtsgxVW7IzL0oJQn6J8kZuA==}
     engines: {node: '>=22.0.0'}
 
   import-in-the-middle@3.0.0:
@@ -4082,11 +4082,11 @@ packages:
       typescript:
         optional: true
 
-  vite-imagetools@10.0.1:
-    resolution: {integrity: sha512-JfM1rUSLQoPAA+8RB9TFxxpfSjmBpLTkU5zaSFPlWYlgfc3g2gFfYH+u+HghqNy+6HCw6zJBmq+2exx6pMJFOg==}
+  vite-imagetools@11.0.0:
+    resolution: {integrity: sha512-9mMuI/gum/hg7OT2VUfVJvolmACJbc1kStMmm0ydoUHX+3jsj1zvsbmI0DYt2K8u2Tex6kiTuj86xDuIYNgV2A==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
-      vite: '>=7.0.0'
+      vite: '>=8.0.0'
 
   vite@8.1.5:
     resolution: {integrity: sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==}
@@ -6042,7 +6042,7 @@ snapshots:
 
   ignore@7.0.5: {}
 
-  imagetools-core@10.0.0: {}
+  imagetools-core@11.0.0: {}
 
   import-in-the-middle@3.0.0:
     dependencies:
@@ -6715,10 +6715,10 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  vite-imagetools@10.0.1(@types/node@22.19.19)(vite@8.1.5(@types/node@22.19.19)(esbuild@0.28.1)(jiti@2.4.2)(yaml@2.9.0)):
+  vite-imagetools@11.0.0(@types/node@22.19.19)(vite@8.1.5(@types/node@22.19.19)(esbuild@0.28.1)(jiti@2.4.2)(yaml@2.9.0)):
     dependencies:
       '@rollup/pluginutils': 5.4.0
-      imagetools-core: 10.0.0
+      imagetools-core: 11.0.0
       sharp: 0.35.3(@types/node@22.19.19)
       vite: 8.1.5(@types/node@22.19.19)(esbuild@0.28.1)(jiti@2.4.2)(yaml@2.9.0)
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,8 @@ minimumReleaseAgeExclude:
   - prettier-plugin-svelte
   - svelte-check
   - esm-env
+  - vite-imagetools
+  - imagetools-core
 blockExoticSubdeps: true
 linkWorkspacePackages: true
 shellEmulator: true


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/16616

Not sure if the changeset should be a major. Decided on patch since it doesn't actually break anything user-facing for `@sveltejs/enhanced-img`