### PR TITLE
fix: generate __route.js files as siblings of .html pages

### DIFF
--- a/.changeset/calm-routes-smile.md
+++ b/.changeset/calm-routes-smile.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: generate route resolution modules as siblings of `.html` pages

--- a/.changeset/tidy-pages-route.md
+++ b/.changeset/tidy-pages-route.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-vercel': patch
+---
+
+fix: match sibling `.html__route.js` route resolution requests

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -321,7 +321,7 @@ const plugin = function (defaults = {}) {
 				);
 
 				static_config.routes.push({
-					src: `${builder.config.kit.paths.base}/(|.+/)__route\\.js`,
+					src: `${builder.config.kit.paths.base}/(?:.+/|.+\\.html)?__route\\.js`,
 					dest: `${builder.config.kit.paths.base}/${builder.config.kit.appDir}/route`
 				});
 			}

--- a/packages/kit/src/exports/index.spec.js
+++ b/packages/kit/src/exports/index.spec.js
@@ -50,6 +50,16 @@ describe('normalizeUrl', () => {
 		assert.equal(denormalize().href, original.href);
 		assert.equal(denormalize('/baz').href, 'http://example.com/baz/__route.js');
 	});
+
+	it('should normalize route requests for .html pages', () => {
+		const original = new URL('http://example.com/foo.html__route.js');
+		const { url, wasNormalized, denormalize } = normalizeUrl(original);
+
+		assert.equal(wasNormalized, true);
+		assert.equal(url.pathname, '/foo.html');
+		assert.equal(denormalize('/baz.html').href, 'http://example.com/baz.html__route.js');
+		assert.equal(denormalize('/baz').href, 'http://example.com/baz/__route.js');
+	});
 });
 
 describe('redirect', () => {

--- a/packages/kit/src/runtime/pathname.js
+++ b/packages/kit/src/runtime/pathname.js
@@ -22,13 +22,14 @@ export function strip_data_suffix(pathname) {
 }
 
 const ROUTE_SUFFIX = '/__route.js';
+const HTML_ROUTE_SUFFIX = '.html__route.js';
 
 /**
  * @param {string} pathname
  * @returns {boolean}
  */
 export function has_resolution_suffix(pathname) {
-	return pathname.endsWith(ROUTE_SUFFIX);
+	return pathname.endsWith(ROUTE_SUFFIX) || pathname.endsWith(HTML_ROUTE_SUFFIX);
 }
 
 /**
@@ -37,6 +38,7 @@ export function has_resolution_suffix(pathname) {
  * @returns {string}
  */
 export function add_resolution_suffix(pathname) {
+	if (pathname.endsWith('.html')) return pathname.replace(/\.html$/, HTML_ROUTE_SUFFIX);
 	return pathname.replace(/\/$/, '') + ROUTE_SUFFIX;
 }
 
@@ -45,6 +47,10 @@ export function add_resolution_suffix(pathname) {
  * @returns {string}
  */
 export function strip_resolution_suffix(pathname) {
+	if (pathname.endsWith(HTML_ROUTE_SUFFIX)) {
+		return pathname.slice(0, -HTML_ROUTE_SUFFIX.length) + '.html';
+	}
+
 	return pathname.slice(0, -ROUTE_SUFFIX.length);
 }
 

--- a/packages/kit/test/prerendering/basics/test/tests.spec.js
+++ b/packages/kit/test/prerendering/basics/test/tests.spec.js
@@ -29,6 +29,14 @@ test('prerenders /', () => {
 	expect(content).toMatch('<h1>hello</h1>');
 });
 
+test('prerenders route resolution modules alongside .html pages', () => {
+	assert.isTrue(fs.statSync(`${build}/page.html`).isFile());
+	expect(read('page.html__route.js')).toContain('export const');
+	assert.isFalse(fs.statSync(`${build}/page.html`).isDirectory());
+	assert.isFalse(fs.existsSync(`${build}/page.html/__route.js`));
+	assert.isTrue(fs.statSync(`${build}/prerendering-true/__route.js`).isFile());
+});
+
 test('renders a redirect', () => {
 	const content = read('redirect.html');
 	assert.equal(

--- a/packages/kit/test/prerendering/basics/test/tests.spec.js
+++ b/packages/kit/test/prerendering/basics/test/tests.spec.js
@@ -32,7 +32,6 @@ test('prerenders /', () => {
 test('prerenders route resolution modules alongside .html pages', () => {
 	assert.isTrue(fs.statSync(`${build}/page.html`).isFile());
 	expect(read('page.html__route.js')).toContain('export const');
-	assert.isFalse(fs.statSync(`${build}/page.html`).isDirectory());
 	assert.isFalse(fs.existsSync(`${build}/page.html/__route.js`));
 	assert.isTrue(fs.statSync(`${build}/prerendering-true/__route.js`).isFile());
 });

--- a/packages/kit/test/prerendering/basics/vite.config.js
+++ b/packages/kit/test/prerendering/basics/vite.config.js
@@ -19,6 +19,9 @@ const config = {
 			paths: {
 				origin: 'http://prerender.origin'
 			},
+			router: {
+				resolution: 'server'
+			},
 			prerender: {
 				handleHttpError: 'warn',
 				handleMissingId: ({ id }) => {


### PR DESCRIPTION
Fixes #16579. Same fix as #11269: for `.html` pages the resolution module is emitted as a sibling (`page.html__route.js`) instead of nested.