### PR TITLE
fix: mark `RequestEvent` properties as `readonly`

### DIFF
--- a/.changeset/funky-turkeys-serve.md
+++ b/.changeset/funky-turkeys-serve.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: mark `RequestEvent` properties as `readonly`

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -1620,7 +1620,7 @@ export interface RequestEvent<
 	/**
 	 * Get or set cookies related to the current request
 	 */
-	cookies: Cookies;
+	readonly cookies: Cookies;
 	/**
 	 * `fetch` is equivalent to the [native `fetch` web API](https://developer.mozilla.org/en-US/docs/Web/API/fetch), with a few additional features:
 	 *
@@ -1632,15 +1632,15 @@ export interface RequestEvent<
 	 *
 	 * You can learn more about making credentialed requests with cookies [here](https://svelte.dev/docs/kit/load#Cookies).
 	 */
-	fetch: typeof fetch;
+	readonly fetch: typeof fetch;
 	/**
 	 * The client's IP address, set by the adapter.
 	 */
-	getClientAddress: () => string;
+	readonly getClientAddress: () => string;
 	/**
 	 * Contains custom data that was added to the request within the [`server handle hook`](https://svelte.dev/docs/kit/hooks#handle).
 	 */
-	locals: App.Locals;
+	readonly locals: App.Locals;
 	/**
 	 * The parameters of the current route - e.g. for a route like `/blog/[slug]`, a `{ slug: string }` object.
 	 *
@@ -1649,19 +1649,19 @@ export interface RequestEvent<
 	 * the remote function was called from, _not_ the URL of the endpoint SvelteKit creates for the remote function. Never use it
 	 * to determine whether or not a user is authorized to access certain data, as these values are part of the request which could be manipulated.
 	 */
-	params: Params;
+	readonly params: Params;
 	/**
 	 * Additional data made available through the adapter.
 	 */
-	platform: Readonly<App.Platform> | undefined;
+	readonly platform: Readonly<App.Platform> | undefined;
 	/**
 	 * The original request object.
 	 */
-	request: Request;
+	readonly request: Request;
 	/**
 	 * Info about the current route.
 	 */
