### PR TITLE
fix: detect $app/server imports when kit is installed inside the project root

### DIFF
--- a/.changeset/smart-pugs-refuse.md
+++ b/.changeset/smart-pugs-refuse.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: detect `$app/server` and `$app/env/private` client imports when SvelteKit is installed inside the project root

--- a/packages/kit/src/exports/vite/utils.js
+++ b/packages/kit/src/exports/vite/utils.js
@@ -113,6 +113,16 @@ const query_pattern = /\?.*$/s;
 export function normalize_id(id, aliases, cwd) {
 	id = id.replace(query_pattern, '');
 
+	// check before the cwd is removed — in a user's app these modules live
+	// inside `node_modules`, i.e. within the cwd
+	if (id === app_server) {
+		return '$app/server';
+	}
+
+	if (id === app_env_private || id === sveltekit_env_private) {
+		return '$app/env/private';
+	}
+
 	for (const { alias, path } of aliases) {
 		if (id === path || id.startsWith(path + '/')) {
 			id = id.replace(path, alias);
@@ -122,14 +132,6 @@ export function normalize_id(id, aliases, cwd) {
 
 	if (id.startsWith(cwd)) {
 		id = path.relative(cwd, id);
-	}
-
-	if (id === app_server) {
-		return '$app/server';
-	}
-
-	if (id === app_env_private || id === sveltekit_env_private) {
-		return '$app/env/private';
 	}
 
 	return posixify(id);

--- a/packages/kit/src/exports/vite/utils.spec.js
+++ b/packages/kit/src/exports/vite/utils.spec.js
@@ -6,10 +6,12 @@ import { dedent } from '../../core/sync/utils.js';
 import {
 	error_for_missing_config,
 	get_config_aliases,
+	normalize_id,
 	remote_module_pattern,
 	server_only_directory_pattern,
 	server_only_module_pattern
 } from './utils.js';
+import { app_server, app_env_private } from './module_ids.js';
 
 test('transform kit.alias to resolve.alias', () => {
 	const config = validate_config({
@@ -42,6 +44,15 @@ test('transform kit.alias to resolve.alias', () => {
 		{ find: /^\$regexChar$/.toString(), replacement: 'windows/path' },
 		{ find: /^\$regexChar\/(.+)$/.toString(), replacement: 'windows/path/$1' }
 	]);
+});
+
+test('normalizes special module ids that live inside the cwd', () => {
+	// in a user's app, kit is installed within the project root, so the
+	// special module ids must be recognized before the cwd is removed
+	const cwd = app_server.slice(0, app_server.indexOf('/src/runtime'));
+
+	expect(normalize_id(app_server, [], cwd)).toBe('$app/server');
+	expect(normalize_id(app_env_private, [], cwd)).toBe('$app/env/private');
 });
 
 test('recognizes server-only module filenames', () => {


### PR DESCRIPTION
`normalize_id` removed the cwd from the id before comparing it against `app_server` and `app_env_private`, but in a user's app those modules live in `node_modules`, inside the cwd, so the comparisons never matched and the "Cannot import $app/server into code that runs in the browser" guard never fired. The test apps in this repo don't catch this because kit lives outside the app root here.

Found while auditing path handling for #16620.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits
- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
