### PR TITLE
chore: skip dep verification

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
+verifyDepsBeforeRun: warn
 minimumReleaseAge: 2880
 minimumReleaseAgeExclude:
   - '@sveltejs/*'


### PR DESCRIPTION
pnpm 11 includes a fantastically unhelpful change: it verifies deps before any `pnpm ...` command after you switch branches, even when the lockfile is unchanged. Since we have a lot of `prepare` scripts in the repo, it's a real timewaster. This fixes it