### PR TITLE
chore: lint rule and windows CI leg to guard the recurring windows path bug class

### DIFF
--- a/.changeset/tangy-llamas-attack.md
+++ b/.changeset/tangy-llamas-attack.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-netlify': patch
+---
+
+fix: import the generated manifest via `pathToFileURL`, which handles special characters in the project path

--- a/.eslint/require-path-to-file-url.js
+++ b/.eslint/require-path-to-file-url.js
@@ -1,0 +1,83 @@
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
+export default {
+	meta: {
+		type: 'problem',
+		docs: {
+			description: 'require dynamic imports of computed file paths to go through pathToFileURL',
+			category: 'Possible Errors',
+			recommended: true
+		},
+		schema: [],
+		messages: {
+			requirePathToFileURL:
+				'Dynamic import() of a computed path must be wrapped in pathToFileURL(...).href — on Windows, absolute paths parse as URLs with the drive letter as protocol and fail to import. See https://github.com/sveltejs/kit/issues/16620'
+		}
+	},
+
+	create(context) {
+		/**
+		 * Returns true if the expression is safe to pass to `import()`:
+		 * a static specifier, a relative computed specifier, or a value
+		 * wrapped in `pathToFileURL`/`new URL`
+		 * @param {import('estree').Node} node
+		 * @param {number} depth
+		 * @returns {boolean}
+		 */
+		function is_safe(node, depth = 0) {
+			if (node.type === 'Literal') {
+				return true;
+			}
+
+			if (node.type === 'TemplateLiteral') {
+				if (node.expressions.length === 0) return true;
+
+				// a computed specifier with a static relative prefix resolves
+				// relative to the importing module — no drive letters involved
+				const prefix = node.quasis[0].value.cooked ?? '';
+				return prefix.startsWith('./') || prefix.startsWith('../');
+			}
+
+			if (node.type === 'CallExpression' || node.type === 'NewExpression') {
+				const callee = node.callee;
+				return (
+					(callee.type === 'Identifier' && callee.name === 'pathToFileURL') ||
+					(callee.type === 'Identifier' && callee.name === 'URL')
+				);
+			}
+
+			// `pathToFileURL(...).href` and `new URL(...).href`
+			if (node.type === 'MemberExpression') {
+				return (
+					node.property.type === 'Identifier' &&
+					node.property.name === 'href' &&
+					is_safe(node.object, depth)
+				);
+			}
+
+			// resolve an identifier one hop to its declaration
+			if (node.type === 'Identifier' && depth === 0) {
+				const variable = context.sourceCode
+					.getScope(node)
+					.references.find((ref) => ref.identifier === node)?.resolved;
+
+				const def = variable?.defs[0];
+
+				if (variable?.defs.length === 1 && def?.type === 'Variable' && def.node.init) {
+					return is_safe(def.node.init, depth + 1);
+				}
+			}
+
+			return false;
+		}
+
+		return {
+			ImportExpression(node) {
+				if (!is_safe(node.source)) {
+					context.report({ node: node.source, messageId: 'requirePathToFileURL' });
+				}
+			}
+		};
+	}
+};

