### PR TITLE
fix(adapter-cloudflare): skip cache lookup for non-GET requests

### DIFF
--- a/.changeset/tame-heads-listen.md
+++ b/.changeset/tame-heads-listen.md
@@ -1,0 +1,7 @@
+---
+'@sveltejs/adapter-cloudflare': patch
+---
+
+fix: skip cache lookup for non-GET requests to avoid 500 on HEAD requests
+
+worktop's `Cache.lookup` rebuilds HEAD requests as GET via `new Request(req, { method: 'GET' })`, which preserves the `Content-Length: 0` header with a null body. Cloudflare's cache API throws on such requests, turning every HEAD request into a 500. Since `Cache.save` only writes GET responses to the cache, HEAD requests can never hit the cache anyway — skip the lookup entirely for non-GET requests.

--- a/packages/adapter-cloudflare/src/worker.js
+++ b/packages/adapter-cloudflare/src/worker.js
@@ -52,7 +52,11 @@ export default {
 
 		// skip cache if "cache-control: no-cache" in request
 		let pragma = req.headers.get('cache-control') || '';
-		let res = !pragma.includes('no-cache') && (await Cache.lookup(req));
+		// Only cache GET requests: worktop's Cache.lookup converts HEAD→GET
+		// but preserves Content-Length: 0 with a null body, which causes
+		// Cloudflare's cache.match to throw a 500. Since Cache.save only
+		// writes GET responses to the cache, HEAD is never cached anyway.
+		let res = req.method === 'GET' && !pragma.includes('no-cache') && (await Cache.lookup(req));
 		if (res) return res;
 
 		let { pathname, search } = new URL(req.url);


### PR DESCRIPTION
## Summary

Fixes a 500 error when HEAD requests hit the `adapter-cloudflare` worker's cache lookup.

### Root cause

worktop's `Cache.lookup` rebuilds HEAD requests as GET via `new Request(req, { method: 'GET' })`, but this preserves the `Content-Length: 0` header with a null body. Cloudflare's `cache.match` API throws on such requests, turning every HEAD request into a 500.

Since `Cache.save` only writes GET responses to the cache (it checks `"GET" === t.method`), HEAD requests can never hit the cache anyway — the lookup was pointless and actively harmful.

### Fix

Skip the cache lookup entirely for non-GET requests by checking `req.method === 'GET'` before calling `Cache.lookup`. HEAD requests flow through to the normal routing logic (ASSETS/fetch or server.respond) which handles them correctly.

### Code changes

- `packages/adapter-cloudflare/src/worker.js`: Add `req.method === 'GET'` guard before `Cache.lookup`
- Added changeset documenting the fix

## Testing

- Verified the root cause: `Cache.lookup` on a HEAD request triggers Cloudflare cache API error
- Verified that `Cache.save` only handles GET (confirming HEAD can never be cached)
- Confirmed HEAD requests are handled correctly downstream (ASSETS/fetch supports HEAD natively)

## Checklist

- [x] Code follows project conventions
- [x] Changeset added
- [x] No new test files required (the fix is a one-line guard in the worker template)