-	route: {
+	readonly route: {
 		/**
 		 * The ID of the current route - e.g. for `src/routes/blog/[slug]`, it would be `/blog/[slug]`. It is `null` when no route is matched.
 		 *
@@ -1694,7 +1694,7 @@ export interface RequestEvent<
 	 *
 	 * You cannot add a `set-cookie` header with `setHeaders` — use the [`cookies`](https://svelte.dev/docs/kit/@sveltejs-kit#Cookies) API instead.
 	 */
-	setHeaders: (headers: Record<string, string>) => void;
+	readonly setHeaders: (headers: Record<string, string>) => void;
 	/**
 	 * The requested URL.
 	 *
@@ -1703,22 +1703,22 @@ export interface RequestEvent<
 	 * the remote function was called from, _not_ the URL of the endpoint SvelteKit creates for the remote function. Never use it
 	 * to determine whether or not a user is authorized to access certain data, as these values are part of the request which could be manipulated.
 	 */
-	url: URL;
+	readonly url: URL;
 	/**
 	 * `true` if the request comes from the client asking for `+page/layout.server.js` data. The `url` property will be stripped of the internal information
 	 * related to the data request in this case. Use this property instead if the distinction is important to you.
 	 */
-	isDataRequest: boolean;
+	readonly isDataRequest: boolean;
 	/**
 	 * `true` for `+server.js` calls coming from SvelteKit without the overhead of actually making an HTTP request. This happens when you make same-origin `fetch` requests on the server.
 	 */
-	isSubRequest: boolean;
+	readonly isSubRequest: boolean;
 
 	/**
 	 * Access to spans for tracing. If tracing is not enabled, these spans will do nothing.
 	 * @since 2.31.0
 	 */
-	tracing: {
+	readonly tracing: {
 		/** Whether tracing is enabled. */
 		enabled: boolean;
 		/** The root span for the request. This span is named `sveltekit.handle.root`. */
@@ -1731,7 +1731,7 @@ export interface RequestEvent<
 	 * `true` if the request comes from the client via a remote function. The `url` property will be stripped of the internal information
 	 * related to the data request in this case. Use this property instead if the distinction is important to you.
 	 */
-	isRemoteRequest: boolean;
+	readonly isRemoteRequest: boolean;
 }
 
 /**

--- a/packages/kit/src/runtime/server/page/load_data.spec.js
+++ b/packages/kit/src/runtime/server/page/load_data.spec.js
@@ -5,11 +5,15 @@ import { create_universal_fetch } from './load_data.js';
  * @param {Partial<Pick<import('@sveltejs/kit').RequestEvent, 'fetch' | 'url' | 'request' | 'route'>>} event
  */
 function create_fetch(event) {
+	// @ts-expect-error
 	// eslint-disable-next-line @typescript-eslint/require-await
-	event.fetch = event.fetch || (async () => new Response('foo'));
-	event.request = event.request || new Request('doesnt:matter');
-	event.route = event.route || { id: 'foo' };
-	event.url = event.url || new URL('https://domain-a.com');
+	event.fetch ||= async () => new Response('foo');
+	// @ts-expect-error
+	event.request ||= new Request('doesnt:matter');
+	// @ts-expect-error
+	event.route ||= { id: 'foo' };
+	// @ts-expect-error
+	event.url ||= new URL('https://domain-a.com');
 	return create_universal_fetch(
 		/** @type {Pick<import('@sveltejs/kit').RequestEvent, 'fetch' | 'url' | 'request' | 'route'>} */ (
 			event

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -197,7 +197,12 @@ export async function internal_respond(request, options, manifest, state) {
 			}),
 		locals: {},
 		params: {},
-		platform: state.platform,
+		platform: state.emulator?.platform
+			? await state.emulator.platform({
+					config: {},
+					prerender: !!state.prerendering?.fallback
+				})
+			: state.platform,
 		request,
 		route: { id: null },
 		setHeaders: (new_headers) => {
@@ -235,6 +240,7 @@ export async function internal_respond(request, options, manifest, state) {
 		isRemoteRequest: !!remote_id
 	};
 
+	// @ts-expect-error this has to be assigned lazily
 	event.fetch = create_fetch({
 		event,
 		options,
@@ -243,13 +249,6 @@ export async function internal_respond(request, options, manifest, state) {
 		get_cookie_header,
 		set_internal
 	});
-
-	if (state.emulator?.platform) {
-		event.platform = await state.emulator.platform({
-			config: {},
-			prerender: !!state.prerendering?.fallback
-		});
-	}
 
 	/** @type {string | null} */
 	let resolved_path = url.pathname;
@@ -368,7 +367,9 @@ export async function internal_respond(request, options, manifest, state) {
 
 			if (result) {
 				route = result.route;
+				// @ts-expect-error this has to be assigned lazily
 				event.route = { id: route.id };
+				// @ts-expect-error this has to be assigned lazily
 				event.params = result.params;
 			}
 		} catch (e) {
@@ -432,6 +433,7 @@ export async function internal_respond(request, options, manifest, state) {
 				}
 
 				if (state.emulator?.platform) {
+					// @ts-expect-error this has to be assigned lazily
 					event.platform = await state.emulator.platform({ config, prerender });
 				}
 
@@ -799,6 +801,7 @@ export async function internal_respond(request, options, manifest, state) {
 				throw new Error('Cannot use `cookies.set(...)` after the response has been generated');
 			};
 
+			// @ts-expect-error this has to be assigned lazily
 			event.setHeaders = () => {
 				throw new Error('Cannot use `setHeaders(...)` after the response has been generated');
 			};

--- a/packages/kit/test/types/request-event.test.ts
+++ b/packages/kit/test/types/request-event.test.ts
@@ -1,0 +1,6 @@
+import { RequestEvent } from '@sveltejs/kit';
+
+declare const event: RequestEvent;
+
+// @ts-expect-error readonly
+event.url = new URL('nope');

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1590,7 +1590,7 @@ declare module '@sveltejs/kit' {
 		/**
 		 * Get or set cookies related to the current request
 		 */
-		cookies: Cookies;
+		readonly cookies: Cookies;
 		/**
 		 * `fetch` is equivalent to the [native `fetch` web API](https://developer.mozilla.org/en-US/docs/Web/API/fetch), with a few additional features:
 		 *
@@ -1602,15 +1602,15 @@ declare module '@sveltejs/kit' {
 		 *
 		 * You can learn more about making credentialed requests with cookies [here](https://svelte.dev/docs/kit/load#Cookies).
 		 */
-		fetch: typeof fetch;
+		readonly fetch: typeof fetch;
 		/**
 		 * The client's IP address, set by the adapter.
 		 */
-		getClientAddress: () => string;
+		readonly getClientAddress: () => string;
 		/**
 		 * Contains custom data that was added to the request within the [`server handle hook`](https://svelte.dev/docs/kit/hooks#handle).
 		 */
-		locals: App.Locals;
+		readonly locals: App.Locals;
 		/**
 		 * The parameters of the current route - e.g. for a route like `/blog/[slug]`, a `{ slug: string }` object.
 		 *
@@ -1619,19 +1619,19 @@ declare module '@sveltejs/kit' {
 		 * the remote function was called from, _not_ the URL of the endpoint SvelteKit creates for the remote function. Never use it
 		 * to determine whether or not a user is authorized to access certain data, as these values are part of the request which could be manipulated.
 		 */
-		params: Params;
+		readonly params: Params;
 		/**
 		 * Additional data made available through the adapter.
 		 */
-		platform: Readonly<App.Platform> | undefined;
+		readonly platform: Readonly<App.Platform> | undefined;
 		/**
 		 * The original request object.
 		 */
-		request: Request;
+		readonly request: Request;
 		/**
 		 * Info about the current route.
 		 */
-		route: {
+		readonly route: {
 			/**
 			 * The ID of the current route - e.g. for `src/routes/blog/[slug]`, it would be `/blog/[slug]`. It is `null` when no route is matched.
 			 *
@@ -1664,7 +1664,7 @@ declare module '@sveltejs/kit' {
 		 *
 		 * You cannot add a `set-cookie` header with `setHeaders` — use the [`cookies`](https://svelte.dev/docs/kit/@sveltejs-kit#Cookies) API instead.
 		 */
-		setHeaders: (headers: Record<string, string>) => void;
+		readonly setHeaders: (headers: Record<string, string>) => void;
 		/**
 		 * The requested URL.
 		 *
@@ -1673,22 +1673,22 @@ declare module '@sveltejs/kit' {
 		 * the remote function was called from, _not_ the URL of the endpoint SvelteKit creates for the remote function. Never use it
 		 * to determine whether or not a user is authorized to access certain data, as these values are part of the request which could be manipulated.
 		 */
-		url: URL;
+		readonly url: URL;
 		/**
 		 * `true` if the request comes from the client asking for `+page/layout.server.js` data. The `url` property will be stripped of the internal information
 		 * related to the data request in this case. Use this property instead if the distinction is important to you.
 		 */
-		isDataRequest: boolean;
+		readonly isDataRequest: boolean;
 		/**
 		 * `true` for `+server.js` calls coming from SvelteKit without the overhead of actually making an HTTP request. This happens when you make same-origin `fetch` requests on the server.
 		 */
-		isSubRequest: boolean;
+		readonly isSubRequest: boolean;
 
 		/**
 		 * Access to spans for tracing. If tracing is not enabled, these spans will do nothing.
 		 * @since 2.31.0
 		 */
-		tracing: {
+		readonly tracing: {
 			/** Whether tracing is enabled. */
 			enabled: boolean;
 			/** The root span for the request. This span is named `sveltekit.handle.root`. */
@@ -1701,7 +1701,7 @@ declare module '@sveltejs/kit' {
 		 * `true` if the request comes from the client via a remote function. The `url` property will be stripped of the internal information
 		 * related to the data request in this case. Use this property instead if the distinction is important to you.
 		 */
-		isRemoteRequest: boolean;
+		readonly isRemoteRequest: boolean;
 	}
 
 	/**


### PR DESCRIPTION
closes #15040. Marks the properties of `RequestEvent` as `readonly`, so that people don't get the idea that they can go around mutating stuff

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
