### PR TITLE
feat: support custom values in `page.state` via `transport` hook

### DIFF
--- a/.changeset/soft-ants-work.md
+++ b/.changeset/soft-ants-work.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: support custom values in `page.state` via `transport` hook

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -9,7 +9,7 @@ import { settled, tick, fork, onMount, hydrate, mount } from 'svelte';
 import { HttpError, Redirect, SvelteKitError } from '@sveltejs/kit/internal';
 import { decode_pathname, strip_hash, make_trackable, normalize_path } from '../../utils/url.js';
 import { dev_fetch, initial_fetch, lock_fetch, subsequent_fetch, unlock_fetch } from './fetcher.js';
-import { parse, parse_server_route } from './parse.js';
+import { parse_routes, parse_server_route } from './parse.js';
 import * as storage from './session-storage.js';
 import {
 	find_anchor,
@@ -50,14 +50,14 @@ import { noop_span } from '../telemetry/noop.js';
 import { read_ndjson } from './ndjson.js';
 import Root from '../components/root.svelte';
 import { Props, RenderNode } from '../props.svelte.js';
-import { init_transport } from '#app/internal/transport';
+import { init_transport, parse, stringify } from '#app/internal/transport';
 
 /**
  * @typedef {{
  *   historyIndex: number;
  *   navigationIndex: number;
  *   pageUrl?: string;
- *   state: Record<string, any>;
+ *   state: string;
  *   persistState: boolean;
  *   resetIndex: number;
  * }} HistoryMetadata
@@ -492,7 +492,7 @@ async function _start(_app, _target, data) {
 
 	await _app.hooks.init?.();
 
-	routes = __SVELTEKIT_CLIENT_ROUTING__ ? parse(_app) : [];
+	routes = __SVELTEKIT_CLIENT_ROUTING__ ? parse_routes(_app) : [];
 	container = __SVELTEKIT_EMBEDDED__ ? _target : document.documentElement;
 	target = _target;
 
@@ -533,7 +533,7 @@ async function _start(_app, _target, data) {
 				[HISTORY_METADATA_KEY]: {
 					historyIndex: current_history_index,
 					navigationIndex: current_navigation_index,
-					state: {},
+					state: stringify({}),
 					persistState: false,
 					resetIndex: current_history_index
 				}
@@ -566,7 +566,7 @@ async function _start(_app, _target, data) {
 			type: 'enter',
 			url: resolve_url(app.hash ? decode_hash(new URL(location.href)) : location.href),
 			replace_state: true,
-			state: history_metadata?.persistState ? history_metadata.state : {},
+			state: history_metadata?.persistState ? parse(history_metadata.state) : {},
 			persist_state: history_metadata?.persistState ?? false
 		});
 
@@ -2057,10 +2057,14 @@ async function navigate({
 		url.pathname = navigation_result.props.page.url.pathname;
 	}
 
-	state = popped ? popped.state : state;
+	if (popped) {
+		state = popped.state;
+	} else {
+		const serialized_state = stringify(state);
+		state = parse(serialized_state);
 
-	if (!popped) {
-		// this is a new navigation, rather than a popstate
+		// Store the serialized state so the browser history can preserve custom transport values.
+		// This is a new navigation, rather than a popstate.
 		const change = replace_state ? 0 : 1;
 		if (type !== 'enter') {
 			if (reset) current_reset_index += 1;
@@ -2070,7 +2074,7 @@ async function navigate({
 			[HISTORY_METADATA_KEY]: /** @satisfies {HistoryMetadata} */ ({
 				historyIndex: (current_history_index += change),
 				navigationIndex: (current_navigation_index += change),
-				state,
+				state: serialized_state,
 				persistState: persist_state,
 				resetIndex: current_reset_index
 			})
@@ -2877,18 +2881,8 @@ export async function replaceState(url, state) {
 async function update_state(intent, state, { replace, persist_state, reset }, caller) {
 	const url = intent.url;
 
-	if (DEV) {
-		if (!started) {
-			throw new Error(`Cannot call ${caller}(...) before router is initialized`);
-		}
-
-		try {
-			// use `devalue.stringify` as a convenient way to ensure we exclude values that can't be properly rehydrated, such as custom class instances
-			devalue.stringify(state);
-		} catch (error) {
-			// @ts-expect-error
-			throw new Error(`Could not serialize state${error.path}`, { cause: error });
-		}
+	if (DEV && !started) {
+		throw new Error(`Cannot call ${caller}(...) before router is initialized`);
 	}
 
 	const nav =
@@ -2908,13 +2902,15 @@ async function update_state(intent, state, { replace, persist_state, reset }, ca
 
 	if (!replace) capture_scroll(current_history_index);
 	if (reset) current_reset_index += 1;
+	const serialized_state = stringify(state);
+	state = parse(serialized_state);
 
 	const entry = {
 		[HISTORY_METADATA_KEY]: /** @satisfies {HistoryMetadata} */ ({
 			historyIndex: (current_history_index += replace ? 0 : 1),
 			navigationIndex: current_navigation_index,
 			pageUrl: page.url.href,
-			state,
+			state: serialized_state,
 			persistState: persist_state,
 			resetIndex: current_reset_index
 		})
@@ -3294,7 +3290,7 @@ function _start_router() {
 			const reset_index = history_metadata.resetIndex;
 			const reset = reset_index !== (source_info?.resetIndex ?? current_reset_index);
 			const scroll = history_info[history_index]?.scroll;
-			const state = history_metadata.state;
+			const state = parse(history_metadata.state);
 			const url = new URL(history_metadata.pageUrl ?? location.href);
 			const navigation_index = history_metadata.navigationIndex;
 			const is_hash_change =
@@ -3540,7 +3536,7 @@ async function _hydrate(
 
 	if (result.props.page) {
 		const history_metadata = get_history_metadata();
-		result.props.page.state = history_metadata?.persistState ? history_metadata.state : {};
+		result.props.page.state = history_metadata?.persistState ? parse(history_metadata.state) : {};
 	}
 
 	await initialize(result, target, should_hydrate);

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2060,6 +2060,9 @@ async function navigate({
 	if (popped) {
 		state = popped.state;
 	} else {
+		// we immediately serialize-then-parse to ensure that the value is
+		// serializable, and to prevent the developer from dangerously
+		// relying on the identity of the serialized objects
 		const serialized_state = stringify(state);
 		state = parse(serialized_state);
 
@@ -2902,6 +2905,8 @@ async function update_state(intent, state, { replace, persist_state, reset }, ca
 
 	if (!replace) capture_scroll(current_history_index);
 	if (reset) current_reset_index += 1;
+
+	// as above, serialize-then-parse to prevent bugs
 	const serialized_state = stringify(state);
 	state = parse(serialized_state);
 

--- a/packages/kit/src/runtime/client/parse.js
+++ b/packages/kit/src/runtime/client/parse.js
@@ -4,7 +4,7 @@ import { exec, parse_route_id } from '../../utils/routing.js';
  * @param {import('./types.js').SvelteKitApp} app
  * @returns {import('types').CSRRoute[]}
  */
-export function parse({ nodes, server_loads, dictionary, matchers }) {
+export function parse_routes({ nodes, server_loads, dictionary, matchers }) {
 	const layouts_with_server_load = new Set(server_loads);
 
 	return Object.entries(dictionary).map(([id, [leaf, layouts, errors]]) => {

--- a/packages/kit/test/apps/basics/src/app.d.ts
+++ b/packages/kit/test/apps/basics/src/app.d.ts
@@ -1,3 +1,5 @@
+import type { Foo } from '#lib';
+
 declare global {
 	namespace App {
 		interface Locals {
@@ -12,6 +14,7 @@ declare global {
 		interface PageState {
 			active?: boolean;
 			count?: number;
+			foo?: Foo;
 		}
 	}
 

--- a/packages/kit/test/apps/basics/src/routes/shallow-routing/push-state/foo/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/shallow-routing/push-state/foo/+page.svelte
@@ -1,0 +1,26 @@
+<script>
+	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
+	import { Foo } from '#lib';
+</script>
+
+<button
+	data-id="shallow"
+	onclick={() => {
+		const state = $state({ foo: new Foo('it works?'), count: 0 });
+		void goto('', { shallow: true, state });
+	}}>add state</button
+>
+
+<button
+	data-id="full"
+	onclick={() => {
+		const state = $state({ foo: new Foo('it works?'), count: 0 });
+		void goto('', { state });
+	}}>add state with navigation</button
+>
+
+<button onclick={() => (page.state.count = (page.state.count ?? 0) + 1)}>bump count</button>
+
+<p data-testid="foo">foo: {page.state.foo?.bar() ?? 'nope'}</p>
+<p data-testid="count">count: {page.state.count ?? 'nope'}</p>

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -1729,6 +1729,29 @@ test.describe('Shallow routing', () => {
 		await expect(page.locator('[data-id="shallow"]')).toHaveText('null');
 	});
 
+	test('serializes custom objects in state', async ({ page }) => {
+		await page.goto('/shallow-routing/push-state/foo');
+		await expect(page.locator('[data-testid=foo]')).toHaveText('foo: nope');
+		await expect(page.locator('[data-testid=count]')).toHaveText('count: nope');
+
+		await page.locator('[data-id=shallow]').click();
+		await expect(page.locator('[data-testid=foo]')).toHaveText('foo: it works?!');
+		await expect(page.locator('[data-testid=count]')).toHaveText('count: 0');
+
+		// State is round-tripped before it becomes page.state, so it cannot retain $state reactivity.
+		await page.getByText('bump count').click();
+		await expect(page.locator('[data-testid=count]')).toHaveText('count: 0');
+
+		await page.goBack();
+		await expect(page.locator('[data-testid=foo]')).toHaveText('foo: nope');
+
+		await page.goForward();
+		await expect(page.locator('[data-testid=foo]')).toHaveText('foo: it works?!');
+
+		await page.locator('[data-id=full]').click();
+		await expect(page.locator('[data-testid=foo]')).toHaveText('foo: it works?!');
+	});
+
 	test('Shallow navigates to a new URL', async ({ baseURL, page }) => {
 		await page.goto('/shallow-routing/push-state');
 		await expect(page.locator('p')).toHaveText('active: false');


### PR DESCRIPTION
Supersedes #14129, closes #14128. Allows custom values to be part of `page.state` and survive reloading. 

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
