### PR TITLE
feat: warn when naively proxying requests that result in responses with a `content-encoding` header

### DIFF
--- a/.changeset/full-turtles-tell.md
+++ b/.changeset/full-turtles-tell.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correctly massage stack traces with async frames

--- a/.changeset/wild-steaks-visit.md
+++ b/.changeset/wild-steaks-visit.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': major
+---
+
+breaking: strip `content-encoding` and `content-length` headers when returning responses created with `fetch`

--- a/.changeset/wild-steaks-visit.md
+++ b/.changeset/wild-steaks-visit.md
@@ -1,5 +1,5 @@
 ---
-'@sveltejs/kit': major
+'@sveltejs/kit': minor
 ---
 
-breaking: strip `content-encoding` and `content-length` headers when returning responses created with `fetch`
+feat: warn when naively proxying requests that result in responses with a `content-encoding` header

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -344,7 +344,7 @@ export async function dev(vite, vite_config, svelte_config, get_remotes, root, s
 		}
 
 		let prelude = '';
-		let start = 0;
+		let start = -1;
 		let end = 0;
 
 		const lines = error.stack
@@ -363,7 +363,7 @@ export async function dev(vite, vite_config, svelte_config, get_remotes, root, s
 
 				if (fs.existsSync(file)) {
 					if (!file.includes('node_modules') && !file.includes(SRC_ROOT)) {
-						start ||= i;
+						if (start === -1) start = i;
 						end = i + 1;
 					}
 
@@ -372,7 +372,9 @@ export async function dev(vite, vite_config, svelte_config, get_remotes, root, s
 
 				return line;
 			})
-			.slice(start, end);
+			// if no user-code frame was found, keep only the prelude (message/header)
+			// lines and drop everything else so the message isn't duplicated
+			.slice(start === -1 ? end : start, end);
 
 		return (error.stack = prelude + lines.join('\n'));
 	}

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -343,14 +343,17 @@ export async function dev(vite, vite_config, svelte_config, get_remotes, root, s
 			return;
 		}
 
+		let prelude = '';
+		let start = 0;
 		let end = 0;
 
