### PR TITLE
feat: warn when tsconfig doesn't exclude service worker

### DIFF
--- a/.changeset/curvy-seas-camp.md
+++ b/.changeset/curvy-seas-camp.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: warn when tsconfig doesn't exclude service worker

--- a/packages/kit/src/core/sync/write_tsconfig/index.js
+++ b/packages/kit/src/core/sync/write_tsconfig/index.js
@@ -94,11 +94,6 @@ function write_parent_tsconfig(root, id, config, transform) {
 	normalized = transform?.(normalized) ?? normalized;
 
 	write_if_changed(out_file, JSON.stringify(normalized, null, '\t'));
-
-	if (!ts) {
-		// The user has not installed TypeScript. Skip validation of config.
-		return;
-	}
 }
 
 /**
@@ -110,6 +105,11 @@ function write_parent_tsconfig(root, id, config, transform) {
  * @param {any} options.example What to print if the user config does _not_ extend the generated config
  */
 function validate_config(dir, options) {
+	if (!ts) {
+		// The user has not installed TypeScript. Skip validation of config.
+		return;
+	}
+
 	const user_config = load_user_tsconfig(dir);
 	if (!user_config || !modified_since_last_check(user_config.file)) return;
 

--- a/packages/kit/src/core/sync/write_tsconfig/index.js
+++ b/packages/kit/src/core/sync/write_tsconfig/index.js
@@ -6,13 +6,12 @@ import { styleText } from 'node:util';
 import { write_if_changed } from '../utils.js';
 import {
 	ESSENTIAL_OPTIONS,
-	extends_id,
 	get_subpath_imports,
 	normalize_config,
 	RECOMMENDED_OPTIONS,
-	remove_trailing_slashstar,
-	validate_resolved_config
+	remove_trailing_slashstar
 } from './utils.js';
+import { extends_id, validate_resolved_config } from './validate.js';
 
 /** @type {import('typescript')} */
 let ts;
@@ -29,16 +28,16 @@ try {
  */
 export function write_tsconfig(kit, root) {
 	const paths = get_paths(kit, root);
+	const types = ['$app/types'];
 
 	write_parent_tsconfig(
-		root,
 		root,
 		'$app/tsconfig',
 		{
 			compilerOptions: {
 				paths,
 				rootDirs: ['.', `${kit.outDir}/types`],
-				types: ['$app/types'],
+				types,
 
 				// This is required for svelte-package to work as expected
 				// Can be overwritten
@@ -46,45 +45,48 @@ export function write_tsconfig(kit, root) {
 
 				...ESSENTIAL_OPTIONS,
 				...RECOMMENDED_OPTIONS
-			},
-			exclude: [kit.files.serviceWorker]
-		},
-		{
-			extends: '$app/tsconfig',
-			include: ['src']
+			}
 		},
 		kit.typescript.config
 	);
 
-	write_parent_tsconfig(
-		root,
-		kit.files.serviceWorker,
-		'$app/tsconfig/service-worker',
-		{
-			compilerOptions: {
-				paths,
-				types: ['$app/types'],
-				lib: ['ESNext', 'WebWorker'],
-				...ESSENTIAL_OPTIONS
-			}
-		},
-		{
+	validate_config(root, {
+		paths,
+		types,
+		exclusions: [kit.files.serviceWorker],
+		example: {
+			extends: '$app/tsconfig'
+		}
+	});
+
+	write_parent_tsconfig(root, '$app/tsconfig/service-worker', {
+		compilerOptions: {
+			paths,
+			types,
+			lib: ['ESNext', 'WebWorker'],
+			...ESSENTIAL_OPTIONS,
+			...RECOMMENDED_OPTIONS
+		}
+	});
+
+	validate_config(kit.files.serviceWorker, {
+		paths,
+		types,
+		example: {
 			extends: '$app/tsconfig/service-worker'
 		}
-	);
+	});
 }
 
 /**
  * Write a generated `tsconfig.json` inside `node_modules`, for the
  * user config to extend
  * @param {string} root The project root
- * @param {string} dir The directory to resolve a user config from
  * @param {string} id The id of the generated config
  * @param {any} config The contents of the generated tsconfig, with paths relative to `root`
- * @param {any} example What to print if the user config does _not_ extend the generated config
  * @param {ValidatedKitConfig['typescript']['config']} [transform] TODO get rid of this
  */
-function write_parent_tsconfig(root, dir, id, config, example, transform) {
+function write_parent_tsconfig(root, id, config, transform) {
 	// simplified tsconfig resolvers (e.g. Playwright's) only find `${id}.json`, not `${id}/tsconfig.json`
 	const out_file = path.join(root, `node_modules/${id}.json`);
 
@@ -97,39 +99,55 @@ function write_parent_tsconfig(root, dir, id, config, example, transform) {
 		// The user has not installed TypeScript. Skip validation of config.
 		return;
 	}
+}
 
+/**
+ * @param {string} dir The directory to resolve a user config from
+ * @param {Object} options
+ * @param {Record<string, string[]>} options.paths The expected paths
+ * @param {string[]} options.types The expected types
+ * @param {string[]} [options.exclusions] Files that should be excluded
+ * @param {any} options.example What to print if the user config does _not_ extend the generated config
+ */
+function validate_config(dir, options) {
 	const user_config = load_user_tsconfig(dir);
+	if (!user_config || !modified_since_last_check(user_config.file)) return;
 
-	if (user_config && modified_since_last_check(user_config.file)) {
-		// now that we've written the parent config, we can resolve the
-		// user config and validate that nothing important was overwritten
-		if (!extends_id(user_config.options, id)) {
-			console.warn(
-				styleText(
-					['bold', 'yellow'],
-					`${path.relative(process.cwd(), user_config.file)} should extend SvelteKit's built-in configuration:`
-				)
-			);
+	// now that we've written the parent config, we can resolve the
+	// user config and validate that nothing important was overwritten
+	if (!extends_id(user_config.options, options.example.extends)) {
+		console.warn(
+			styleText(
+				['bold', 'yellow'],
+				`${path.relative(process.cwd(), user_config.file)} should extend SvelteKit's built-in configuration:`
+			)
+		);
 
-			console.warn(JSON.stringify(example, null, '  '));
+		console.warn(JSON.stringify(options.example, null, '  '));
 
-			return;
-		}
+		return;
+	}
 
-		const resolved = ts.parseJsonConfigFileContent(user_config.options, ts.sys, dir).options;
-		const warnings = validate_resolved_config(resolved, config.compilerOptions);
+	const resolved = ts.parseJsonConfigFileContent(user_config.options, ts.sys, dir);
 
-		if (warnings.length > 0) {
-			console.warn(
-				styleText(
-					['bold', 'yellow'],
-					`Found issues while validating ${path.relative(process.cwd(), user_config.file)}`
-				)
-			);
+	const warnings = validate_resolved_config(
+		dir,
+		resolved,
+		options.paths,
+		options.types,
+		options.exclusions
+	);
 
-			for (const warning of warnings) {
-				console.warn(`  - ${warning}`);
-			}
+	if (warnings.length > 0) {
+		console.warn(
+			styleText(
+				['bold', 'yellow'],
+				`Found issues while validating ${path.relative(process.cwd(), user_config.file)}`
+			)
+		);
+
+		for (const warning of warnings) {
+			console.warn(`  - ${warning}`);
 		}
 	}
 }

--- a/packages/kit/src/core/sync/write_tsconfig/utils.js
+++ b/packages/kit/src/core/sync/write_tsconfig/utils.js
@@ -37,16 +37,6 @@ export const RECOMMENDED_OPTIONS = {
 };
 
 /**
- * Validates that a tsconfig contains `"extends": "<id>"`
- * @param {any} options
- * @param {string} id
- */
-export function extends_id(options, id) {
-	const o = options.extends;
-	return Array.isArray(o) ? o.includes(id) : o === id;
-}
-
-/**
  * Makes paths relative to the output file
  * @param {string} out
  * @param {any} config
@@ -74,57 +64,6 @@ export function normalize_config(out, config, transform) {
 	};
 
 	return transform?.(normalized) ?? normalized;
-}
-
-/**
- * @param {any} resolved
- * @param {any} options
- */
-export function validate_resolved_config(resolved, options) {
-	const warnings = [];
-
-	const join = (/** @type {string[]} */ array) =>
-		array
-			.map((v) => JSON.stringify(v))
-			.join(', ')
-			.replace(/, ([^,]*)$/, ' and $1');
-
-	const missing_types = options.types?.filter(
-		(/** @type {string} */ type) => !resolved.types?.includes(type)
-	);
-
-	if (missing_types.length > 0) {
-		warnings.push(`"types" was overwritten. It must include ${join(missing_types)}`);
-	}
-
-	if (options.paths) {
-		/** @type {Set<string>} */
-		const mismatch = new Set();
-
-		for (const [k, expected] of Object.entries(options.paths)) {
-			const actual = resolved.paths?.[k]?.map((/** @type {string} */ x) =>
-				path.resolve(/** @type {string} */ (resolved.pathsBasePath), x)
-			);
-
-			if (JSON.stringify(expected) !== JSON.stringify(actual)) {
-				mismatch.add(remove_trailing_slashstar(k));
-			}
-		}
-
-		if (mismatch.size > 0) {
-			const joined = join([...mismatch]);
-
-			warnings.push(`"paths" was overwritten. Imports from ${joined} may not typecheck`);
-		}
-	}
-
-	for (const key in ESSENTIAL_OPTIONS) {
-		if (resolved[key] !== options[key]) {
-			warnings.push(`"${key}" was overwritten. It should be ${JSON.stringify(options[key])}`);
-		}
-	}
-
-	return warnings;
 }
 
 /**

--- a/packages/kit/src/core/sync/write_tsconfig/utils.spec.js
+++ b/packages/kit/src/core/sync/write_tsconfig/utils.spec.js
@@ -1,10 +1,5 @@
 import { assert, describe, test } from 'vitest';
-import {
-	extends_id,
-	get_subpath_imports,
-	normalize_config,
-	validate_resolved_config
-} from './utils.js';
+import { get_subpath_imports, normalize_config } from './utils.js';
 
 describe('normalize_config', () => {
 	test('normalizes rootDirs', () => {
@@ -71,29 +66,5 @@ describe('get_subpath_imports', () => {
 			'#lib': 'src/lib',
 			'#lib/*': 'src/lib/*'
 		});
-	});
-});
-
-describe('extends_id', () => {
-	const id = 'POTATO';
-
-	test('validates that a config extends an id (string)', () => {
-		assert.equal(extends_id({ extends: id }, id), true);
-	});
-
-	test('validates that a config extends an id (array)', () => {
-		assert.equal(extends_id({ extends: [id] }, id), true);
-	});
-
-	test('validates that a config does not extend an id', () => {
-		assert.equal(extends_id({}, id), false);
-	});
-});
-
-describe('validate_resolved_config', () => {
-	test('warns if types is overwritten', () => {
-		const warnings = validate_resolved_config({ types: [] }, { types: ['pinky', 'perky'] });
-
-		assert.deepEqual(warnings, ['"types" was overwritten. It must include "pinky" and "perky"']);
 	});
 });

--- a/packages/kit/src/core/sync/write_tsconfig/validate.js
+++ b/packages/kit/src/core/sync/write_tsconfig/validate.js
@@ -102,7 +102,7 @@ export function validate_paths(warnings, base, expected, actual) {
  * @param {string[]} files
  */
 export function validate_exclusions(warnings, dir, exclusions, files) {
-	const missing_exclusions = exclusions.filter((exclusion) => {
+	const missing_exclusions = exclusions.map(posixify).filter((exclusion) => {
 		return files.some(
 			(f) => f === exclusion || f.startsWith(exclusion + '/') || f.startsWith(exclusion + '.')
 		);

--- a/packages/kit/src/core/sync/write_tsconfig/validate.js
+++ b/packages/kit/src/core/sync/write_tsconfig/validate.js
@@ -1,0 +1,125 @@
+/** @import ts from 'typescript' */
+import path from 'node:path';
+import { ESSENTIAL_OPTIONS, remove_trailing_slashstar } from './utils.js';
+
+const formatter = new Intl.ListFormat('en-gb', { type: 'conjunction' });
+
+/**
+ * @param {string[]} things
+ */
+function join(things) {
+	return formatter.format(things.map((thing) => JSON.stringify(thing)));
+}
+
+/**
+ * @param {string} dir
+ * @param {ts.ParsedCommandLine} resolved
+ * @param {Record<string, string[]>} paths
+ * @param {string[]} types
+ * @param {string[]} [exclusions]
+ */
+export function validate_resolved_config(dir, resolved, paths, types, exclusions) {
+	/** @type {string[]} */
+	const warnings = [];
+
+	if (resolved.options.types) {
+		validate_types(warnings, types, resolved.options.types);
+	}
+
+	if (resolved.options.paths) {
+		validate_paths(
+			warnings,
+			/** @type {string} */ (resolved.options.pathsBasePath),
+			paths,
+			resolved.options.paths
+		);
+	}
+
+	if (exclusions) {
+		validate_exclusions(warnings, dir, exclusions, resolved.fileNames);
+	}
+
+	for (const key in ESSENTIAL_OPTIONS) {
+		if (resolved.options[key] !== ESSENTIAL_OPTIONS[key]) {
+			warnings.push(
+				`"${key}" was overwritten. It should be ${JSON.stringify(ESSENTIAL_OPTIONS[key])}`
+			);
+		}
+	}
+
+	return warnings;
+}
+
+/**
+ * @param {string[]} warnings
+ * @param {string[]} expected
+ * @param {string[]} actual
+ */
+export function validate_types(warnings, expected, actual) {
+	const missing_types = expected.filter((/** @type {string} */ type) => !actual.includes(type));
+
+	if (missing_types.length > 0) {
+		warnings.push(`"types" was overwritten. It must include ${join(missing_types)}`);
+	}
+
+	return warnings;
+}
+
+/**
+ * @param {string[]} warnings
+ * @param {string} base
+ * @param {Record<string, string[]>} expected
+ * @param {ts.MapLike<string[]>} actual
+ */
+export function validate_paths(warnings, base, expected, actual) {
+	/** @type {Set<string>} */
+	const mismatch = new Set();
+
+	for (const [k, e] of Object.entries(expected)) {
+		const a = actual[k]?.map((/** @type {string} */ x) =>
+			path.resolve(/** @type {string} */ (base), x)
+		);
+
+		if (JSON.stringify(e) !== JSON.stringify(a)) {
+			mismatch.add(remove_trailing_slashstar(k));
+		}
+	}
+
+	if (mismatch.size > 0) {
+		const joined = join([...mismatch]);
+
+		warnings.push(`"paths" was overwritten. Imports from ${joined} may not typecheck`);
+	}
+
+	return warnings;
+}
+
+/**
+ * @param {string[]} warnings
+ * @param {string} dir
+ * @param {string[]} exclusions
+ * @param {string[]} files
+ */
+export function validate_exclusions(warnings, dir, exclusions, files) {
+	const missing_exclusions = exclusions.filter((exclusion) => {
+		return files.some((file) => file === exclusion || file.startsWith(exclusion + '/'));
+	});
+
+	if (missing_exclusions.length > 0) {
+		warnings.push(
+			`${join(missing_exclusions.map((file) => path.relative(dir, file)))} should be added to the "exclude" array`
+		);
+	}
+
+	return warnings;
+}
+
+/**
+ * Validates that a tsconfig contains `"extends": "<id>"`
+ * @param {any} options
+ * @param {string} id
+ */
+export function extends_id(options, id) {
+	const o = options.extends;
+	return Array.isArray(o) ? o.includes(id) : o === id;
+}

--- a/packages/kit/src/core/sync/write_tsconfig/validate.js
+++ b/packages/kit/src/core/sync/write_tsconfig/validate.js
@@ -103,10 +103,7 @@ export function validate_paths(warnings, base, expected, actual) {
 export function validate_exclusions(warnings, dir, exclusions, files) {
 	const missing_exclusions = exclusions.filter((exclusion) => {
 		return files.some(
-			(file) =>
-				file === exclusion ||
-				file.startsWith(exclusion + '/') ||
-				file.startsWith(exclusion + '.')
+			(f) => f === exclusion || f.startsWith(exclusion + '/') || f.startsWith(exclusion + '.')
 		);
 	});
 

--- a/packages/kit/src/core/sync/write_tsconfig/validate.js
+++ b/packages/kit/src/core/sync/write_tsconfig/validate.js
@@ -1,6 +1,7 @@
 /** @import ts from 'typescript' */
 import path from 'node:path';
 import { ESSENTIAL_OPTIONS, remove_trailing_slashstar } from './utils.js';
+import { posixify } from '../../../utils/os.js';
 
 const formatter = new Intl.ListFormat('en-gb', { type: 'conjunction' });
 
@@ -109,7 +110,7 @@ export function validate_exclusions(warnings, dir, exclusions, files) {
 
 	if (missing_exclusions.length > 0) {
 		warnings.push(
-			`${join(missing_exclusions.map((file) => path.relative(dir, file)))} should be added to the "exclude" array`
+			`${join(missing_exclusions.map((file) => posixify(path.relative(dir, file))))} should be added to the "exclude" array`
 		);
 	}
 

--- a/packages/kit/src/core/sync/write_tsconfig/validate.js
+++ b/packages/kit/src/core/sync/write_tsconfig/validate.js
@@ -102,7 +102,12 @@ export function validate_paths(warnings, base, expected, actual) {
  */
 export function validate_exclusions(warnings, dir, exclusions, files) {
 	const missing_exclusions = exclusions.filter((exclusion) => {
-		return files.some((file) => file === exclusion || file.startsWith(exclusion + '/'));
+		return files.some(
+			(file) =>
+				file === exclusion ||
+				file.startsWith(exclusion + '/') ||
+				file.startsWith(exclusion + '.')
+		);
 	});
 
 	if (missing_exclusions.length > 0) {

--- a/packages/kit/src/core/sync/write_tsconfig/validate.spec.js
+++ b/packages/kit/src/core/sync/write_tsconfig/validate.spec.js
@@ -36,4 +36,25 @@ describe('validate_exclusions', () => {
 
 		assert.deepEqual(warnings, ['"src/service-worker" should be added to the "exclude" array']);
 	});
+
+	test('does not warn if service worker is absent', () => {
+		const warnings = validate_exclusions(
+			[],
+			'/path/to/project',
+			['/path/to/project/src/service-worker'],
+			[]
+		);
+
+		assert.deepEqual(warnings, []);
+	});
+
+	test('detects windows-style exclusions', () => {
+		const warnings = validate_exclusions(
+			[],
+			'C:/project',
+			['C:\\project\\src\\service-worker'],
+			['C:/project/src/service-worker/index.ts']
+		);
+		assert.deepEqual(warnings, ['"src/service-worker" should be added to the "exclude" array']);
+	});
 });

--- a/packages/kit/src/core/sync/write_tsconfig/validate.spec.js
+++ b/packages/kit/src/core/sync/write_tsconfig/validate.spec.js
@@ -1,0 +1,39 @@
+import { assert, describe, test } from 'vitest';
+import { extends_id, validate_exclusions, validate_types } from './validate.js';
+
+describe('extends_id', () => {
+	const id = 'POTATO';
+
+	test('validates that a config extends an id (string)', () => {
+		assert.equal(extends_id({ extends: id }, id), true);
+	});
+
+	test('validates that a config extends an id (array)', () => {
+		assert.equal(extends_id({ extends: [id] }, id), true);
+	});
+
+	test('validates that a config does not extend an id', () => {
+		assert.equal(extends_id({}, id), false);
+	});
+});
+
+describe('validate_types', () => {
+	test('warns if types is overwritten', () => {
+		const warnings = validate_types([], ['pinky', 'perky'], []);
+
+		assert.deepEqual(warnings, ['"types" was overwritten. It must include "pinky" and "perky"']);
+	});
+});
+
+describe('validate_exclusions', () => {
+	test('warns if service worker is incorrectly included', () => {
+		const warnings = validate_exclusions(
+			[],
+			'/path/to/project',
+			['/path/to/project/src/service-worker'],
+			['/path/to/project/src/service-worker/index.ts']
+		);
+
+		assert.deepEqual(warnings, ['"src/service-worker" should be added to the "exclude" array']);
+	});
+});


### PR DESCRIPTION
closes #16581. Different approach to #16593 — rather than adding an empty `include` array from the generated `tsconfig.json`, we just get rid of the `exclude` array and validate the result. This removes a layer of magic and makes it easier for the user to understand the shape of their config.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