--- a/.eslint/require-path-to-file-url.js
+++ b/.eslint/require-path-to-file-url.js
@@ -41,9 +41,11 @@ export default {
 
 			if (node.type === 'CallExpression' || node.type === 'NewExpression') {
 				const callee = node.callee;
+				if (callee.type !== 'Identifier') return false;
+
+				// single-argument new URL(path) misparses absolute windows paths just like import(), so require a base
 				return (
-					(callee.type === 'Identifier' && callee.name === 'pathToFileURL') ||
-					(callee.type === 'Identifier' && callee.name === 'URL')
+					callee.name === 'pathToFileURL' || (callee.name === 'URL' && node.arguments.length > 1)
 				);
 			}
 
@@ -64,7 +66,13 @@ export default {
 
 				const def = variable?.defs[0];
 
-				if (variable?.defs.length === 1 && def?.type === 'Variable' && def.node.init) {
+				if (
+					variable?.defs.length === 1 &&
+					def?.type === 'Variable' &&
+					def.node.init &&
+					// a reassignment after a safe initializer would not be seen here
+					variable.references.every((ref) => !ref.isWrite() || ref.init)
+				) {
 					return is_safe(def.node.init, depth + 1);
 				}
 			}

--- a/.eslint/require-path-to-file-url.js
+++ b/.eslint/require-path-to-file-url.js
@@ -5,9 +5,7 @@ export default {
 	meta: {
 		type: 'problem',
 		docs: {
-			description: 'require dynamic imports of computed file paths to go through pathToFileURL',
-			category: 'Possible Errors',
-			recommended: true
+			description: 'require dynamic imports of computed file paths to go through pathToFileURL'
 		},
 		schema: [],
 		messages: {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,3 +263,16 @@ jobs:
       - uses: ./.github/actions/playwright-setup
       - run: cd packages/kit && pnpm prepublishOnly
       - run: pnpm run test:others
+  test-others-windows:
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - run: git config --global core.autocrlf false
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/node-setup
+        with:
+          node-version: 24
+      - run: cd packages/kit && pnpm prepublishOnly
+      - run: pnpm run test:others:unit

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,13 +29,13 @@ export default [
 		// code that runs in Node, where dynamic imports of absolute paths
 		// need `pathToFileURL` to work on Windows
 		files: [
-			'packages/kit/src/core/**/*.js',
-			'packages/kit/src/exports/vite/**/*.js',
-			'packages/kit/src/utils/**/*.js',
+			'packages/kit/src/**/*.js',
 			'packages/adapter-*/*.js',
 			'packages/adapter-*/src/**/*.js',
 			'packages/package/src/**/*.js'
 		],
+		// the client runtime's dynamic imports are resolved by vite, not Node
+		ignores: ['packages/kit/src/runtime/**'],
 		plugins: {
 			'kit-node-custom': {
 				rules: {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,6 @@
 import svelte_config from '@sveltejs/eslint-config';
 import noRuntimeToExportsImports from './.eslint/no-runtime-to-exports-imports.js';
+import requirePathToFileURL from './.eslint/require-path-to-file-url.js';
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
@@ -22,6 +23,28 @@ export default [
 		},
 		rules: {
 			'kit-custom/no-runtime-to-exports-imports': 'error'
+		}
+	},
+	{
+		// code that runs in Node, where dynamic imports of absolute paths
+		// need `pathToFileURL` to work on Windows
+		files: [
+			'packages/kit/src/core/**/*.js',
+			'packages/kit/src/exports/vite/**/*.js',
+			'packages/kit/src/utils/**/*.js',
+			'packages/adapter-*/*.js',
+			'packages/adapter-*/src/**/*.js',
+			'packages/package/src/**/*.js'
+		],
+		plugins: {
+			'kit-node-custom': {
+				rules: {
+					'require-path-to-file-url': requirePathToFileURL
+				}
+			}
+		},
+		rules: {
+			'kit-node-custom/require-path-to-file-url': 'error'
 		}
 	},
 	{

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"test:svelte-async:build": "pnpm run --dir packages/kit test:svelte-async:build",
 		"test:vite-ecosystem-ci": "pnpm --dir packages/kit test",
 		"test:others": "pnpm -r --filter='./packages/*' --filter=!./packages/kit/ --workspace-concurrency=1 test",
+		"test:others:unit": "pnpm -r --filter=\"./packages/*\" --filter=\"!./packages/kit\" --workspace-concurrency=1 test:unit",
 		"test:unit": "vitest run",
 		"check": "pnpm -r prepublishOnly && pnpm -r check",
 		"lint": "pnpm -r lint && echo '\nRunning eslint...' && eslint --cache --cache-location node_modules/.eslintcache 'packages/**/*.{js,d.ts}'",

--- a/packages/adapter-auto/package.json
+++ b/packages/adapter-auto/package.json
@@ -36,7 +36,8 @@
 		"lint": "prettier --check .",
 		"format": "pnpm lint --write",
 		"check": "tsc",
-		"test": "vitest run"
+		"test": "vitest run",
+		"test:unit": "vitest run"
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:^",

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join, posix } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { builtinModules } from 'node:module';
 import process from 'node:process';
 import toml from '@iarna/toml';
@@ -377,8 +377,7 @@ async function generate_edge_functions({ builder }) {
 	writeFileSync(`${tmp}/manifest.js`, `export const manifest = ${manifest};\n`);
 
 	/** @type {{ assets: Set<string> }} */
-	// we have to prepend the file:// protocol because Windows doesn't support absolute path imports
-	const { assets } = (await import(`file://${tmp}/manifest.js`)).manifest;
+	const { assets } = (await import(pathToFileURL(`${tmp}/manifest.js`).href)).manifest;
 
 	const path = '/*';
 	// We only need to specify paths without the trailing slash because

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -36,6 +36,7 @@
 		"dev": "rolldown -cw",
 		"build": "rolldown -c",
 		"test": "vitest run",
+		"test:unit": "vitest run",
 		"check": "tsc",
 		"lint": "prettier --check .",
 		"format": "pnpm lint --write",

--- a/packages/kit/src/utils/import.js
+++ b/packages/kit/src/utils/import.js
@@ -54,6 +54,7 @@ export async function import_peer(dependency, root) {
 	try {
 		return await import(/* @vite-ignore */ pathToFileURL(resolve_peer(dependency, root)).href);
 	} catch {
+		// eslint-disable-next-line kit-node-custom/require-path-to-file-url -- bare package specifier, not a path
 		return await import(/* @vite-ignore */ dependency);
 	}
 }

--- a/packages/kit/src/version.spec.js
+++ b/packages/kit/src/version.spec.js
@@ -4,11 +4,10 @@ import { assert, describe, it } from 'vitest';
 
 // runs the version generation as a side-effect of importing
 import '../scripts/generate-version.js';
-import { join } from 'node:path';
 
 describe('@sveltejs/kit VERSION', () => {
 	it('should be the exact version from package.json', async () => {
-		const { VERSION } = await import(join(import.meta.dirname, 'version.js'));
+		const { VERSION } = await import(new URL('./version.js', import.meta.url).href);
 		const pkg = JSON.parse(
 			readFileSync(fileURLToPath(new URL('../package.json', import.meta.url)), 'utf-8')
 		);

--- a/packages/package/package.json
+++ b/packages/package/package.json
@@ -56,7 +56,8 @@
 		"check": "tsc",
 		"check:all": "tsc && pnpm -r --filter=\"./**\" check",
 		"format": "pnpm lint --write",
-		"test": "vitest run"
+		"test": "vitest run",
+		"test:unit": "vitest run"
 	},
 	"exports": {
 		"./package.json": "./package.json"

--- a/packages/package/src/config.js
+++ b/packages/package/src/config.js
@@ -42,6 +42,7 @@ async function import_peer(dependency, root) {
 	try {
 		return await import(/* @vite-ignore */ pathToFileURL(resolve_peer(dependency, root)).href);
 	} catch {
+		// eslint-disable-next-line kit-node-custom/require-path-to-file-url -- bare package specifier, not a path
 		return await import(/* @vite-ignore */ dependency);
 	}
 }


### PR DESCRIPTION
closes #16620

The rule's one live catch was adapter-netlify's `file://` manifest import. The unit suites in the new windows job have never run on windows-latest before.
