### PR TITLE
chore: add `exclude` for service worker file

### DIFF
--- a/packages/kit/test/apps/basics/tsconfig.json
+++ b/packages/kit/test/apps/basics/tsconfig.json
@@ -1,4 +1,5 @@
 {
 	"extends": "$app/tsconfig",
-	"include": ["src", "unit-test", "test", "*.js"]
+	"include": ["src", "unit-test", "test", "*.js"],
+	"exclude": ["src/service-worker.js"]
 }

--- a/packages/kit/test/apps/options-2/tsconfig.json
+++ b/packages/kit/test/apps/options-2/tsconfig.json
@@ -1,4 +1,5 @@
 {
 	"extends": "$app/tsconfig",
-	"include": ["src", "test", "*.js"]
+	"include": ["src", "test", "*.js"],
+	"exclude": ["src/service-worker.js"]
 }

--- a/packages/kit/test/apps/options-3/tsconfig.json
+++ b/packages/kit/test/apps/options-3/tsconfig.json
@@ -1,4 +1,5 @@
 {
 	"extends": "$app/tsconfig",
-	"include": ["src", "test", "*.js"]
+	"include": ["src", "test", "*.js"],
+	"exclude": ["src/service-worker.js"]
 }

--- a/packages/kit/test/build-errors/apps/env-private-service-worker/tsconfig.json
+++ b/packages/kit/test/build-errors/apps/env-private-service-worker/tsconfig.json
@@ -1,5 +1,5 @@
 {
 	"extends": "$app/tsconfig",
 	"include": ["src", "*.js"],
-	"exclude": ["src/service-worker"]
+	"exclude": ["src/service-worker.js"]
 }

--- a/packages/kit/test/build-errors/apps/env-private-service-worker/tsconfig.json
+++ b/packages/kit/test/build-errors/apps/env-private-service-worker/tsconfig.json
@@ -1,4 +1,5 @@
 {
 	"extends": "$app/tsconfig",
-	"include": ["src", "*.js"]
+	"include": ["src", "*.js"],
+	"exclude": ["src/service-worker"]
 }

--- a/packages/kit/test/prerendering/basics/tsconfig.json
+++ b/packages/kit/test/prerendering/basics/tsconfig.json
@@ -5,5 +5,6 @@
 		"noEmit": true
 	},
 	"include": ["src", "test", "vite.config.js", "globalSetup.js"],
+	"exclude": ["src/service-worker.js"],
 	"extends": "$app/tsconfig"
 }


### PR DESCRIPTION
gets rid of the kit warnings for the test apps