### PR TITLE
chore: use the peer imported Vite consistently

### DIFF
--- a/packages/kit/src/cli.js
+++ b/packages/kit/src/cli.js
@@ -2,8 +2,9 @@ import fs from 'node:fs';
 import process from 'node:process';
 import { parseArgs, styleText } from 'node:util';
 import { extract_svelte_config, load_vite_config } from './core/config/index.js';
-import { coalesce_to_error } from './utils/error.js';
 import { resolve_explicit_env_entry } from './core/env.js';
+import { coalesce_to_error } from './utils/error.js';
+import { import_peer } from './utils/import.js';
 
 /** @param {unknown} e */
 function handle_error(e) {
@@ -96,14 +97,16 @@ if (command === 'sync') {
 	}
 
 	try {
-		const vite_config = await load_vite_config(values.config);
+		const vite = /** @type {import('vite')} */ (await import_peer('vite', process.cwd()));
+
+		const vite_config = await load_vite_config(values.config, vite);
 		const sveltekit_config = extract_svelte_config(vite_config);
 
 		const sync = await import('./core/sync/sync.js');
 		sync.all_types(sveltekit_config, vite_config.root);
 
 		const explicit_env_entry = resolve_explicit_env_entry(sveltekit_config.kit);
-		await sync.env(sveltekit_config.kit, explicit_env_entry, vite_config.root, values.mode);
+		await sync.env(vite, sveltekit_config.kit, explicit_env_entry, vite_config.root, values.mode);
 	} catch (error) {
 		handle_error(error);
 	} finally {

--- a/packages/kit/src/core/config/index.js
+++ b/packages/kit/src/core/config/index.js
@@ -120,13 +120,12 @@ export function load_error_page(config) {
 
 /**
  * @param {string} [config]
+ * @param {typeof import('vite')} [vite]
  */
-export async function load_vite_config(config) {
-	const { resolveConfig } = /** @type {import('vite')} */ (
-		await import_peer('vite', process.cwd())
-	);
+export async function load_vite_config(config, vite) {
+	vite ??= /** @type {import('vite')} */ (await import_peer('vite', process.cwd()));
 
-	return resolveConfig({ configFile: config }, 'build', process.env.MODE ?? 'production');
+	return vite.resolveConfig({ configFile: config }, 'build', process.env.MODE ?? 'production');
 }
 
 /**

--- a/packages/kit/src/core/env.js
+++ b/packages/kit/src/core/env.js
@@ -2,7 +2,6 @@
 /** @import { EnvVarConfig } from '@sveltejs/kit' */
 /** @import { ValidatedKitConfig } from 'types' */
 import path from 'node:path';
-import * as vite from 'vite';
 import * as devalue from 'devalue';
 import { GENERATED_COMMENT } from '../constants.js';
 import { dedent } from './sync/utils.js';
@@ -25,13 +24,14 @@ export function resolve_explicit_env_entry(config) {
 }
 
 /**
+ * @param {typeof import('vite')} vite
  * @param {ValidatedKitConfig} kit
  * @param {string | null} file
  * @param {string} root
  * @param {string} mode
  * @returns {Promise<Record<string, EnvVarConfig<any>> | null>}
  */
-export async function load_explicit_env(kit, file, root, mode) {
+export async function load_explicit_env(vite, kit, file, root, mode) {
 	if (!file) return null;
 
 	const server = await vite.createServer({
@@ -53,7 +53,7 @@ export async function load_explicit_env(kit, file, root, mode) {
 	/** @type {Record<string, EnvVarConfig<any>>} */
 	let variables;
 
-	const runner = get_runner(server);
+	const runner = get_runner(vite, server);
 
 	/** @type {import('../runtime/app/env/internal.js')} */ (
 		await runner.import(`${runtime_directory}/app/env/internal.js`)

--- a/packages/kit/src/core/sync/sync.js
+++ b/packages/kit/src/core/sync/sync.js
@@ -89,13 +89,14 @@ export function all_types(config, root) {
 
 /**
  * Generate modules and types for explicit env vars
+ * @param {typeof import('vite')} vite
  * @param {import('types').ValidatedKitConfig} kit
  * @param {string | null} entry
  * @param {string} root The Vite root
  * @param {string} mode The Vite mode
  */
-export async function env(kit, entry, root, mode) {
-	const env_config = await load_explicit_env(kit, entry, root, mode);
+export async function env(vite, kit, entry, root, mode) {
+	const env_config = await load_explicit_env(vite, kit, entry, root, mode);
 
 	write_env(entry, env_config, root);
 

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -8,7 +8,6 @@ import { URL } from 'node:url';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { styleText } from 'node:util';
 import sirv from 'sirv';
-import { isCSSRequest, loadEnv, buildErrorMessage } from 'vite';
 import { createReadableStream, getRequest, setResponse } from '../../../exports/node/index.js';
 import { coalesce_to_error } from '../../../utils/error.js';
 import { resolve_entry } from '../../../utils/filesystem.js';
@@ -31,7 +30,8 @@ import { get_runner } from '../../../runner.js';
 const vite_css_query_regex = /(?:\?|&)(?:raw|url|inline)(?:&|$)/;
 
 /**
- * @param {ViteDevServer} vite
+ * @param {typeof import('vite')} vite the peer resolved vite module
+ * @param {ViteDevServer} vite_dev_server
  * @param {ResolvedConfig} vite_config
  * @param {ValidatedConfig} svelte_config
  * @param {() => RemoteChunk[]} get_remotes
@@ -39,7 +39,15 @@ const vite_css_query_regex = /(?:\?|&)(?:raw|url|inline)(?:&|$)/;
  * @param {(manifest_data: ManifestData) => void} set_manifest_data
  * @return {Promise<Promise<() => void>>}
  */
-export async function dev(vite, vite_config, svelte_config, get_remotes, root, set_manifest_data) {
+export async function dev(
+	vite,
+	vite_dev_server,
+	vite_config,
+	svelte_config,
+	get_remotes,
+	root,
+	set_manifest_data
+) {
 	/** @type {AsyncLocalStorage<{ event: RequestEvent, config: any, prerender: PrerenderOption }>} */
 	const async_local_storage = new AsyncLocalStorage();
 
@@ -76,7 +84,7 @@ export async function dev(vite, vite_config, svelte_config, get_remotes, root, s
 	/** @type {Error | null} */
 	let manifest_error = null;
 
-	const runner = get_runner(vite);
+	const runner = get_runner(vite, vite_dev_server);
 
 	/**
 	 * @param {string} url
@@ -86,19 +94,19 @@ export async function dev(vite, vite_config, svelte_config, get_remotes, root, s
 		try {
 			return await runner.import(url);
 		} catch (/** @type {any} */ err) {
-			const msg = buildErrorMessage(err, [
+			const msg = vite.buildErrorMessage(err, [
 				styleText('red', `Internal server error: ${err.message}`)
 			]);
 
-			if (!vite.config.logger.hasErrorLogged(err)) {
-				vite.config.logger.error(msg, { error: err });
+			if (!vite_dev_server.config.logger.hasErrorLogged(err)) {
+				vite_dev_server.config.logger.error(msg, { error: err });
 			}
 
 			// TODO this is inadequate — it doesn't reliably show the overlay on every page load,
 			// and when it does appear it may immediately vanish. `vite.hot.send` broadcasts
 			// to all connected clients, even ones that are unaffected by the error.
 			// we need a more considered approach
-			vite.hot.send({
+			vite_dev_server.hot.send({
 				type: 'error',
 				err: /** @type {ErrorPayload['err']} */ ({
 					...err,
@@ -119,7 +127,7 @@ export async function dev(vite, vite_config, svelte_config, get_remotes, root, s
 
 		const module = await loud_ssr_load_module(url);
 
-		const module_node = await vite.environments.ssr.moduleGraph.getModuleByUrl(url);
+		const module_node = await vite_dev_server.environments.ssr.moduleGraph.getModuleByUrl(url);
 		if (!module_node) throw new Error(`Could not find node for ${url}`);
 
 		return { module, module_node, url };
@@ -139,13 +147,13 @@ export async function dev(vite, vite_config, svelte_config, get_remotes, root, s
 
 			if (manifest_error) {
 				manifest_error = null;
-				vite.hot.send({ type: 'full-reload' });
+				vite_dev_server.hot.send({ type: 'full-reload' });
 			}
 		} catch (error) {
 			manifest_error = /** @type {Error} */ (error);
 
 			console.error(styleText(['bold', 'red'], manifest_error.message));
-			vite.hot.send({
+			vite_dev_server.hot.send({
 				type: 'error',
 				err: {
 					message: manifest_error.message ?? 'Invalid routes',
@@ -256,14 +264,14 @@ export async function dev(vite, vite_config, svelte_config, get_remotes, root, s
 							const deps = new Set();
 
 							for (const module_node of module_nodes) {
-								await find_deps(vite, module_node, deps);
+								await find_deps(vite_dev_server, module_node, deps);
 							}
 
 							/** @type {Record<string, string>} */
 							const styles = {};
 
 							for (const dep of deps) {
-								if (isCSSRequest(dep.url) && !vite_css_query_regex.test(dep.url)) {
+								if (vite.isCSSRequest(dep.url) && !vite_css_query_regex.test(dep.url)) {
 									const inlineCssUrl = dep.url.includes('?')
 										? dep.url.replace('?', '?inline&')
 										: dep.url + '?inline';
@@ -381,7 +389,7 @@ export async function dev(vite, vite_config, svelte_config, get_remotes, root, s
 	 * @param {(file: string) => void} cb
 	 */
 	const watch = (event, cb) => {
-		vite.watcher.on(event, (file) => {
+		vite_dev_server.watcher.on(event, (file) => {
 			if (
 				file.startsWith(svelte_config.kit.files.routes + path.sep) ||
 				file.startsWith(svelte_config.kit.files.assets + path.sep) ||
@@ -429,14 +437,14 @@ export async function dev(vite, vite_config, svelte_config, get_remotes, root, s
 	// kit defaults to src/app.html, so unless user changed that to index.html
 	// send the vite client a full-reload event without path being set
 	if (appTemplate !== 'index.html') {
-		vite.watcher.on('change', (file) => {
+		vite_dev_server.watcher.on('change', (file) => {
 			if (file === appTemplate) {
-				vite.hot.send({ type: 'full-reload' });
+				vite_dev_server.hot.send({ type: 'full-reload' });
 			}
 		});
 	}
 
-	vite.watcher.on('all', (_, file) => {
+	vite_dev_server.watcher.on('all', (_, file) => {
 		if (
 			file === appTemplate ||
 			file === errorTemplate ||
@@ -455,8 +463,8 @@ export async function dev(vite, vite_config, svelte_config, get_remotes, root, s
 		extensions: []
 	});
 
-	vite.middlewares.use((req, res, next) => {
-		const base = `${vite.config.server.https ? 'https' : 'http'}://${
+	vite_dev_server.middlewares.use((req, res, next) => {
+		const base = `${vite_dev_server.config.server.https ? 'https' : 'http'}://${
 			req.headers[':authority'] || req.headers.host
 		}`;
 
@@ -478,23 +486,23 @@ export async function dev(vite, vite_config, svelte_config, get_remotes, root, s
 		next();
 	});
 
-	const env = loadEnv(vite_config.mode, svelte_config.kit.env.dir, '');
+	const env = vite.loadEnv(vite_config.mode, svelte_config.kit.env.dir, '');
 	const emulator = await svelte_config.kit.adapter?.emulate?.();
 
 	/** @type {Promise<void> | undefined} */
 	let init_manifest;
 
 	return () => {
-		const serve_static_middleware = vite.middlewares.stack.find(
+		const serve_static_middleware = vite_dev_server.middlewares.stack.find(
 			(middleware) =>
 				/** @type {Function} */ (middleware.handle).name === 'viteServeStaticMiddleware'
 		);
 
 		// Vite will give a 403 on URLs like /test, /static, and /package.json preventing us from
 		// serving routes with those names. See https://github.com/vitejs/vite/issues/7363
-		remove_static_middlewares(vite.middlewares);
+		remove_static_middlewares(vite_dev_server.middlewares);
 
-		vite.middlewares.use(async (req, res) => {
+		vite_dev_server.middlewares.use(async (req, res) => {
 			// Vite throws a Cannot read properties of undefined (reading 'wrapDynamicImport')
 			// if you try to run ssr.runner.import before the server has started so
 			// we do it inside here to avoid that
@@ -504,7 +512,7 @@ export async function dev(vite, vite_config, svelte_config, get_remotes, root, s
 			const original_url = req.url;
 			req.url = req.originalUrl;
 			try {
-				const base = `${vite.config.server.https ? 'https' : 'http'}://${
+				const base = `${vite_dev_server.config.server.https ? 'https' : 'http'}://${
 					req.headers[':authority'] || req.headers.host
 				}`;
 

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -619,7 +619,7 @@ function kit({ svelte_config }) {
 
 		async configResolved(config) {
 			explicit_env_entry = resolve_explicit_env_entry(kit);
-			explicit_env_config = await sync.env(kit, explicit_env_entry, config.root, config.mode);
+			explicit_env_config = await sync.env(vite, kit, explicit_env_entry, config.root, config.mode);
 		},
 
 		configureServer(server) {
@@ -633,6 +633,7 @@ function kit({ svelte_config }) {
 				if (file === explicit_env_entry || file === resolved) {
 					explicit_env_entry = resolved;
 					explicit_env_config = await sync.env(
+						vite,
 						kit,
 						explicit_env_entry,
 						vite_config.root,
@@ -995,7 +996,7 @@ function kit({ svelte_config }) {
 				// being called again with `opts.ssr === true` if the module isn't
 				// already loaded) so we can determine what it exports
 				if (dev_server) {
-					const module = await get_runner(dev_server).import(id);
+					const module = await get_runner(vite, dev_server).import(id);
 
 					for (const [name, value] of Object.entries(module)) {
 						const type = value?.__?.type;
@@ -1542,6 +1543,7 @@ function kit({ svelte_config }) {
 		 */
 		async configureServer(server) {
 			return await dev(
+				vite,
 				server,
 				vite_config,
 				svelte_config,

--- a/packages/kit/src/runner.js
+++ b/packages/kit/src/runner.js
@@ -1,10 +1,12 @@
 /** @import { ViteDevServer } from 'vite' */
-import * as vite from 'vite';
 
 /**
+ * @param {typeof import('vite')} vite the peer resolved vite module
  * @param {ViteDevServer} server
  */
-export function get_runner(server) {
+export function get_runner(vite, server) {
+	// `isRunnableDevEnvironment` does an `instanceof` check and will fail if
+	// we're using different instances of Vite
 	if (!vite.isRunnableDevEnvironment(server.environments.ssr)) {
 		throw new Error('The configured Vite SSR environment must be a RunnableDevEnvironment');
 	}


### PR DESCRIPTION
fixes an error in the vite ecosystem ci where the `isRunnableDevEnvironment` fails because of different Vite instances being imported https://github.com/vitejs/vite-ecosystem-ci/actions/runs/30985451349/job/92239036950#step:7:1943 (the helper uses an `instanceOf` check which fails because the class then comes from different imported instances)

This PR refactors the code such that we're using the same imported Vite module