### PR TITLE
fix(adapter-node): fail the build on imports that resolve to no installed package

### DIFF
--- a/.changeset/adapter-node-unresolvable-imports.md
+++ b/.changeset/adapter-node-unresolvable-imports.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+fix: fail the build when the output contains imports that resolve to no installed package

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -1,6 +1,7 @@
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { createRequire, isBuiltin } from 'node:module';
 import { extname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { rolldown } from 'rolldown';
 
 const files = fileURLToPath(new URL('./files', import.meta.url).href);
@@ -137,7 +138,7 @@ export default function (opts = {}) {
 				]
 			});
 
-			await bundle.write({
+			const bundled = await bundle.write({
 				dir: out,
 				format: 'esm',
 				sourcemap: true,
@@ -154,6 +155,40 @@ export default function (opts = {}) {
 					return 'server/chunks/[name]-[hash].js';
 				}
 			});
+
+			// Anything not in `dependencies` is bundled, so a bare import left in the output
+			// resolves against a deployment that will not contain it. That is fatal but silent:
+			// the build succeeds and the server dies as the module is evaluated, which for
+			// `instrumentation.server.js` is before it can log anything at all.
+			const require_from_project = createRequire(pathToFileURL('package.json'));
+			const emitted = new Set(bundled.output.map((chunk) => chunk.fileName));
+
+			/** @type {string[]} */
+			const unresolvable = [];
+
+			for (const chunk of bundled.output) {
+				if (chunk.type !== 'chunk') continue;
+
+				for (const source of [...chunk.imports, ...chunk.dynamicImports]) {
+					// imports of our own chunks are relative but reported without a leading `./`
+					if (emitted.has(source) || /^[./]/.test(source) || isBuiltin(source)) continue;
+
+					try {
+						require_from_project.resolve(source);
+					} catch {
+						unresolvable.push(`  ${source} (imported by ${chunk.fileName})`);
+					}
+				}
+			}
+
+			if (unresolvable.length > 0) {
+				throw new Error(
+					'The build contains imports that resolve to no installed package, so the server ' +
+						`would fail to start with ERR_MODULE_NOT_FOUND:\n${unresolvable.join('\n')}\n\n` +
+						'If these are optional dependencies, add them to "dependencies" so they are ' +
+						'installed alongside the build, or stop importing them.'
+				);
+			}
 
 			if (builder.hasServerInstrumentationFile()) {
 				builder.instrument({


### PR DESCRIPTION
Related to #16653 (does not close it — see "Scope" below)

adapter-node marks only `pkg.dependencies` as external, so everything else is bundled and any bare import left in the output has to resolve against a deployment that will not contain it. When it cannot, the failure is fatal and silent: the build succeeds, the image builds, and the server exits during module evaluation with `ERR_MODULE_NOT_FOUND`. For `instrumentation.server.js` that happens before the server can log anything at all — you get a container that starts and immediately dies.

This PR checks what was actually emitted rather than trusting the graph, and fails the build with the offending specifier and the chunk it came from.

### Reproduction on `version-3`

A dependency that statically imports an unmet optional peer is enough. With a package in `node_modules` containing:

```js
// esm-optional-dep/index.js
import 'not-installed-esm-package';

export function hello() {
  return 'hello';
}
```

imported from `src/instrumentation.server.js`, the build succeeds and produces:

```js
// build/instrumentation.server.js
import "not-installed-esm-package";
```

```
$ node build/index.js
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'not-installed-esm-package'
  imported from .../build/instrumentation.server.js
```

Rolldown does warn — `Module not found, treating it as an external dependency` — but it is one line among the rest of the build output, and it doesn't stop a bundle that cannot start from being written. With this PR the build fails instead:

```
Error: The build contains imports that resolve to no installed package, so the server would
fail to start with ERR_MODULE_NOT_FOUND:
  not-installed-esm-package (imported by instrumentation.server.js)

If these are optional dependencies, add them to "dependencies" so they are installed
alongside the build, or stop importing them.
```

### Scope, and what this does *not* fix

This came out of #16653, where adapter-node 5.5.6/5.5.7 emitted `import '@babel/preset-typescript/package.json'` into `build/instrumentation.server.js` and took down a production deployment. The root cause there is `@rollup/plugin-commonjs` hoisting a `require` from inside a `catch` clause into a top-level import — fix proposed in rollup/plugins#2018 — so **this PR is not a fix for #16653**. It is the guard that would have turned that incident into a build error.

Worth noting the two lines behave differently here. On `main` (adapter-node 5.5.7, rollup + `@rollup/plugin-commonjs`) that catch-clause require becomes a static import and the server cannot start. On `version-3` (rolldown) the same input compiles to a lazy `__require(...)` and boots fine — which is why the reproduction above uses an ESM import instead, a path that is still live here.

The guard itself applies equally to both lines. I have it implemented and verified against `main`/5.5.7 as well, where it catches the original `@babel/preset-typescript` case directly; happy to open that as a companion PR if you'd want the fix on the released line too.

### Notes on the implementation

- Resolution is done with `createRequire` from the project root, which is where the deployment's `node_modules` will be. Anything unresolvable there is unresolvable at runtime.
- Skips: emitted chunks (rolldown reports sibling chunks without a leading `./`, so they must be filtered by `fileName`, not by prefix — this caused false positives on `env.js` and `manifest.js-*.js` in a first attempt), relative specifiers, and Node builtins via `isBuiltin`.
- Covers `dynamicImports` as well as static `imports`.
- `bundle.write`'s result is bound to `bundled` rather than `written`, since `written` is already taken further up.

### Verification

- `pnpm test` in `packages/adapter-node`: 16/16 pass
- `pnpm lint`: clean
- `pnpm check`: 7 errors, identical with and without this change (all pre-existing, from unbuilt `@sveltejs/kit` types in my sparse checkout)
- **False positives:** the equivalent guard was run against a large real application — ~130 devDependencies bundled, 2 production dependencies — and stays silent on a healthy build. Also verified silent on the reproduction above once the bad import is removed, with the server still serving normally.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

The existing adapter-node tests don't build fixture apps, so there's no harness a test for this could hang off. #16305 proposes exactly that — a fixture app built with the real adapter and booted — and this guard would slot into it naturally. Happy to add one here if you'd rather not wait for that, or to rebase on it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
