### PR TITLE
Revert "chore: remove dependency on chokidar"

### DIFF
--- a/.changeset/quiet-owls-watch.md
+++ b/.changeset/quiet-owls-watch.md
@@ -1,5 +1,0 @@
----
-'@sveltejs/package': patch
----
-
-chore: remove dependency on chokidar

--- a/packages/package/package.json
+++ b/packages/package/package.json
@@ -20,6 +20,7 @@
 	"homepage": "https://svelte.dev",
 	"type": "module",
 	"dependencies": {
+		"chokidar": "^5.0.0",
 		"semver": "^7.8.5",
 		"svelte2tsx": "~0.7.56"
 	},

--- a/packages/package/src/index.js
+++ b/packages/package/src/index.js
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { styleText } from 'node:util';
+import chokidar from 'chokidar';
 import { preprocess } from 'svelte/compiler';
 import { copy, mkdirp, posixify, rimraf } from './filesystem.js';
 import {
@@ -90,11 +91,8 @@ export async function watch(options) {
 
 	console.log(message);
 
-	/** @type {Array<{ file: import('./types.js').File, type: 'change' | 'unlink' }>} */
+	/** @type {Array<{ file: import('./types.js').File, type: string }>} */
 	const pending = [];
-
-	// Remember files because deleted paths cannot be stat-ed to distinguish them from directories.
-	const known_files = new Set(scan(input, extensions).map((file) => file.name));
 
 	/** @type {Array<(value?: any) => void>} */
 	const fulfillers = [];
@@ -105,48 +103,21 @@ export async function watch(options) {
 	/** @type {Map<string, import('typescript').CompilerOptions>} */
 	const tsconfig_cache = new Map();
 
-	/**
-	 * @param {string} name
-	 * @param {'change' | 'unlink'} type
-	 */
-	function enqueue(name, type) {
-		const file = analyze(name, extensions);
+	const watcher = chokidar.watch(input, { ignoreInitial: true });
+	/** @type {Promise<void>} */
+	const ready = new Promise((resolve) => watcher.on('ready', resolve));
 
-		if (!pending.some((event) => event.type === type && event.file.name === file.name)) {
-			pending.push({ file, type });
-		}
+	watcher.on('all', (type, filepath) => {
+		const file = analyze(path.relative(input, filepath), extensions);
+
+		pending.push({ file, type });
 
 		if (
 			file.name.endsWith('tsconfig.json') ||
 			file.name.endsWith('jsconfig.json') ||
-			(options.tsconfig && posixify(path.join(input, name)) === posixify(options.tsconfig))
+			(options.tsconfig && posixify(filepath) === posixify(options.tsconfig))
 		) {
 			tsconfig_cache.clear();
-		}
-	}
-
-	const watcher = fs.watch(input, { recursive: true }, (_, filename) => {
-		if (filename !== null) {
-			const name = posixify(filename);
-			const stats = fs.statSync(path.join(input, filename), { throwIfNoEntry: false });
-
-			if (stats) {
-				if (!stats.isFile()) return;
-				known_files.add(name);
-				enqueue(name, 'change');
-			} else if (known_files.delete(name)) {
-				enqueue(name, 'unlink');
-			} else {
-				// a removed directory only fires an event for itself, not for the files inside it
-				const prefix = name + '/';
-
-				for (const child of known_files) {
-					if (child.startsWith(prefix)) {
-						known_files.delete(child);
-						enqueue(child, 'unlink');
-					}
-				}
-			}
 		}
 
 		clearTimeout(timeout);
@@ -180,7 +151,7 @@ export async function watch(options) {
 					console.log(`Removed ${file.dest}`);
 				}
 
-				if (type === 'change') {
+				if (type === 'add' || type === 'change') {
 					console.log(`Processing ${file.name}`);
 					try {
 						await process_file(
@@ -222,6 +193,7 @@ export async function watch(options) {
 
 	return {
 		watcher,
+		ready,
 		settled: () =>
 			new Promise((fulfil, reject) => {
 				fulfillers.push(fulfil);

--- a/packages/package/test/index.spec.js
+++ b/packages/package/test/index.spec.js
@@ -181,7 +181,7 @@ test('create package with tsconfig specified', async () => {
 	await test_make_package('tsconfig-specified', { tsconfig: 'tsconfig.build.json' });
 });
 
-// File watching is unreliable in GitHub Actions
+// chokidar doesn't fire events in github actions :shrug:
 if (!process.env.CI) {
 	test('watches for changes', async () => {
 		const cwd = join(import.meta.dirname, 'watch');
@@ -190,7 +190,7 @@ if (!process.env.CI) {
 		const config = await load_config();
 		process.chdir(original_cwd);
 
-		const { watcher, settled } = await watch({
+		const { watcher, ready, settled } = await watch({
 			cwd,
 			input: 'src/lib',
 			output: 'package',
@@ -224,6 +224,8 @@ if (!process.env.CI) {
 		}
 
 		try {
+			await ready;
+
 			// completes initial build
 			compare('index.js');
 
@@ -253,32 +255,13 @@ if (!process.env.CI) {
 			write('src/lib/post-error.svelte', '<button on:click={foo}>click me</button>');
 			await settled();
 			compare('post-error.svelte');
-
-			// removes outputs when a source file is deleted
-			remove('src/lib/a.js');
-			await settled();
-			expect(fs.existsSync(join(cwd, 'package/a.js'))).toBe(false);
-			expect(fs.existsSync(join(cwd, 'package/a.d.ts'))).toBe(false);
-
-			// removes outputs when a directory is renamed
-			fs.mkdirSync(join(cwd, 'src/lib/sub'));
-			write('src/lib/sub/c.js', "export const c = 'c';");
-			await settled();
-			expect(fs.existsSync(join(cwd, 'package/sub/c.js'))).toBe(true);
-
-			fs.renameSync(join(cwd, 'src/lib/sub'), join(cwd, 'src/lib/sub2'));
-			await settled();
-			expect(fs.existsSync(join(cwd, 'package/sub/c.js'))).toBe(false);
-			expect(fs.existsSync(join(cwd, 'package/sub2/c.js'))).toBe(true);
 		} finally {
-			watcher.close();
+			await watcher.close();
 
 			remove('src/lib/Test.svelte');
 			remove('src/lib/a.js');
 			remove('src/lib/b.ts');
 			remove('src/lib/post-error.svelte');
-			fs.rmSync(join(cwd, 'src/lib/sub'), { recursive: true, force: true });
-			fs.rmSync(join(cwd, 'src/lib/sub2'), { recursive: true, force: true });
 		}
 	}, 30_000);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1466,6 +1466,9 @@ importers:
 
   packages/package:
     dependencies:
+      chokidar:
+        specifier: ^5.0.0
+        version: 5.0.0
       semver:
         specifier: ^7.8.5
         version: 7.8.5
@@ -3084,6 +3087,10 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
+
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
@@ -3815,6 +3822,10 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
 
   regexparam@3.0.0:
     resolution: {integrity: sha512-RSYAtP31mvYLkAHrOlh25pCNQ5hWnT106VukGaaFfuJrZFkGRX5GhUAdPqpSDXxOhA2c4akmRuplv1mRqnBn6Q==}
@@ -5707,6 +5718,10 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
+
   chownr@3.0.0: {}
 
   cjs-module-lexer@2.2.0: {}
@@ -6393,6 +6408,8 @@ snapshots:
   punycode@2.3.1: {}
 
   readdirp@4.1.2: {}
+
+  readdirp@5.0.0: {}
 
   regexparam@3.0.0: {}
 


### PR DESCRIPTION
Reverts sveltejs/kit#16621 — doing this rather than fixing it because it's not a Kit 3 priority.

This broke stuff silently (because `watch` tests don't run in CI). The issue is that renames aren't properly accounted for — renaming a directory `foo` to `bar` (or `sub` to `sub2` in the test) means that pending `unlink` events are created for everything inside `foo`, with no corresponding events for the files that are now inside `bar`. As a result, files are removed from the output directory instead of being renamed (or recreated).