### PR TITLE
chore: deflake tests that share mutable server state

### DIFF
--- a/packages/kit/test/apps/async/src/hooks.server.js
+++ b/packages/kit/test/apps/async/src/hooks.server.js
@@ -7,8 +7,8 @@ export async function handle({ event, resolve }) {
 	// state in `routes/remote/query-command.remote.js` is isolated per test.
 	// Without this, tests running in parallel (different Playwright workers)
 	// against the same server clobber each other's state and flake.
-	if (!event.cookies.get('count_session')) {
-		event.cookies.set('count_session', crypto.randomUUID(), {
+	if (!event.cookies.get('session')) {
+		event.cookies.set('session', crypto.randomUUID(), {
 			path: '/',
 			httpOnly: true,
 			sameSite: 'lax'

--- a/packages/kit/test/apps/async/src/routes/remote/form/as-value/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/as-value/+page.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { as_value_form, get_values, get_hidden_values, reset_values } from './form.remote.ts';
+	import { as_value_form, get_values, get_hidden_values } from './form.remote.ts';
 	import Form from './Form.svelte';
 
 	const values = $derived(await get_values());
@@ -35,10 +35,6 @@
 		{...as_value_form.fields.text_field.as('text', 'default text')}
 	/>
 </div>
-
-<form {...reset_values}>
-	<button id="reset-values" type="submit">reset</button>
-</form>
 
 <style>
 	.forms {

--- a/packages/kit/test/apps/async/src/routes/remote/form/as-value/form.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/form/as-value/form.remote.ts
@@ -39,14 +39,9 @@ const default_values: Array<Omit<v.InferOutput<typeof ValueSchema>, 'hidden'>> =
 	}
 ];
 
-type SessionState = {
-	values: typeof default_values;
-	hidden_values: { string?: string; number?: number; boolean?: boolean };
-};
-
-const session = per_session((): SessionState => ({
+const session = per_session(() => ({
 	values: structuredClone(default_values),
-	hidden_values: {}
+	hidden_values: {} as { string?: string; number?: number; boolean?: boolean }
 }));
 
 export const get_values = query(() => session().values);

--- a/packages/kit/test/apps/async/src/routes/remote/form/as-value/form.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/form/as-value/form.remote.ts
@@ -1,5 +1,6 @@
 import { form, query } from '$app/server';
 import * as v from 'valibot';
+import { per_session } from '../../per-session.js';
 
 const ValueSchema = v.object({
 	id: v.string(),
@@ -38,18 +39,21 @@ const default_values: Array<Omit<v.InferOutput<typeof ValueSchema>, 'hidden'>> =
 	}
 ];
 
-let values = structuredClone(default_values);
+type SessionState = {
+	values: typeof default_values;
+	hidden_values: { string?: string; number?: number; boolean?: boolean };
+};
 
-export const get_values = query(() => values);
+const session = per_session((): SessionState => ({
+	values: structuredClone(default_values),
+	hidden_values: {}
+}));
 
-let hidden_values: {
-	string?: string;
-	number?: number;
-	boolean?: boolean;
-} = {};
+export const get_values = query(() => session().values);
 
 export const as_value_form = form(ValueSchema, async (data) => {
-	const element = values.find((v) => v.id === data.id);
+	const state = session();
+	const element = state.values.find((v) => v.id === data.id);
 	if (element) {
 		element.text_field = data.text_field;
 		element.number_field = data.number_field;
@@ -59,12 +63,7 @@ export const as_value_form = form(ValueSchema, async (data) => {
 		element.checkbox_field = data.checkbox_field;
 		await get_values().refresh();
 	}
-	hidden_values = data.hidden;
+	state.hidden_values = data.hidden;
 });
 
-export const get_hidden_values = query(() => hidden_values);
-
-export const reset_values = form(async () => {
-	values = structuredClone(default_values);
-	hidden_values = {};
-});
+export const get_hidden_values = query(() => session().hidden_values);

--- a/packages/kit/test/apps/async/src/routes/remote/form/for-duplicate/form.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/form/for-duplicate/form.remote.ts
@@ -1,11 +1,12 @@
 import { form, query } from '$app/server';
 import * as v from 'valibot';
+import { per_session } from '../../per-session.js';
 
-let count = 0;
+const session = per_session(() => ({ count: 0 }));
 
-export const get_count = query(() => count);
+export const get_count = query(() => session().count);
 
 export const increment = form(v.object({}), async () => {
-	count++;
+	session().count++;
 	await get_count().refresh();
 });

--- a/packages/kit/test/apps/async/src/routes/remote/form/transform/form.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/form/transform/form.remote.ts
@@ -1,7 +1,8 @@
 import { query, command, requested } from '$app/server';
 import * as v from 'valibot';
+import { per_session } from '../../per-session.js';
 
-let count = 0;
+const session = per_session(() => ({ count: 0 }));
 
 export const get_transformed_data = query(
 	v.pipe(
@@ -9,12 +10,12 @@ export const get_transformed_data = query(
 		v.transform((n) => String(n)) // Transforms number to string
 	),
 	(transformed_value) => {
-		return `Count for ${transformed_value} is ${count}`;
+		return `Count for ${transformed_value} is ${session().count}`;
 	}
 );
 
 export const update_data = command(async () => {
-	count++;
+	session().count++;
 
 	await requested(get_transformed_data, 1).refreshAll();
 });

--- a/packages/kit/test/apps/async/src/routes/remote/isomorphic-caching/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/isomorphic-caching/+page.svelte
@@ -1,20 +1,9 @@
 <script>
-	import { get_value, get_call_count, reset } from './isomorphic.remote.js';
+	import { get_value, get_call_count } from './isomorphic.remote.js';
 
 	let call_count = $state('-');
 	let dedupe_status = $state('idle');
 </script>
-
-<button
-	id="reset"
-	onclick={async () => {
-		await reset();
-		call_count = '-';
-		dedupe_status = 'idle';
-	}}
->
-	reset server-side counters
-</button>
 
 <p>call count: <span id="call-count">{call_count}</span></p>
 

--- a/packages/kit/test/apps/async/src/routes/remote/isomorphic-caching/isomorphic.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/isomorphic-caching/isomorphic.remote.js
@@ -1,16 +1,12 @@
-import { query, command } from '$app/server';
+import { query } from '$app/server';
+import { per_session } from '../per-session.js';
 
-let counter = 0;
-let times_called = 0;
+const session = per_session(() => ({ counter: 0, times_called: 0 }));
 
 export const get_value = query(() => {
-	times_called += 1;
-	return counter;
+	const state = session();
+	state.times_called += 1;
+	return state.counter;
 });
 
-export const get_call_count = query(() => times_called);
-
-export const reset = command(() => {
-	counter = 0;
-	times_called = 0;
-});
+export const get_call_count = query(() => session().times_called);

--- a/packages/kit/test/apps/async/src/routes/remote/live/live.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/live/live.remote.js
@@ -1,10 +1,10 @@
 import { command, form, getRequestEvent, query, requested } from '$app/server';
+import { per_session } from '../per-session.js';
 
-// `count` is stored per browser session (keyed by the `count_session` cookie set
-// in `hooks.server.js`) so that tests running in parallel against the same server
-// — e.g. test.js reading the SSR value while client.test.js increments — don't
-// clobber each other. The connection counters below remain global because they're
-// only asserted relatively (and within a single, serial test file).
+// All mutable state is stored per browser session (keyed by the `count_session`
+// cookie set in `hooks.server.js`) so that tests running in parallel against the
+// same server — e.g. test.js loading this route in the no-js project while
+// client.test.js asserts exact counter values — don't clobber each other.
 /** @type {Map<string, number>} */
 const counts = new Map();
 
@@ -21,11 +21,13 @@ function session_id() {
 	return getRequestEvent().cookies.get('count_session') ?? 'default';
 }
 
-let drop_next = false;
-let active_connections = 0;
-let cleanup_count = 0;
-let finite_connection_count = 0;
-let requested_reconnect_count = 0;
+const session_stats = per_session(() => ({
+	drop_next: false,
+	active_connections: 0,
+	cleanup_count: 0,
+	finite_connection_count: 0,
+	requested_reconnect_count: 0
+}));
 
 /** @type {Set<() => void>} */
 const listeners = new Set();
@@ -58,10 +60,11 @@ function wait_for_change(signal) {
 
 export const get_count = query.live(async function* () {
 	const signal = getRequestEvent().request.signal;
-	// capture the session id once; getRequestEvent() may not be available after awaits
+	// capture the session once; getRequestEvent() may not be available after awaits
 	const id = session_id();
+	const state = session_stats();
 
-	active_connections += 1;
+	state.active_connections += 1;
 
 	try {
 		yield counts.get(id) ?? 0;
@@ -73,21 +76,21 @@ export const get_count = query.live(async function* () {
 				return;
 			}
 
-			if (drop_next) {
-				drop_next = false;
+			if (state.drop_next) {
+				state.drop_next = false;
 				throw new Error('stream dropped');
 			}
 
 			yield counts.get(id) ?? 0;
 		}
 	} finally {
-		active_connections -= 1;
-		cleanup_count += 1;
+		state.active_connections -= 1;
+		state.cleanup_count += 1;
 	}
 });
 
 export const get_finite_count = query.live(async function* () {
-	finite_connection_count += 1;
+	session_stats().finite_connection_count += 1;
 	yield get_count_value();
 });
 
@@ -123,7 +126,7 @@ export const notify_only = command(() => {
 });
 
 export const drop = command(() => {
-	drop_next = true;
+	session_stats().drop_next = true;
 	notify();
 });
 
@@ -132,8 +135,9 @@ export const reconnect_live = command(() => {
 });
 
 export const reconnect_requested_live = command(async () => {
+	const state = session_stats();
 	await requested(get_count, 5).reconnectAll();
-	requested_reconnect_count += 1;
+	state.requested_reconnect_count += 1;
 });
 
 export const reconnect_live_form = form('unchecked', async () => {
@@ -141,11 +145,12 @@ export const reconnect_live_form = form('unchecked', async () => {
 });
 
 export const get_stats = query(() => {
+	const state = session_stats();
 	return {
-		active_connections,
-		cleanup_count,
-		finite_connection_count,
-		requested_reconnect_count,
+		active_connections: state.active_connections,
+		cleanup_count: state.cleanup_count,
+		finite_connection_count: state.finite_connection_count,
+		requested_reconnect_count: state.requested_reconnect_count,
 		count: get_count_value()
 	};
 });

--- a/packages/kit/test/apps/async/src/routes/remote/live/live.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/live/live.remote.js
@@ -1,27 +1,10 @@
 import { command, form, getRequestEvent, query, requested } from '$app/server';
 import { per_session } from '../per-session.js';
 
-// All mutable state is stored per browser session (keyed by the `count_session`
-// cookie set in `hooks.server.js`) so that tests running in parallel against the
-// same server — e.g. test.js loading this route in the no-js project while
-// client.test.js asserts exact counter values — don't clobber each other.
-/** @type {Map<string, number>} */
-const counts = new Map();
-
-function get_count_value() {
-	return counts.get(session_id()) ?? 0;
-}
-
-/** @param {number} value */
-function set_count_value(value) {
-	counts.set(session_id(), value);
-}
-
-function session_id() {
-	return getRequestEvent().cookies.get('count_session') ?? 'default';
-}
-
-const session_stats = per_session(() => ({
+// all mutable state is per browser session so tests running in parallel against
+// the same server can't clobber each other's counters
+const session = per_session(() => ({
+	count: 0,
 	drop_next: false,
 	active_connections: 0,
 	cleanup_count: 0,
@@ -61,13 +44,12 @@ function wait_for_change(signal) {
 export const get_count = query.live(async function* () {
 	const signal = getRequestEvent().request.signal;
 	// capture the session once; getRequestEvent() may not be available after awaits
-	const id = session_id();
-	const state = session_stats();
+	const state = session();
 
 	state.active_connections += 1;
 
 	try {
-		yield counts.get(id) ?? 0;
+		yield state.count;
 
 		while (true) {
 			const status = await wait_for_change(signal);
@@ -81,7 +63,7 @@ export const get_count = query.live(async function* () {
 				throw new Error('stream dropped');
 			}
 
-			yield counts.get(id) ?? 0;
+			yield state.count;
 		}
 	} finally {
 		state.active_connections -= 1;
@@ -90,15 +72,16 @@ export const get_count = query.live(async function* () {
 });
 
 export const get_finite_count = query.live(async function* () {
-	session_stats().finite_connection_count += 1;
-	yield get_count_value();
+	const state = session();
+	state.finite_connection_count += 1;
+	yield state.count;
 });
 
 export const get_duplicate_payload = query.live(async function* () {
 	const signal = getRequestEvent().request.signal;
-	const id = session_id();
+	const state = session();
 
-	yield { count: counts.get(id) ?? 0 };
+	yield { count: state.count };
 
 	while (true) {
 		const status = await wait_for_change(signal);
@@ -107,17 +90,17 @@ export const get_duplicate_payload = query.live(async function* () {
 			return;
 		}
 
-		yield { count: counts.get(id) ?? 0 };
+		yield { count: state.count };
 	}
 });
 
 export const increment = command(() => {
-	set_count_value(get_count_value() + 1);
+	session().count += 1;
 	notify();
 });
 
 export const reset = command(() => {
-	set_count_value(0);
+	session().count = 0;
 	notify();
 });
 
@@ -126,7 +109,7 @@ export const notify_only = command(() => {
 });
 
 export const drop = command(() => {
-	session_stats().drop_next = true;
+	session().drop_next = true;
 	notify();
 });
 
@@ -135,7 +118,7 @@ export const reconnect_live = command(() => {
 });
 
 export const reconnect_requested_live = command(async () => {
-	const state = session_stats();
+	const state = session();
 	await requested(get_count, 5).reconnectAll();
 	state.requested_reconnect_count += 1;
 });
@@ -144,13 +127,4 @@ export const reconnect_live_form = form('unchecked', async () => {
 	get_count().reconnect();
 });
 
-export const get_stats = query(() => {
-	const state = session_stats();
-	return {
-		active_connections: state.active_connections,
-		cleanup_count: state.cleanup_count,
-		finite_connection_count: state.finite_connection_count,
-		requested_reconnect_count: state.requested_reconnect_count,
-		count: get_count_value()
-	};
-});
+export const get_stats = query(() => session());

--- a/packages/kit/test/apps/async/src/routes/remote/nested-refresh/data.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/nested-refresh/data.remote.js
@@ -5,7 +5,7 @@ import { command, getRequestEvent, query } from '$app/server';
 const sessions = new Map();
 
 function session() {
-	const id = getRequestEvent().cookies.get('count_session') ?? 'nested-refresh-default';
+	const id = getRequestEvent().cookies.get('session') ?? 'nested-refresh-default';
 	let state = sessions.get(id);
 	if (!state) {
 		state = { a: 0, b: 0 };

--- a/packages/kit/test/apps/async/src/routes/remote/per-session.js
+++ b/packages/kit/test/apps/async/src/routes/remote/per-session.js
@@ -1,0 +1,24 @@
+import { getRequestEvent } from '$app/server';
+
+/**
+ * Returns an accessor for state keyed by the `count_session` cookie from
+ * `hooks.server.js`, so tests running in parallel projects/workers against the
+ * same server (and CI retries) can't see each other's mutations.
+ * @template T
+ * @param {() => T} init
+ * @returns {() => T}
+ */
+export function per_session(init) {
+	/** @type {Map<string, T>} */
+	const sessions = new Map();
+
+	return () => {
+		const id = getRequestEvent().cookies.get('count_session') ?? 'default';
+		let state = sessions.get(id);
+		if (!state) {
+			state = init();
+			sessions.set(id, state);
+		}
+		return state;
+	};
+}

--- a/packages/kit/test/apps/async/src/routes/remote/per-session.js
+++ b/packages/kit/test/apps/async/src/routes/remote/per-session.js
@@ -1,7 +1,7 @@
 import { getRequestEvent } from '$app/server';
 
 /**
- * Returns an accessor for state keyed by the `count_session` cookie from
+ * Returns an accessor for state keyed by the `session` cookie from
  * `hooks.server.js`, isolating it per test (and per CI retry).
  * @template T
  * @param {() => T} init
@@ -12,7 +12,7 @@ export function per_session(init) {
 	const sessions = new Map();
 
 	return () => {
-		const id = getRequestEvent().cookies.get('count_session') ?? 'default';
+		const id = getRequestEvent().cookies.get('session') ?? 'default';
 		let state = sessions.get(id);
 		if (!state) {
 			state = init();

--- a/packages/kit/test/apps/async/src/routes/remote/per-session.js
+++ b/packages/kit/test/apps/async/src/routes/remote/per-session.js
@@ -2,8 +2,7 @@ import { getRequestEvent } from '$app/server';
 
 /**
  * Returns an accessor for state keyed by the `count_session` cookie from
- * `hooks.server.js`, so tests running in parallel projects/workers against the
- * same server (and CI retries) can't see each other's mutations.
+ * `hooks.server.js`, isolating it per test (and per CI retry).
  * @template T
  * @param {() => T} init
  * @returns {() => T}

--- a/packages/kit/test/apps/async/src/routes/remote/query-command.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/query-command.remote.js
@@ -5,7 +5,7 @@ export const add = query('unchecked', ({ a, b }) => a + b);
 
 /**
  * The mutable `count`/`should_fail_flaky` state is stored per browser session
- * (keyed by the `count_session` cookie set in `hooks.server.js`) so that tests
+ * (keyed by the `session` cookie set in `hooks.server.js`) so that tests
  * running in parallel against the same dev/preview server — e.g. `test.js` and
  * `client.test.js` on different Playwright workers — don't clobber each other's
  * in-memory state. Each Playwright test gets a fresh browser context, and thus
@@ -17,7 +17,7 @@ const sessions = new Map();
 
 /** @returns {SessionState} */
 function session() {
-	const id = getRequestEvent().cookies.get('count_session') ?? 'default';
+	const id = getRequestEvent().cookies.get('session') ?? 'default';
 	let state = sessions.get(id);
 	if (!state) {
 		state = { count: 0, should_fail_flaky: false };

--- a/packages/kit/test/apps/async/src/routes/remote/re-refresh/data.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/re-refresh/data.remote.js
@@ -5,7 +5,7 @@ import { command, getRequestEvent, query } from '$app/server';
 const sessions = new Map();
 
 function session() {
-	const id = getRequestEvent().cookies.get('count_session') ?? 're-refresh-default';
+	const id = getRequestEvent().cookies.get('session') ?? 're-refresh-default';
 	let state = sessions.get(id);
 	if (!state) {
 		state = { value: 0 };

--- a/packages/kit/test/apps/async/src/routes/remote/refresh-cycle/data.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/refresh-cycle/data.remote.js
@@ -5,7 +5,7 @@ import { command, getRequestEvent, query } from '$app/server';
 const sessions = new Map();
 
 function session() {
-	const id = getRequestEvent().cookies.get('count_session') ?? 'refresh-cycle-default';
+	const id = getRequestEvent().cookies.get('session') ?? 'refresh-cycle-default';
 	let state = sessions.get(id);
 	if (!state) {
 		state = { value: 0 };

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -894,8 +894,6 @@ test.describe('remote function mutations', () => {
 		// iteration breaks after 3 values
 		await expect(page.locator('#for-await-count')).toHaveText('3');
 		await expect(page.locator('#for-await-values')).toHaveText('0,1,2');
-
-		await page.click('#reset');
 	});
 
 	test('for await consumers continue receiving values across refreshAll-triggered reconnects', async ({
@@ -920,8 +918,6 @@ test.describe('remote function mutations', () => {
 		// this value never arrived and the loop hung.
 		await page.click('#increment');
 		await expect(page.locator('#stream-log')).toContainText('1');
-
-		await page.click('#reset');
 	});
 
 	test('refreshAll resolves while a live query is offline', async ({ page, context }) => {
@@ -1036,7 +1032,6 @@ test.describe('remote function mutations', () => {
 	test.describe('isomorphic query caching', () => {
 		test('await in event handler shares cache with simultaneous awaits', async ({ page }) => {
 			await page.goto('/remote/isomorphic-caching');
-			await page.click('#reset');
 
 			await page.click('#await-dedupe');
 			await expect(page.locator('#dedupe')).toHaveText('dedupe ok');
@@ -1065,12 +1060,6 @@ test.describe('remote function mutations', () => {
 
 		// the query resource should report the 403 status from the hook
 		await expect(page.locator('#status')).toHaveText('403');
-
-		// clean up the cookie so other tests aren't affected
-		await page.click('#clear-btn');
-		await page.evaluate(() => {
-			document.cookie = 'deny-remote=; path=/; max-age=0';
-		});
 	});
 
 	test('form.for() with enhance does not duplicate requests', async ({ page }) => {
@@ -1106,10 +1095,6 @@ test.describe('remote function mutations', () => {
 		// the input value should reflect the updated data
 		await expect(text).toHaveValue('Updated text');
 		await expect(checkbox).not.toBeChecked();
-
-		// reset the values for the other tests, awaited so the page can't close mid-request
-		await page.click('#reset-values');
-		await expect(text).toHaveValue('Example text');
 	});
 
 	test('.as(type, value) updates when field.set() is called', async ({ page }) => {

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -1107,8 +1107,9 @@ test.describe('remote function mutations', () => {
 		await expect(text).toHaveValue('Updated text');
 		await expect(checkbox).not.toBeChecked();
 
-		// reset the values for the client tests
+		// reset the values for the other tests, awaited so the page can't close mid-request
 		await page.click('#reset-values');
+		await expect(text).toHaveValue('Example text');
 	});
 
 	test('.as(type, value) updates when field.set() is called', async ({ page }) => {

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-same-url/data.json/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-same-url/data.json/+server.js
@@ -3,7 +3,12 @@ import { json } from '@sveltejs/kit';
 let result = 0;
 
 /** @type {import('./$types').RequestHandler} */
-export function GET() {
+export function GET({ url }) {
+	if (url.searchParams.has('reset')) {
+		result = 0;
+		return json({ result });
+	}
+
 	result++;
 	return json({ result });
 }

--- a/packages/kit/test/apps/basics/src/routes/load/invalidation/search-params/server/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/invalidation/search-params/server/+page.server.js
@@ -2,6 +2,7 @@ let count = 0;
 
 /** @type {import("./$types").PageServerLoad} */
 export function load({ url }) {
+	if (url.searchParams.has('reset')) count = 0;
 	url.searchParams.get('a');
 	return {
 		count: count++

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -266,7 +266,12 @@ test.describe('Load', () => {
 		expect(requests.filter((r) => !r.includes('/__route.js'))).toEqual([]);
 	});
 
-	test('use correct cache result when fetching same url multiple times', async ({ page }) => {
+	test('use correct cache result when fetching same url multiple times', async ({
+		page,
+		request
+	}) => {
+		// reset so the assertion also holds when the test is retried
+		await request.get('/load/fetch-same-url/data.json?reset');
 		await page.goto('/load/fetch-same-url');
 		expect(await page.textContent('h1')).toBe('the result is 1,2,3');
 	});
@@ -466,11 +471,12 @@ test.describe('Invalidation', () => {
 	}) => {
 		await page.goto('/load/unchanged/isolated/a');
 		expect(await page.textContent('h1')).toBe('slug: a');
-		expect(await page.textContent('h2')).toBe('count: 0');
+		const count = await page.textContent('h2');
+		expect(count).toMatch(/^count: \d+$/);
 
 		await clicknav('[href="/load/unchanged/isolated/b"]');
 		expect(await page.textContent('h1')).toBe('slug: b');
-		expect(await page.textContent('h2')).toBe('count: 0');
+		expect(await page.textContent('h2')).toBe(count);
 	});
 
 	test('+layout.server.js re-runs when await parent() is called from downstream load function', async ({
@@ -479,15 +485,15 @@ test.describe('Invalidation', () => {
 	}) => {
 		await page.goto('/load/unchanged-parent/uses-parent/a');
 		expect(await page.textContent('h1')).toBe('slug: a');
-		expect(await page.textContent('h2')).toBe('count: 0');
-		expect(await page.textContent('h3')).toBe('doubled: 0');
+		const count = Number((await page.textContent('h2'))?.replace('count: ', ''));
+		expect(await page.textContent('h3')).toBe(`doubled: ${count * 2}`);
 
 		await clicknav('[href="/load/unchanged-parent/uses-parent/b"]');
 		expect(await page.textContent('h1')).toBe('slug: b');
-		expect(await page.textContent('h2')).toBe('count: 0');
+		expect(await page.textContent('h2')).toBe(`count: ${count}`);
 
 		// this looks wrong, but is actually the intended behaviour (the increment side-effect in a GET would be a bug in a real app)
-		expect(await page.textContent('h3')).toBe('doubled: 2');
+		expect(await page.textContent('h3')).toBe(`doubled: ${(count + 1) * 2}`);
 	});
 
 	test('load function re-runs when searchParams change', async ({ page, clicknav }) => {
@@ -517,7 +523,7 @@ test.describe('Invalidation', () => {
 		page,
 		clicknav
 	}) => {
-		await page.goto('/load/invalidation/search-params/server?tracked=0');
+		await page.goto('/load/invalidation/search-params/server?tracked=0&reset');
 		expect(await page.textContent('span')).toBe('count: 0');
 		await clicknav('[data-id="tracked"]');
 		expect(await page.textContent('span')).toBe('count: 1');

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -936,7 +936,12 @@ test.describe('$app/state', () => {
 		clicknav,
 		javaScriptEnabled
 	}) => {
-		await page.goto('/state/data/foo?reset=true');
+		if (!javaScriptEnabled) {
+			// only the no-js run consumes the server-side `is_first` state; with js the
+			// sequence below runs on the isolated client copy, and resetting the server
+			// copy here would corrupt the no-js twin running in the parallel project
+			await page.goto('/state/data/foo?reset=true');
+		}
 		const stuff1 = { foo: { bar: 'Custom layout' }, name: 'SvelteKit', value: 123 };
 		const stuff2 = { ...stuff1, foo: true, number: 2 };
 		const stuff3 = { ...stuff2 };

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -937,9 +937,8 @@ test.describe('$app/state', () => {
 		javaScriptEnabled
 	}) => {
 		if (!javaScriptEnabled) {
-			// only the no-js run consumes the server-side `is_first` state; with js the
-			// sequence below runs on the isolated client copy, and resetting the server
-			// copy here would corrupt the no-js twin running in the parallel project
+			// only the no-js run consumes the server-side `is_first` state (with js the clicknavs
+			// use the client copy); resetting it would corrupt the parallel no-js twin
 			await page.goto('/state/data/foo?reset=true');
 		}
 		const stuff1 = { foo: { bar: 'Custom layout' }, name: 'SvelteKit', value: 123 };

--- a/packages/kit/test/apps/options-2/src/hooks.server.js
+++ b/packages/kit/test/apps/options-2/src/hooks.server.js
@@ -2,11 +2,7 @@
 export async function handle({ event, resolve }) {
 	// isolates the in-memory count in count.remote.js per browser session
 	if (!event.cookies.get('count_session')) {
-		event.cookies.set('count_session', crypto.randomUUID(), {
-			path: '/',
-			httpOnly: true,
-			sameSite: 'lax'
-		});
+		event.cookies.set('count_session', crypto.randomUUID(), { path: '/' });
 	}
 
 	return resolve(event, {

--- a/packages/kit/test/apps/options-2/src/hooks.server.js
+++ b/packages/kit/test/apps/options-2/src/hooks.server.js
@@ -1,5 +1,14 @@
 /** @type {import("@sveltejs/kit").Handle} */
 export async function handle({ event, resolve }) {
+	// isolates the in-memory count in count.remote.js per browser session
+	if (!event.cookies.get('count_session')) {
+		event.cookies.set('count_session', crypto.randomUUID(), {
+			path: '/',
+			httpOnly: true,
+			sameSite: 'lax'
+		});
+	}
+
 	return resolve(event, {
 		// needed for link header preload tests
 		preload: () => true

--- a/packages/kit/test/apps/options-2/src/hooks.server.js
+++ b/packages/kit/test/apps/options-2/src/hooks.server.js
@@ -1,8 +1,8 @@
 /** @type {import("@sveltejs/kit").Handle} */
 export async function handle({ event, resolve }) {
 	// isolates the in-memory count in count.remote.js per browser session
-	if (!event.cookies.get('count_session')) {
-		event.cookies.set('count_session', crypto.randomUUID(), { path: '/' });
+	if (!event.cookies.get('session')) {
+		event.cookies.set('session', crypto.randomUUID(), { path: '/' });
 	}
 
 	return resolve(event, {

--- a/packages/kit/test/apps/options-2/src/routes/remote/count.remote.js
+++ b/packages/kit/test/apps/options-2/src/routes/remote/count.remote.js
@@ -7,9 +7,7 @@ import * as v from 'valibot';
 /** @type {Map<string, number>} */
 const counts = new Map();
 
-function session_id() {
-	return getRequestEvent().cookies.get('count_session') ?? 'default';
-}
+const session_id = () => getRequestEvent().cookies.get('count_session') ?? 'default';
 
 export const get_count = query(() => counts.get(session_id()) ?? 0);
 

--- a/packages/kit/test/apps/options-2/src/routes/remote/count.remote.js
+++ b/packages/kit/test/apps/options-2/src/routes/remote/count.remote.js
@@ -2,12 +2,12 @@ import { building, dev } from '$app/env';
 import { command, form, getRequestEvent, prerender, query } from '$app/server';
 import * as v from 'valibot';
 
-// count is keyed by the `count_session` cookie from hooks.server.js so the
+// count is keyed by the `session` cookie from hooks.server.js so the
 // parallel tests that read and set it can't see each other's mutations
 /** @type {Map<string, number>} */
 const counts = new Map();
 
-const session_id = () => getRequestEvent().cookies.get('count_session') ?? 'default';
+const session_id = () => getRequestEvent().cookies.get('session') ?? 'default';
 
 export const get_count = query(() => counts.get(session_id()) ?? 0);
 

--- a/packages/kit/test/apps/options-2/src/routes/remote/count.remote.js
+++ b/packages/kit/test/apps/options-2/src/routes/remote/count.remote.js
@@ -1,16 +1,24 @@
 import { building, dev } from '$app/env';
-import { command, form, prerender, query } from '$app/server';
+import { command, form, getRequestEvent, prerender, query } from '$app/server';
 import * as v from 'valibot';
 
-let count = 0;
+// count is keyed by the `count_session` cookie from hooks.server.js so the
+// parallel tests that read and set it can't see each other's mutations
+/** @type {Map<string, number>} */
+const counts = new Map();
 
-export const get_count = query(() => count);
+function session_id() {
+	return getRequestEvent().cookies.get('count_session') ?? 'default';
+}
+
+export const get_count = query(() => counts.get(session_id()) ?? 0);
 
 export const set_count = command(
 	'unchecked',
 	/** @param {number} c */
 	async (c) => {
-		return (count = c);
+		counts.set(session_id(), c);
+		return c;
 	}
 );
 
@@ -23,7 +31,8 @@ export const prerendered = prerender(() => {
 });
 
 export const set_count_form = form(v.object({ count: v.string() }), async (data) => {
-	count = parseInt(data.count);
+	const count = parseInt(data.count);
+	counts.set(session_id(), count);
 	get_count().set(count);
 	return count;
 });

--- a/packages/kit/test/apps/writes/test/test.js
+++ b/packages/kit/test/apps/writes/test/test.js
@@ -38,7 +38,7 @@ test.describe('Filesystem updates', () => {
 	}
 
 	test('Components are not double-mounted', async ({ page, javaScriptEnabled }) => {
-		// the file on disk is shared with the no-js project running in parallel — its
+		// js-only: the file on disk is shared with the parallel no-js project, whose
 		// writes would trigger HMR updates that remount the component mid-assertion
 		test.skip(!javaScriptEnabled);
 

--- a/packages/kit/test/apps/writes/test/test.js
+++ b/packages/kit/test/apps/writes/test/test.js
@@ -38,10 +38,14 @@ test.describe('Filesystem updates', () => {
 	}
 
 	test('Components are not double-mounted', async ({ page, javaScriptEnabled }) => {
+		// the file on disk is shared with the no-js project running in parallel — its
+		// writes would trigger HMR updates that remount the component mid-assertion
+		test.skip(!javaScriptEnabled);
+
 		const file = fileURLToPath(new URL('../src/routes/double-mount/+page.svelte', import.meta.url));
 		const contents = fs.readFileSync(file, 'utf-8');
 
-		const mounted = javaScriptEnabled ? 1 : 0;
+		const mounted = 1;
 
 		try {
 			// we write to the file, to trigger HMR invalidation


### PR DESCRIPTION
Noticed `.as(type, value) renders correct values` failing in this run: https://github.com/sveltejs/kit/actions/runs/30681430489/job/91319090645. Both Playwright projects run the same test files against one shared server, so state that one test mutates is visible to tests in the other project, and retries rerun against the already-mutated state.

This audits the test apps for that class. Mutable remote-function state in async and options-2 is now keyed per browser session the way `query-command.remote.js` already does it, the counter tests in basics reset first or assert relatively, and the double-mount test in writes only runs with JS since the file it rewrites on disk is shared with the no-js project.

Verified with `--workers=1 --repeat-each=2` against one server: the four basics counter tests fail their second run on version-3 and pass here.