### PR TITLE
fix: pass function name to config

### DIFF
--- a/.changeset/metal-bats-care.md
+++ b/.changeset/metal-bats-care.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-netlify': patch
+---
+
+fix: provide distinct names for each split serverless function

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -264,7 +264,7 @@ function generate_serverless_function({ builder, routes, patterns, name, exclude
 	});
 
 	const fn = generate_serverless_function_module(manifest);
-	const config = generate_config_export(patterns, exclude);
+	const config = generate_config_export(name, patterns, exclude);
 
 	if (builder.hasServerInstrumentationFile()) {
 		writeFileSync(`${netlify_framework_serverless_path}/${name}.mjs`, fn);
@@ -296,17 +296,18 @@ export default init(${manifest});
 const generator_string = `@sveltejs/adapter-netlify@${adapter_version}`;
 
 /**
+ * @param {string} name The name that shows up in the logs & metrics functions list
  * @param {string[]} patterns
  * @param {string[]} [exclude]
  * @returns {string}
  */
-function generate_config_export(patterns, exclude = []) {
+function generate_config_export(name, patterns, exclude = []) {
 	// TODO: add a human friendly name for the function https://docs.netlify.com/build/frameworks/frameworks-api/#configuration-options-2
 
 	// https://docs.netlify.com/build/frameworks/frameworks-api/#configuration-options-2
 	return `\
 export const config = {
-	name: 'SvelteKit server',
+	name: ${JSON.stringify(name)},
 	generator: '${generator_string}',
 	path: [${patterns.map(s).join(', ')}],
 	excludedPath: [${['/.netlify/*', ...exclude].map(s).join(', ')}],


### PR DESCRIPTION
There was a regression and now all the split serverless functions use the same name.
This PR corrects that so that each function uses a distinct name (same as the function filename)

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
