### PR TITLE
fix: update `match` parameter type

### DIFF
--- a/.changeset/great-ears-thank.md
+++ b/.changeset/great-ears-thank.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: update `match` parameter type

--- a/packages/kit/src/runtime/app/paths/client.js
+++ b/packages/kit/src/runtime/app/paths/client.js
@@ -1,4 +1,4 @@
-/** @import { AssetPath, RouteId, RouteIdWithSearchOrHash, Path, PathnameWithSearchOrHash, ResolvedPathname, RouteParams } from '$app/types' */
+/** @import { AssetPath, RouteId, RouteIdWithSearchOrHash, PathnameWithSearchOrHash, ResolvedPathname, RouteParams } from '$app/types' */
 /** @import { ResolveArgs } from './types.js' */
 import { base, assets, hash_routing, match_implementation } from './internal/client.js';
 import { resolve_route } from '../../../utils/routing.js';
@@ -92,7 +92,7 @@ export function resolve(...args) {
  * ```
  * @since 2.52.0
  *
- * @param {Path | URL | (string & {})} url
+ * @param {URL | (string & {})} url
  * @returns {Promise<{ [K in RouteId]: { id: K; params: RouteParams<K>; } }[RouteId] | null>}
  */
 export function match(url) {

--- a/packages/kit/src/runtime/app/paths/client.js
+++ b/packages/kit/src/runtime/app/paths/client.js
@@ -92,7 +92,7 @@ export function resolve(...args) {
  * ```
  * @since 2.52.0
  *
- * @param {URL | (string & {})} url
+ * @param {URL | string} url
  * @returns {Promise<{ [K in RouteId]: { id: K; params: RouteParams<K>; } }[RouteId] | null>}
  */
 export function match(url) {

--- a/packages/kit/src/runtime/app/paths/internal/client.js
+++ b/packages/kit/src/runtime/app/paths/internal/client.js
@@ -9,7 +9,7 @@ export const hash_routing = __SVELTEKIT_HASH_ROUTING__;
 /**
  * We make this configurable per-environment so that it's possible to import `$app/paths`
  * into a service worker without importing the entire client
- * @param {URL | (string & {})} _url
+ * @param {URL | string} _url
  * @returns {Promise<{ [K in RouteId]: { id: K; params: import('$app/types').RouteParams<K>; } }[RouteId] | null>}
  */
 // eslint-disable-next-line @typescript-eslint/require-await

--- a/packages/kit/src/runtime/app/paths/internal/client.js
+++ b/packages/kit/src/runtime/app/paths/internal/client.js
@@ -1,4 +1,4 @@
-/** @import { RouteId, Path } from '$app/types' */
+/** @import { RouteId } from '$app/types' */
 import { payload } from '../../../client/payload.js';
 
 export const base = payload.base ?? __SVELTEKIT_PATHS_BASE__;
@@ -9,7 +9,7 @@ export const hash_routing = __SVELTEKIT_HASH_ROUTING__;
 /**
  * We make this configurable per-environment so that it's possible to import `$app/paths`
  * into a service worker without importing the entire client
- * @param {Path | URL | (string & {})} _url
+ * @param {URL | (string & {})} _url
  * @returns {Promise<{ [K in RouteId]: { id: K; params: import('$app/types').RouteParams<K>; } }[RouteId] | null>}
  */
 // eslint-disable-next-line @typescript-eslint/require-await

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -3275,7 +3275,7 @@ declare module '$app/navigation' {
 }
 
 declare module '$app/paths' {
-	import type { AssetPath, RouteIdWithSearchOrHash, PathnameWithSearchOrHash, ResolvedPathname, Path, RouteId, RouteParams } from '$app/types';
+	import type { AssetPath, RouteIdWithSearchOrHash, PathnameWithSearchOrHash, ResolvedPathname, RouteId, RouteParams } from '$app/types';
 	/**
 	 * Resolve the URL of an asset in your `static` directory, by prefixing it with [`config.paths.assets`](https://svelte.dev/docs/kit/configuration#paths) if configured, or otherwise by prefixing it with the base path.
 	 *
@@ -3332,7 +3332,7 @@ declare module '$app/paths' {
 	 * @since 2.52.0
 	 *
 	 * */
-	export function match(url: Path | URL | (string & {})): Promise<{ [K in RouteId]: {
+	export function match(url: URL | string): Promise<{ [K in RouteId]: {
 		id: K;
 		params: RouteParams<K>;
 	}; }[RouteId] | null>;


### PR DESCRIPTION
`match` can be given a `URL` or a `string` representing a pathname relative to the current location. `Path` is an enum of valid pathnames relative to the base path. In some cases these overlap, but it's by no means guaranteed, and the fact that there's an autocomplete dropdown is misleading and confusing. 

In any case, the general idea of a function like `match` is that you don't _know_ what the input is, so expecting a member of an enum rather than a `string` really makes no sense. This PR fixes it.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
