### PR TITLE
fix: persist global app state across module graph reloads

### DIFF
--- a/.changeset/all-donkeys-rest.md
+++ b/.changeset/all-donkeys-rest.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: persist global app state across module graph reloads

--- a/packages/kit/src/runtime/server/dev.js
+++ b/packages/kit/src/runtime/server/dev.js
@@ -1,0 +1,22 @@
+const symbol = Symbol.for('sveltekit.global_state');
+const state = /** @type {Record<symbol, any>} */ (
+	/** @type {Record<symbol, unknown>} */ (/** @type {unknown} */ (globalThis))[symbol] ??= {}
+);
+
+/**
+ * Persist a value across dev server reloads, in case a freshly-invalidated module
+ * reads global state that is not set until a request is handled
+ * @param {symbol} key
+ * @param {any} value
+ */
+export function save(key, value) {
+	state[key] = value;
+}
+
+/**
+ * Restore a value after a dev server reload
+ * @param {symbol} key
+ */
+export function restore(key) {
+	return state[key];
+}

--- a/packages/kit/src/runtime/server/internal.js
+++ b/packages/kit/src/runtime/server/internal.js
@@ -1,26 +1,25 @@
 /** @import { SSRManifest } from '@sveltejs/kit'; */
+import { restore, save } from './dev.js';
 
 const read_implementation_key = Symbol.for('sveltekit.read_implementation');
 const manifest_key = Symbol.for('sveltekit.manifest');
-const state = /** @type {Record<symbol, unknown>} */ (/** @type {unknown} */ (globalThis));
 
 // Vite's development module runner clears its module cache before it reevaluates page entries.
 // Keep this per-process implementation available while those entries are evaluated.
 export let read_implementation = /** @type {((path: string) => ReadableStream<any>) | null} */ (
-	__SVELTEKIT_DEV__ ? (state[read_implementation_key] ?? null) : null
+	(__SVELTEKIT_DEV__ && restore(read_implementation_key)) ?? null
 );
 
-export let manifest = /** @type {SSRManifest} */ (__SVELTEKIT_DEV__ ? state[manifest_key] : null);
+export let manifest = /** @type {SSRManifest} */ (
+	(__SVELTEKIT_DEV__ && restore(manifest_key)) ?? null
+);
 
 /**
  * @param {(path: string) => ReadableStream<any>} fn
  */
 export function set_read_implementation(fn) {
 	read_implementation = fn;
-
-	if (__SVELTEKIT_DEV__) {
-		state[read_implementation_key] = fn;
-	}
+	if (__SVELTEKIT_DEV__) save(read_implementation_key, fn);
 }
 
 /**
@@ -29,10 +28,7 @@ export function set_read_implementation(fn) {
  */
 export function set_manifest(value) {
 	manifest = value;
-
-	if (__SVELTEKIT_DEV__) {
-		state[manifest_key] = value;
-	}
+	if (__SVELTEKIT_DEV__) save(manifest_key, value);
 }
 
 export { fix_stack_trace, set_fix_stack_trace } from './sourcemaps.js';

--- a/packages/kit/src/runtime/server/internal.js
+++ b/packages/kit/src/runtime/server/internal.js
@@ -1,17 +1,26 @@
 /** @import { SSRManifest } from '@sveltejs/kit'; */
 
-/**
- * @type {((path: string) => ReadableStream<any>) | null}
- */
-export let read_implementation = null;
+const read_implementation_key = Symbol.for('sveltekit.read_implementation');
+const manifest_key = Symbol.for('sveltekit.manifest');
+const state = /** @type {Record<symbol, unknown>} */ (/** @type {unknown} */ (globalThis));
 
-export let manifest = /** @type {SSRManifest} */ (/** @type {unknown} */ (null));
+// Vite's development module runner clears its module cache before it reevaluates page entries.
+// Keep this per-process implementation available while those entries are evaluated.
+export let read_implementation = /** @type {((path: string) => ReadableStream<any>) | null} */ (
+	__SVELTEKIT_DEV__ ? (state[read_implementation_key] ?? null) : null
+);
+
+export let manifest = /** @type {SSRManifest} */ (__SVELTEKIT_DEV__ ? state[manifest_key] : null);
 
 /**
  * @param {(path: string) => ReadableStream<any>} fn
  */
 export function set_read_implementation(fn) {
 	read_implementation = fn;
+
+	if (__SVELTEKIT_DEV__) {
+		state[read_implementation_key] = fn;
+	}
 }
 
 /**
@@ -20,6 +29,10 @@ export function set_read_implementation(fn) {
  */
 export function set_manifest(value) {
 	manifest = value;
+
+	if (__SVELTEKIT_DEV__) {
+		state[manifest_key] = value;
+	}
 }
 
 export { fix_stack_trace, set_fix_stack_trace } from './sourcemaps.js';

--- a/packages/kit/src/runtime/server/internal.js
+++ b/packages/kit/src/runtime/server/internal.js
@@ -4,8 +4,6 @@ import { restore, save } from './dev.js';
 const read_implementation_key = Symbol.for('sveltekit.read_implementation');
 const manifest_key = Symbol.for('sveltekit.manifest');
 
-// Vite's development module runner clears its module cache before it reevaluates page entries.
-// Keep this per-process implementation available while those entries are evaluated.
 export let read_implementation = /** @type {((path: string) => ReadableStream<any>) | null} */ (
 	(__SVELTEKIT_DEV__ && restore(read_implementation_key)) ?? null
 );


### PR DESCRIPTION
Prevents these annoying errors that sometimes happen when the dev server invalidates the module graph:

> No `read` implementation was provided. Please ensure that your adapter is up to date and supports this feature

This can happen if an entry point is eagerly evaluated before the global state is set. The solution feels a little inelegant but I'm not sure what a better one would look like

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