-		error.stack = error.stack
+		const lines = error.stack
 			.replaceAll('\0', '') // remove null bytes from e.g. virtual module IDs, or the response will fail
 			.split('\n')
 			.map((line, i) => {
-				const match = /^ {4}at (?:[^ ]+ \((.+)\)|(.+))$/.exec(line);
+				const match = /^ {4}at (?:[^(]+ \((.+)\)|(.+))$/.exec(line);
 				if (!match) {
+					prelude += line + '\n';
 					end = i + 1;
 					return line;
 				}
@@ -360,6 +363,7 @@ export async function dev(vite, vite_config, svelte_config, get_remotes, root, s
 
 				if (fs.existsSync(file)) {
 					if (!file.includes('node_modules') && !file.includes(SRC_ROOT)) {
+						start ||= i;
 						end = i + 1;
 					}
 
@@ -368,10 +372,9 @@ export async function dev(vite, vite_config, svelte_config, get_remotes, root, s
 
 				return line;
 			})
-			.slice(0, end)
-			.join('\n');
+			.slice(start, end);
 
-		return error.stack;
+		return (error.stack = prelude + lines.join('\n'));
 	}
 
 	const params_file = resolve_entry(svelte_config.kit.files.params);

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -2,7 +2,7 @@ import { noop } from '../../utils/functions.js';
 import { IN_WEBCONTAINER } from './constants.js';
 import { respond } from './respond.js';
 import { options, get_hooks } from '__SERVER__/internal.js';
-import { set_read_implementation, set_manifest } from './internal.js';
+import { set_read_implementation, set_manifest, fix_stack_trace } from './internal.js';
 import { set_env } from '__sveltekit/env';
 import { set_app } from './app.js';
 import { SvelteKitError } from '@sveltejs/kit/internal';
@@ -17,21 +17,33 @@ let current = null;
  * Responses that were created with our monkey-patched `fetch`, which may need
  * to have their `content-encoding` and `content-length` headers removed
  * if returned directly (i.e. `fetch` is being used to proxy a request)
- * @type {WeakSet<Response>}
+ * @type {WeakMap<Response, Error>}
  */
-const decoded_responses = new WeakSet();
+const decoded_responses = new WeakMap();
 
-const fetch = globalThis.fetch;
+if (__SVELTEKIT_DEV__) {
+	const fetch = globalThis.fetch;
 
-/**
- * @param {RequestInfo | URL} info
- * @param {RequestInit} [init]
- */
-globalThis.fetch = async (info, init) => {
-	const response = await fetch(info, init);
-	decoded_responses.add(response);
-	return response;
-};
+	/**
+	 * @param {RequestInfo | URL} info
+	 * @param {RequestInit} [init]
+	 */
+	globalThis.fetch = async (info, init) => {
+		const response = await fetch(info, init);
+		const encoding = response.headers.get('content-encoding');
+
+		if (encoding) {
+			decoded_responses.set(
+				response,
+				new Error(
+					`Cannot return \`fetch(...)\` directly from a handler if the response has a \`Content-Encoding: ${encoding}\` header. The body has already been decoded`
+				)
+			);
+		}
+
+		return response;
+	};
+}
 
 export class Server {
 	/** @type {import('types').SSROptions} */
@@ -201,23 +213,9 @@ export class Server {
 			depth: 0
 		});
 
-		if (decoded_responses.has(response)) {
-			// The body was already decoded by `fetch`, so we need to strip
-			// these headers to avoid as `ERR_CONTENT_DECODING_FAILED` error.
-			// `fetch` only decodes when a `content-encoding` is present, so we
-			// only strip the headers in that case to avoid discarding a valid
-			// `content-length` (e.g. for uncompressed or 206 range responses).
-			const headers = new Headers(response.headers);
-			if (headers.has('content-encoding')) {
-				headers.delete('content-encoding');
-				headers.delete('content-length');
-			}
-
-			return new Response(response.body, {
-				status: response.status,
-				statusText: response.statusText,
-				headers
-			});
+		if (__SVELTEKIT_DEV__) {
+			const error = decoded_responses.get(response);
+			if (error) console.error(fix_stack_trace(error));
 		}
 
 		return response;

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -203,10 +203,15 @@ export class Server {
 
 		if (decoded_responses.has(response)) {
 			// The body was already decoded by `fetch`, so we need to strip
-			// these headers to avoid as `ERR_CONTENT_DECODING_FAILED` error
+			// these headers to avoid as `ERR_CONTENT_DECODING_FAILED` error.
+			// `fetch` only decodes when a `content-encoding` is present, so we
+			// only strip the headers in that case to avoid discarding a valid
+			// `content-length` (e.g. for uncompressed or 206 range responses).
 			const headers = new Headers(response.headers);
-			headers.delete('content-encoding');
-			headers.delete('content-length');
+			if (headers.has('content-encoding')) {
+				headers.delete('content-encoding');
+				headers.delete('content-length');
+			}
 
 			return new Response(response.body, {
 				status: response.status,

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -6,6 +6,7 @@ import { set_read_implementation, set_manifest, fix_stack_trace } from './intern
 import { set_env } from '__sveltekit/env';
 import { set_app } from './app.js';
 import { SvelteKitError } from '@sveltejs/kit/internal';
+import { DEV } from 'esm-env';
 
 /** @type {Promise<any>} */
 let init_promise;
@@ -213,7 +214,7 @@ export class Server {
 			depth: 0
 		});
 
-		if (__SVELTEKIT_DEV__) {
+		if (DEV) {
 			const error = decoded_responses.get(response);
 			if (error) console.error(fix_stack_trace(error));
 		}

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -13,6 +13,26 @@ let init_promise;
 /** @type {Promise<void> | null} */
 let current = null;
 
+/**
+ * Responses that were created with our monkey-patched `fetch`, which may need
+ * to have their `content-encoding` and `content-length` headers removed
+ * if returned directly (i.e. `fetch` is being used to proxy a request)
+ * @type {WeakSet<Response>}
+ */
+const decoded_responses = new WeakSet();
+
+const fetch = globalThis.fetch;
+
+/**
+ * @param {RequestInfo | URL} info
+ * @param {RequestInit} [init]
+ */
+globalThis.fetch = async (info, init) => {
+	const response = await fetch(info, init);
+	decoded_responses.add(response);
+	return response;
+};
+
 export class Server {
 	/** @type {import('types').SSROptions} */
 	#options;
@@ -174,11 +194,27 @@ export class Server {
 	 * @param {Request} request
 	 * @param {import('types').RequestOptions} options
 	 */
-	respond(request, options) {
-		return respond(request, this.#options, this.#manifest, {
+	async respond(request, options) {
+		const response = await respond(request, this.#options, this.#manifest, {
 			...options,
 			error: false,
 			depth: 0
 		});
+
+		if (decoded_responses.has(response)) {
+			// The body was already decoded by `fetch`, so we need to strip
+			// these headers to avoid as `ERR_CONTENT_DECODING_FAILED` error
+			const headers = new Headers(response.headers);
+			headers.delete('content-encoding');
+			headers.delete('content-length');
+
+			return new Response(response.body, {
+				status: response.status,
+				statusText: response.statusText,
+				headers
+			});
+		}
+
+		return response;
 	}
 }

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -21,7 +21,7 @@ let current = null;
  */
 const decoded_responses = new WeakMap();
 
-if (__SVELTEKIT_DEV__) {
+if (DEV) {
 	const fetch = globalThis.fetch;
 
 	/**


### PR DESCRIPTION
Alternative to #16629 that warns instead of proactively removing headers. Closes #12197. I punted on docs for now

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
