### PR TITLE
feat: Navigate on cross-page form submissions

### DIFF
--- a/.changeset/hungry-jokes-repeat.md
+++ b/.changeset/hungry-jokes-repeat.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': major
+---
+
+breaking: enhanced cross-page form actions now navigate to the action page on success and failure, matching native form behavior

--- a/documentation/docs/20-core-concepts/30-form-actions.md
+++ b/documentation/docs/20-core-concepts/30-form-actions.md
@@ -50,6 +50,8 @@ We can also invoke the action from other pages (for example if there's a login w
 </form>
 ```
 
+Submitting this form takes you to `/login`, whether the action succeeds or fails — that's what the browser does, and [`use:enhance`](#Progressive-enhancement-use:enhance) emulates it. If you'd rather stay where you are and handle the result in place, there's a recipe for that in the [progressive enhancement](#Progressive-enhancement-use:enhance) section.
+
 ## Named actions
 
 Instead of one `default` action, a page can have as many named actions as it needs:
@@ -361,12 +363,36 @@ The easiest way to progressively enhance a form is to add the `use:enhance` acti
 
 Without an argument, `use:enhance` will emulate the browser-native behaviour, just without the full-page reloads. It will:
 
-- update the `form` property, `page.form` and `page.status` on a successful or invalid response, but only if the action is on the same page you're submitting from. For example, if your form looks like `<form action="/somewhere/else" ..>`, the `form` prop and the `page.form` state will _not_ be updated. This is because in the native form submission case you would be redirected to the page the action is on. If you want to have them updated either way, use [`applyAction`](#Progressive-enhancement-Customising-use:enhance)
+- if the action is on the page you're submitting from, emulate a reload of the current page — updating the `form` property, `page.form` and `page.status` on a successful or invalid response
+- if the action is on a different page (for example `<form action="/somewhere/else" ..>`), navigate to the action's URL on a successful _or_ invalid response, populating that page's `form` property and `page.status`, just as a native submission would. A new history entry is pushed
 - reset the `<form>` element
-- invalidate all data using `invalidateAll` on a successful response
+- refresh all data using `refreshAll` on a successful response
 - call `goto` on a redirect response
-- render the nearest `+error` boundary if an error occurs
+- render the nearest `+error` boundary if an unexpected error occurs — the boundary nearest the _action's_ route, if the action is on a different page
 - [reset focus](accessibility#Focus-management) to the appropriate element
+
+> [!NOTE] Two details are worth knowing about the URL:
+>
+> Where a submission lands is `result.location` — the form's `action` with the `?/actionName` parameter removed, since that parameter has done its job once the action has run. `action="/login?/do-login"` lands on `/login`, and any other query parameters are kept, so `action="/login?redirectTo=/dashboard&/do-login"` lands on `/login?redirectTo=/dashboard`. The destination's `load` functions see that URL via `url.search`.
+>
+> Two consequences worth knowing:
+>
+> - A _relative_ action replaces the entire query string as a side effect of URL resolution — `action="?/delete"` on `/items?page=2` resolves to `/items?/delete`, so both enhanced and native submissions drop `page=2`. Write `action="?page=2&/delete"` to preserve it.
+> - Without JavaScript the browser can't strip anything, so an unenhanced submission leaves you on the raw action URL (`/login?/do-login`). Reloading that URL is a plain `GET`, which doesn't re-run the action and renders the page normally, so the difference is cosmetic — but a `load` function can observe a different `url.search` depending on whether JavaScript is available.
+
+If you don't want a cross-page submission to navigate — a common need for login or newsletter widgets that live in a layout and post to another page's action — pass `navigate: false` to `update`, which gives you the same behaviour as SvelteKit 2:
+
+```svelte
+<form
+	method="POST"
+	action="/other/page?/subscribe"
+	use:enhance={() => async ({ update }) => {
+		await update({ navigate: false });
+	}}
+>
+```
+
+The result is applied to the page you're on: `form`, `page.form` and `page.status` are updated, and error results render the current route's nearest `+error` boundary.
 
 ### Customising use:enhance
 
@@ -392,7 +418,7 @@ To customise the behaviour, you can provide a `SubmitFunction` that runs immedia
 
 You can use these functions to show and hide loading UI, and so on.
 
-If you return a callback, you override the default post-submission behavior. To get it back, call `update`, which accepts `invalidateAll` and `reset` parameters, or use `applyAction` on the result:
+If you return a callback, you override the default post-submission behavior. To get it back, call `update`, which accepts `navigate`, `refreshAll` and `reset` parameters, or use `applyAction` on the result:
 
 ```svelte
 /// file: src/routes/login/+page.svelte
@@ -418,13 +444,21 @@ If you return a callback, you override the default post-submission behavior. To 
 >
 ```
 
-The behaviour of `applyAction(result)` depends on `result.type`:
+> [!NOTE] `update` accepts these options:
+>
+> - `reset: false` if you don't want the `<form>` values to be reset after a successful submission
+> - `refreshAll` controls whether all data is refreshed after submission. It defaults to `true` for successful results and `false` for failures. When the submission navigates to another page, setting it to `false` does _not_ prevent the destination's own `load` functions from running — it only allows shared layout data to be reused. `invalidateAll` is a deprecated alias for `refreshAll`
+> - `navigate: false` applies a non-redirect result to the current page instead of navigating to `result.location`. Redirects are always followed
 
-- `success`, `failure` — sets `page.status` to `result.status` and updates `form` and `page.form` to `result.data` (regardless of where you are submitting from, in contrast to `update` from `enhance`)
-- `redirect` — calls `goto(result.location, { invalidateAll: true })`
-- `error` — renders the nearest `+error` boundary with `result.error`
+The behaviour of `applyAction(result)` depends on `result.type` and on `result.location` — the page the submission should land on. The server includes it in every action response, so `applyAction` can do what the browser would do:
+
+- `success`, `failure` — if `result.location` is a different page, navigates there and renders it with the result, populating that page's `form` property and `page.status`. Otherwise sets `page.status` to `result.status` and updates `form` and `page.form` to `result.data`
+- `redirect` — calls `goto(result.location, { refreshAll: true })`
+- `error` — renders the nearest `+error` boundary with `result.error`. If `result.location` is a different page, it navigates there first, so the boundary is the one nearest the _destination's_ route
 
 In all cases, [focus will be reset](accessibility#Focus-management).
+
+> [!NOTE] Like `update`, `applyAction` accepts a `navigate: false` option. It applies non-redirect results to the current page and resolves error boundaries against the current route, however `result.location` is set. Redirects are always followed.
 
 ### Custom event listener
 

--- a/documentation/docs/20-core-concepts/30-form-actions.md
+++ b/documentation/docs/20-core-concepts/30-form-actions.md
@@ -450,15 +450,13 @@ If you return a callback, you override the default post-submission behavior. To 
 > - `refreshAll` controls whether all data is refreshed after submission. It defaults to `true` for successful results and `false` for failures. When the submission navigates to another page, setting it to `false` does _not_ prevent the destination's own `load` functions from running — it only allows shared layout data to be reused. `invalidateAll` is a deprecated alias for `refreshAll`
 > - `navigate: false` applies a non-redirect result to the current page instead of navigating to `result.location`. Redirects are always followed
 
-The behaviour of `applyAction(result)` depends on `result.type` and on `result.location` — the page the submission should land on. The server includes it in every action response, so `applyAction` can do what the browser would do:
+The behaviour of `applyAction(result)` depends on `result.type`:
 
-- `success`, `failure` — if `result.location` is a different page, navigates there and renders it with the result, populating that page's `form` property and `page.status`. Otherwise sets `page.status` to `result.status` and updates `form` and `page.form` to `result.data`
+- `success`, `failure` — sets `page.status` to `result.status` and updates `form` and `page.form` to `result.data`
 - `redirect` — calls `goto(result.location, { refreshAll: true })`
-- `error` — renders the nearest `+error` boundary with `result.error`. If `result.location` is a different page, it navigates there first, so the boundary is the one nearest the _destination's_ route
+- `error` — renders the current route's nearest `+error` boundary with `result.error`
 
-In all cases, [focus will be reset](accessibility#Focus-management).
-
-> [!NOTE] Like `update`, `applyAction` accepts a `navigate: false` option. It applies non-redirect results to the current page and resolves error boundaries against the current route, however `result.location` is set. Redirects are always followed.
+In all cases, [focus will be reset](accessibility#Focus-management). `applyAction` does not navigate to the `location` of a non-redirect result or refresh data. Use `update` to get the complete default enhanced behavior, including carrying form data and status into a cross-page navigation. When implementing enhancement manually, inspect `result.location` and use [`goto`](../$app-navigation#goto) or [`refreshAll`](../$app-navigation#refreshAll) as appropriate.
 
 ### Custom event listener
 
@@ -486,12 +484,15 @@ We can also implement progressive enhancement ourselves, without `use:enhance`, 
 		/** @type {import('@sveltejs/kit').ActionResult} */
 		const result = deserialize(await response.text());
 
-		if (result.type === 'success') {
-			// rerun all `load` functions and queries, following the successful update
-			await refreshAll();
+		if (result.type !== 'redirect' && result.location !== undefined) {
+			if (result.location === location.pathname + location.search) {
+				if (result.type === 'success') await refreshAll();
+			} else {
+				await goto(result.location, { refreshAll: result.type === 'success' });
+			}
 		}
 
-		applyAction(result);
+		await applyAction(result);
 	}
 </script>
 

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -1941,15 +1941,21 @@ export type Actions<
  *   };
  * }}
  * ```
+ *
+ * Success and failure results carry the root-relative `pathname + search` of the action URL, with
+ * the `?/actionName` parameter removed. Redirect results carry the redirect target. Server-generated
+ * error results also carry the action location, while client-generated errors such as network
+ * failures do not. [`applyAction`](https://svelte.dev/docs/kit/$app-forms#applyAction) navigates to
+ * the location when present, or updates the current page in place.
  */
 export type ActionResult<
 	Success extends Record<string, unknown> | undefined = Record<string, any>,
 	Failure extends Record<string, unknown> | undefined = Record<string, any>
 > =
-	| { type: 'success'; status: number; data?: Success }
-	| { type: 'failure'; status: number; data?: Failure }
+	| { type: 'success'; status: number; data?: Success; location: string }
+	| { type: 'failure'; status: number; data?: Failure; location: string }
 	| { type: 'redirect'; status: number; location: string }
-	| { type: 'error'; status?: number; error: App.Error };
+	| { type: 'error'; status?: number; error: App.Error; location?: string };
 
 /**
  * The object returned by the [`error`](https://svelte.dev/docs/kit/@sveltejs-kit#error) function.
@@ -1990,10 +1996,15 @@ export type SubmitFunction<
 			result: ActionResult<Success, Failure>;
 			/**
 			 * Call this to get the default behavior of a form submission response.
-			 * @param options Set `reset: false` if you don't want the `<form>` values to be reset after a successful submission.
-			 * @param invalidateAll Set `invalidateAll: false` if you don't want the action to call `invalidateAll` after submission.
+			 * @param options Set `reset: false` if you don't want the `<form>` values to be reset after a successful submission. `refreshAll` defaults to `true` for successful results and `false` for failures. When the submission navigates, setting it to `false` still runs the destination's `load` functions but may reuse shared layout data. Set `navigate: false` to apply non-redirect results to the current page instead of navigating to `result.location`. Redirects are always followed.
 			 */
-			update: (options?: { reset?: boolean; invalidateAll?: boolean }) => Promise<void>;
+			update: (options?: {
+				reset?: boolean;
+				refreshAll?: boolean;
+				navigate?: boolean;
+				/** @deprecated Use `refreshAll` instead. */
+				invalidateAll?: boolean;
+			}) => Promise<void>;
 	  }) => MaybePromise<void>)
 >;
 

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -1945,8 +1945,7 @@ export type Actions<
  * Success and failure results carry the root-relative `pathname + search` of the action URL, with
  * the `?/actionName` parameter removed. Redirect results carry the redirect target. Server-generated
  * error results also carry the action location, while client-generated errors such as network
- * failures do not. [`applyAction`](https://svelte.dev/docs/kit/$app-forms#applyAction) navigates to
- * the location when present, or updates the current page in place.
+ * failures do not. `update` uses this location to emulate native form navigation.
  */
 export type ActionResult<
 	Success extends Record<string, unknown> | undefined = Record<string, any>,

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -55,8 +55,6 @@ function clone(element) {
 	return /** @type {T} */ (HTMLElement.prototype.cloneNode.call(element));
 }
 
-
-
 /**
  * This action enhances a `<form>` element that otherwise would work without JavaScript.
  *

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -1,7 +1,12 @@
 import { DEV } from 'esm-env';
 import { noop } from '../../utils/functions.js';
 import { refreshAll } from './navigation.js';
-import { applyAction, handle_error } from '../client/client.js';
+import {
+	applyAction,
+	apply_action_navigation,
+	handle_error,
+	is_current_location
+} from '../client/client.js';
 import { notify_version } from '../client/state.svelte.js';
 import { parse } from '#app/internal/transport';
 
@@ -30,10 +35,6 @@ export { applyAction };
  * @returns {import('@sveltejs/kit').ActionResult<Success, Failure>}
  */
 export function deserialize(result) {
-	if (result === '') {
-		return { type: 'success', status: 204, data: undefined };
-	}
-
 	const parsed = JSON.parse(result);
 
 	if (parsed.data) {
@@ -54,6 +55,8 @@ function clone(element) {
 	return /** @type {T} */ (HTMLElement.prototype.cloneNode.call(element));
 }
 
+
+
 /**
  * This action enhances a `<form>` element that otherwise would work without JavaScript.
  *
@@ -63,17 +66,18 @@ function clone(element) {
  * If a function is returned, that function is called with the response from the server.
  * If nothing is returned, the fallback will be used.
  *
- * If this function or its return value isn't set, it
- * - falls back to updating the `form` prop with the returned data if the action is on the same page as the form
- * - updates `page.status`
- * - resets the `<form>` element and invalidates all data in case of successful submission with no redirect response
+ * If this function or its return value isn't set, it emulates the browser-native behaviour, just without the full-page reload. It
+ * - resets the `<form>` element and refreshes all data in case of a successful submission with no redirect response
+ * - updates the `form` prop, `page.form` and `page.status` if the action is on the same page as the form
+ * - navigates to the page the submission lands on — populating that page's `form` prop and `page.status` — on success and failure if that isn't the current page, just as a native form submission would, but with the `?/actionName` param stripped from the destination URL
  * - redirects in case of a redirect response
- * - redirects to the nearest error page in case of an unexpected error
+ * - renders the nearest error page in case of an unexpected error — the one nearest the action's route, if the action is on a different page
  *
  * If you provide a custom function with a callback and want to use the default behavior, invoke `update` in your callback.
  * It accepts an options object
  * - `reset: false` if you don't want the `<form>` values to be reset after a successful submission
- * - `invalidateAll: false` if you don't want the action to call `invalidateAll` after submission
+ * - `refreshAll` to control whether all data is refreshed after submission; it defaults to `true` for successes and `false` for failures
+ * - `navigate: false` to apply non-redirect results to the current page rather than navigating to `result.location`; redirects are always followed
  * @template {Record<string, unknown> | undefined} Success
  * @template {Record<string, unknown> | undefined} Failure
  * @param {HTMLFormElement} form_element The form element
@@ -86,37 +90,57 @@ export function enhance(form_element, submit = noop) {
 
 	/**
 	 * @param {{
-	 *   action: URL;
-	 *   invalidateAll?: boolean;
 	 *   result: import('@sveltejs/kit').ActionResult;
-	 *   reset?: boolean
+	 *   reset?: boolean;
+	 *   refreshAll?: boolean;
+	 *   invalidateAll?: boolean;
+	 *   navigate?: boolean;
 	 * }} opts
 	 */
 	const fallback_callback = async ({
-		action,
 		result,
 		reset = true,
-		invalidateAll: shouldInvalidateAll = true
+		refreshAll: should_refresh_all,
+		invalidateAll: deprecated_invalidate_all,
+		navigate = true
 	}) => {
-		if (result.type === 'success') {
-			if (reset) {
-				// We call reset from the prototype to avoid DOM clobbering
-				HTMLFormElement.prototype.reset.call(form_element);
-			}
-			if (shouldInvalidateAll) {
-				await refreshAll();
-			}
+		if (DEV && deprecated_invalidate_all !== undefined) {
+			console.warn(
+				'The `update({ invalidateAll })` option has been deprecated in favour of `update({ refreshAll })`'
+			);
 		}
 
-		// For success/failure results, only apply action if it belongs to the
-		// current page, otherwise `form` will be updated erroneously
-		if (
-			location.origin + location.pathname === action.origin + action.pathname ||
-			result.type === 'redirect' ||
-			result.type === 'error'
-		) {
-			await applyAction(result);
+		should_refresh_all ??= deprecated_invalidate_all ?? result.type === 'success';
+
+		if (result.type === 'success' && reset) {
+			// We call reset from the prototype to avoid DOM clobbering
+			HTMLFormElement.prototype.reset.call(form_element);
 		}
+
+		const destination =
+			navigate && result.type !== 'redirect' && !is_current_location(result.location)
+				? result.location
+				: undefined;
+
+		if (destination === undefined) {
+			if (should_refresh_all) {
+				await refreshAll();
+			}
+
+			await applyAction(result, { navigate: false });
+			return;
+		}
+
+		if (result.type === 'success' || result.type === 'failure') {
+			// emulate the browser: navigate to where the submission lands, rendering that
+			// page with this result
+			await apply_action_navigation(destination, result, should_refresh_all);
+			return;
+		}
+
+		// cross-page `error` results are handled by `applyAction`, which renders the error
+		// page nearest the destination's route
+		await applyAction(result, { navigate });
 	};
 
 	/** @param {SubmitEvent} event */
@@ -202,13 +226,9 @@ export function enhance(form_element, submit = noop) {
 			// detect new deployments from the response header
 			notify_version(response.headers.get('x-sveltekit-version'));
 
-			if (response.status === 204) {
-				result = { type: 'success', status: 204 };
-			} else {
-				result = deserialize(await response.text());
-				if (result.type === 'error' || result.type === 'failure') {
-					result.status = response.status;
-				}
+			result = deserialize(await response.text());
+			if (result.type === 'error' || result.type === 'failure') {
+				result.status = response.status;
 			}
 		} catch (error) {
 			if (/** @type {any} */ (error)?.name === 'AbortError') return;
@@ -228,10 +248,11 @@ export function enhance(form_element, submit = noop) {
 			formElement: form_element,
 			update: (opts) =>
 				fallback_callback({
-					action,
 					result,
 					reset: opts?.reset,
-					invalidateAll: opts?.invalidateAll
+					refreshAll: opts?.refreshAll,
+					invalidateAll: opts?.invalidateAll,
+					navigate: opts?.navigate
 				}),
 			// @ts-expect-error generic constraints stuff we don't care about
 			result

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -121,24 +121,17 @@ export function enhance(form_element, submit = noop) {
 				: undefined;
 
 		if (destination === undefined) {
-			if (should_refresh_all) {
+			if (should_refresh_all && result.type !== 'redirect') {
 				await refreshAll();
 			}
 
-			await applyAction(result, { navigate: false });
+			await applyAction(result);
 			return;
 		}
 
-		if (result.type === 'success' || result.type === 'failure') {
-			// emulate the browser: navigate to where the submission lands, rendering that
-			// page with this result
-			await apply_action_navigation(destination, result, should_refresh_all);
-			return;
-		}
-
-		// cross-page `error` results are handled by `applyAction`, which renders the error
-		// page nearest the destination's route
-		await applyAction(result, { navigate });
+		// emulate the browser: navigate to where the submission lands, rendering that
+		// page with this result
+		await apply_action_navigation(destination, result, should_refresh_all);
 	};
 
 	/** @param {SubmitEvent} event */

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -697,7 +697,7 @@ function persist_state() {
 
 /**
  * @param {string | URL} url
- * @param {{ type?: import('@sveltejs/kit').NavigationType; replace?: boolean; reset?: boolean; refreshAll?: boolean; invalidate?: Array<string | URL | ((url: URL) => boolean)>; state?: Record<string, any>; persistState?: boolean; event?: Event }} [options]
+ * @param {{ type?: import('@sveltejs/kit').NavigationType; replace?: boolean; reset?: boolean; refreshAll?: boolean; invalidate?: Array<string | URL | ((url: URL) => boolean)>; state?: Record<string, any>; persistState?: boolean; event?: Event; action_result?: import('@sveltejs/kit').ActionResult }} [options]
  * @param {number} [redirect_count]
  * @param {{}} [nav_token]
  * @param {NavigationIntent | undefined} [intent] navigation intent, when already known by the caller (avoids recomputing it)
@@ -723,6 +723,7 @@ export async function _goto(url, options = {}, redirect_count = 0, nav_token = {
 		state: options.state,
 		persist_state: options.persistState,
 		event: options.event,
+		action_result: options.action_result,
 		redirect_count,
 		nav_token,
 		intent,
@@ -1366,7 +1367,7 @@ function diff_search_params(old_url, new_url) {
 
 /**
  * @overload
- * @param {import('./types.js').NavigationIntent} intent
+ * @param {import('./types.js').NavigationIntent & { action_result?: import('@sveltejs/kit').ActionResult }} intent
  * @returns {Promise<import('./types.js').NavigationResult | undefined>}
  */
 /**
@@ -1375,11 +1376,11 @@ function diff_search_params(old_url, new_url) {
  * @returns {Promise<import('./types.js').NavigationResult>}
  */
 /**
- * @param {import('./types.js').NavigationIntent & { preload?: {} }} intent
+ * @param {import('./types.js').NavigationIntent & { preload?: {}; action_result?: import('@sveltejs/kit').ActionResult }} intent
  * @returns {Promise<import('./types.js').NavigationResult | undefined>}
  */
-async function load_route({ id, invalidating, url, params, route, preload }) {
-	if (load_cache?.id === id) {
+async function load_route({ id, invalidating, url, params, route, preload, action_result }) {
+	if (!action_result && load_cache?.id === id) {
 		// the preload becomes the real navigation
 		preload_tokens.delete(load_cache.token);
 		return load_cache.promise;
@@ -1388,6 +1389,8 @@ async function load_route({ id, invalidating, url, params, route, preload }) {
 	const { errors, layouts, leaf } = route;
 
 	const loaders = [...layouts, leaf];
+	const leaf_index = loaders.length - 1;
+	const action_error = action_result?.type === 'error';
 
 	// preload modules to avoid waterfall, but handle rejections
 	// so they don't get reported to Sentry et al (we don't need
@@ -1406,6 +1409,8 @@ async function load_route({ id, invalidating, url, params, route, preload }) {
 
 	if (__SVELTEKIT_HAS_SERVER_LOAD__) {
 		const invalid_server_nodes = loaders.map((loader, i) => {
+			if (action_error && i === leaf_index) return false;
+
 			const previous = current.branch[i];
 
 			const invalid =
@@ -1456,7 +1461,7 @@ async function load_route({ id, invalidating, url, params, route, preload }) {
 	let parent_changed = false;
 
 	const branch_promises = loaders.map(async (loader, i) => {
-		if (!loader) return;
+		if (!loader || (action_error && i === leaf_index)) return;
 
 		/** @type {import('./types.js').BranchNode | undefined} */
 		const previous = current.branch[i];
@@ -1569,6 +1574,25 @@ async function load_route({ id, invalidating, url, params, route, preload }) {
 		}
 	}
 
+	if (action_result?.type === 'error') {
+		// render the nearest error boundary of the route the action belongs to,
+		// as a native form submission would
+		const error_load = await load_nearest_error_page(loaders.length, branch, errors);
+		if (error_load) {
+			return get_navigation_result_from_branch({
+				url,
+				params,
+				branch: branch.slice(0, error_load.idx).concat(error_load.node),
+				errors,
+				error: action_result.error,
+				status: action_result.status,
+				route
+			});
+		}
+
+		return await server_fallback(url, { id: route.id }, action_result.error);
+	}
+
 	return get_navigation_result_from_branch({
 		url,
 		params,
@@ -1576,8 +1600,15 @@ async function load_route({ id, invalidating, url, params, route, preload }) {
 		errors,
 		error: null,
 		route,
-		// Reset `form` on navigation, but not invalidation
-		form: invalidating ? undefined : null
+		status: action_result?.status,
+		// `error` results returned above, `redirect` results are never passed here
+		form:
+			action_result?.type === 'success' || action_result?.type === 'failure'
+				? (action_result.data ?? null)
+				: // Reset `form` on navigation, but not invalidation
+					invalidating
+					? undefined
+					: null
 	});
 }
 
@@ -1894,7 +1925,8 @@ function _before_navigate({ url, type, intent, delta, event, scroll, shallow = f
  *   accept?: () => void;
  *   block?: () => void;
  *   event?: Event;
- *   intent?: NavigationIntent | undefined
+ *   intent?: NavigationIntent | undefined;
+ *   action_result?: import('@sveltejs/kit').ActionResult;
  * }} opts
  * @returns {Promise<void>}
  */
@@ -1911,7 +1943,8 @@ async function navigate({
 	accept = noop,
 	block = noop,
 	event,
-	intent
+	intent,
+	action_result
 }) {
 	const prev_token = navigation_token;
 	const prev_invalidation_token = invalidation_token;
@@ -1952,7 +1985,7 @@ async function navigate({
 		navigating.current = nav.navigation;
 	}
 
-	let navigation_result = intent && (await load_route(intent));
+	let navigation_result = intent && (await load_route({ ...intent, action_result }));
 
 	if (!navigation_result) {
 		if (is_external_url(url, base, app.hash)) {
@@ -2989,22 +3022,45 @@ async function update_state(intent, state, { replace, persist_state, reset }, ca
 }
 
 /**
- * This action updates the `form` property of the current page with the given data and updates `page.status`.
- * In case of an error, it redirects to the nearest error page.
+ * Applies an `ActionResult` the way the browser would.
+ *
+ * For redirects it navigates to the redirect location. For every other result it navigates to
+ * `result.location` — the page the submission should land on — populating that page's `form`
+ * property and `page.status`, or rendering that route's nearest error page for `error` results.
+ * When `result.location` is the page you're already on, this updates it in place instead of
+ * navigating. Pass `navigate: false` to update the current page in place for non-redirect results.
+ * Redirects are always followed.
  * @template {Record<string, unknown> | undefined} Success
  * @template {Record<string, unknown> | undefined} Failure
  * @param {import('@sveltejs/kit').ActionResult<Success, Failure>} result
+ * @param {{ navigate?: boolean }} [options]
  * @returns {Promise<void>}
  */
-export async function applyAction(result) {
+export async function applyAction(result, options) {
 	if (!BROWSER) {
 		throw new Error('Cannot call applyAction(...) on the server');
 	}
 
+	if (result.type === 'redirect') {
+		await _goto(result.location, { refreshAll: true });
+		return;
+	}
+
+	if (options?.navigate !== false && result.location !== undefined) {
+		if (!is_current_location(result.location)) {
+			// emulate the browser: render the destination page (or its nearest error
+			// boundary) with this result
+			await apply_action_navigation(result.location, result, result.type === 'success');
+			return;
+		}
+
+		if (result.type === 'success') {
+			await refreshAll();
+		}
+	}
+
 	if (result.type === 'error') {
 		await set_nearest_error_page(result.error);
-	} else if (result.type === 'redirect') {
-		await _goto(result.location, { refreshAll: true });
 	} else {
 		page.form = result.data;
 		page.status = result.status;
@@ -3022,6 +3078,51 @@ export async function applyAction(result) {
 			reset_focus(/** @type {URL} */ (page.url));
 		}
 	}
+}
+
+/**
+ * Whether a submission should update the current page in place rather than navigating — either
+ * because it lands where we already are, or because the result carries no location at all
+ * (hand-constructed results, which have always applied in place).
+ * @param {string | undefined} value
+ */
+export function is_current_location(value) {
+	if (value === undefined) return true;
+
+	const destination = resolve_url(value);
+	const current = new URL(location.href);
+	if (destination.pathname !== current.pathname) return false;
+
+	const keys = new Set([...destination.searchParams.keys(), ...current.searchParams.keys()]);
+	for (const key of keys) {
+		const destination_values = destination.searchParams.getAll(key).sort();
+		const current_values = current.searchParams.getAll(key).sort();
+
+		if (
+			destination_values.length !== current_values.length ||
+			destination_values.some((value, i) => value !== current_values[i])
+		) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/**
+ * Navigate to where a form submission should land, rendering that page with the given result
+ * — what the browser would do for a native submission.
+ * @param {string} location
+ * @param {import('@sveltejs/kit').ActionResult} result
+ * @param {boolean} refresh_all
+ * @returns {Promise<void>}
+ */
+export function apply_action_navigation(location, result, refresh_all) {
+	return _goto(location, {
+		type: 'form',
+		refreshAll: refresh_all,
+		action_result: result
+	});
 }
 
 /**

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1553,19 +1553,15 @@ async function load_route({ id, invalidating, url, params, route, preload, actio
 					error = await handle_error(err, { params, url, route: { id: route.id } });
 				}
 
-				const error_load = await load_nearest_error_page(i, branch, errors);
-				if (error_load) {
-					return get_navigation_result_from_branch({
-						url,
-						params,
-						branch: branch.slice(0, error_load.idx).concat(error_load.node),
-						errors,
-						error,
-						route
-					});
-				} else {
-					return await server_fallback(url, { id: route.id }, error);
-				}
+				return load_route_error({
+					i,
+					branch,
+					errors,
+					error,
+					url,
+					params,
+					route
+				});
 			}
 		} else {
 			// push an empty slot so we can rewind past gaps to the
@@ -1577,20 +1573,16 @@ async function load_route({ id, invalidating, url, params, route, preload, actio
 	if (action_result?.type === 'error') {
 		// render the nearest error boundary of the route the action belongs to,
 		// as a native form submission would
-		const error_load = await load_nearest_error_page(loaders.length, branch, errors);
-		if (error_load) {
-			return get_navigation_result_from_branch({
-				url,
-				params,
-				branch: branch.slice(0, error_load.idx).concat(error_load.node),
-				errors,
-				error: action_result.error,
-				status: action_result.status,
-				route
-			});
-		}
-
-		return await server_fallback(url, { id: route.id }, action_result.error);
+		return load_route_error({
+			i: loaders.length,
+			branch,
+			errors,
+			error: action_result.error,
+			status: action_result.status,
+			url,
+			params,
+			route
+		});
 	}
 
 	return get_navigation_result_from_branch({
@@ -1639,6 +1631,35 @@ async function load_nearest_error_page(i, branch, errors) {
 			}
 		}
 	}
+}
+
+/**
+ * @param {{
+ *   i: number;
+ *   branch: Array<import('./types.js').BranchNode | undefined>;
+ *   errors: Array<import('types').CSRPageNodeLoader | undefined>;
+ *   error: App.Error;
+ *   status?: number;
+ *   url: URL;
+ *   params: Record<string, string>;
+ *   route: import('./types.js').NavigationIntent['route'];
+ * }} opts
+ */
+async function load_route_error({ i, branch, errors, error, status, url, params, route }) {
+	const error_load = await load_nearest_error_page(i, branch, errors);
+	if (error_load) {
+		return get_navigation_result_from_branch({
+			url,
+			params,
+			branch: branch.slice(0, error_load.idx).concat(error_load.node),
+			errors,
+			error,
+			status,
+			route
+		});
+	}
+
+	return server_fallback(url, { id: route.id }, error);
 }
 
 /**
@@ -3022,21 +3043,15 @@ async function update_state(intent, state, { replace, persist_state, reset }, ca
 }
 
 /**
- * Applies an `ActionResult` the way the browser would.
- *
- * For redirects it navigates to the redirect location. For every other result it navigates to
- * `result.location` — the page the submission should land on — populating that page's `form`
- * property and `page.status`, or rendering that route's nearest error page for `error` results.
- * When `result.location` is the page you're already on, this updates it in place instead of
- * navigating. Pass `navigate: false` to update the current page in place for non-redirect results.
- * Redirects are always followed.
+ * Updates the `form` property of the current page with the given data and updates `page.status`.
+ * In case of an error, it renders the nearest error page. In case of a redirect, it navigates to
+ * the redirect location.
  * @template {Record<string, unknown> | undefined} Success
  * @template {Record<string, unknown> | undefined} Failure
  * @param {import('@sveltejs/kit').ActionResult<Success, Failure>} result
- * @param {{ navigate?: boolean }} [options]
  * @returns {Promise<void>}
  */
-export async function applyAction(result, options) {
+export async function applyAction(result) {
 	if (!BROWSER) {
 		throw new Error('Cannot call applyAction(...) on the server');
 	}
@@ -3044,19 +3059,6 @@ export async function applyAction(result, options) {
 	if (result.type === 'redirect') {
 		await _goto(result.location, { refreshAll: true });
 		return;
-	}
-
-	if (options?.navigate !== false && result.location !== undefined) {
-		if (!is_current_location(result.location)) {
-			// emulate the browser: render the destination page (or its nearest error
-			// boundary) with this result
-			await apply_action_navigation(result.location, result, result.type === 'success');
-			return;
-		}
-
-		if (result.type === 'success') {
-			await refreshAll();
-		}
 	}
 
 	if (result.type === 'error') {

--- a/packages/kit/src/runtime/server/page/actions.js
+++ b/packages/kit/src/runtime/server/page/actions.js
@@ -29,6 +29,7 @@ export function is_action_json_request(event) {
  */
 export async function handle_action_json_request(event, state, options, server) {
 	const actions = server?.actions;
+	const location = get_action_location(event.url);
 
 	if (!actions) {
 		const no_actions_error = new SvelteKitError(
@@ -42,7 +43,8 @@ export async function handle_action_json_request(event, state, options, server) 
 		return action_json(
 			{
 				type: 'error',
-				error
+				error,
+				location
 			},
 			{
 				status: error.status,
@@ -69,6 +71,7 @@ export async function handle_action_json_request(event, state, options, server) 
 				{
 					type: 'failure',
 					status: data.status,
+					location,
 					// @ts-expect-error we assign a string to what is supposed to be an object. That's ok
 					// because we don't use the object outside, and this way we have better code navigation
 					// through knowing where the related interface is used.
@@ -82,12 +85,16 @@ export async function handle_action_json_request(event, state, options, server) 
 			return action_json({
 				type: 'success',
 				status: 200,
+				location,
 				// @ts-expect-error see comment above
 				data: try_serialize(data, stringify, /** @type {string} */ (event.route.id))
 			});
 		} else {
-			// no data returned — use 204 No Content (without a body, per the spec)
-			return with_version_header(new Response(null, { status: 204 }));
+			return action_json({
+				type: 'success',
+				status: 204,
+				location
+			});
 		}
 	} catch (e) {
 		const err = normalize_error(e);
@@ -106,13 +113,30 @@ export async function handle_action_json_request(event, state, options, server) 
 		return action_json(
 			{
 				type: 'error',
-				error: transformed
+				error: transformed,
+				location
 			},
 			{
 				status: transformed.status
 			}
 		);
 	}
+}
+
+/**
+ * @param {URL} url
+ */
+export function get_action_location(url) {
+	const location = new URL(url);
+
+	for (const key of location.searchParams.keys()) {
+		if (key.startsWith('/')) {
+			location.searchParams.delete(key);
+			break;
+		}
+	}
+
+	return location.pathname + location.search;
 }
 
 /**
@@ -158,6 +182,7 @@ export function is_action_request(event) {
  */
 export async function handle_action_request(event, state, server) {
 	const actions = server?.actions;
+	const location = get_action_location(event.url);
 
 	if (!actions) {
 		// TODO should this be a different error altogether?
@@ -168,6 +193,7 @@ export async function handle_action_request(event, state, server) {
 		});
 		return {
 			type: 'error',
+			location,
 			// We're lying a bit with the types here; this will be transformed into a proper App.Error object later
 			error: new SvelteKitError(
 				405,
@@ -190,12 +216,14 @@ export async function handle_action_request(event, state, server) {
 			return {
 				type: 'failure',
 				status: data.status,
+				location,
 				data: data.data
 			};
 		} else {
 			return {
 				type: 'success',
 				status: 200,
+				location,
 				// @ts-expect-error this will be removed upon serialization, so `undefined` is the same as omission
 				data
 			};
@@ -213,6 +241,7 @@ export async function handle_action_request(event, state, server) {
 
 		return {
 			type: 'error',
+			location,
 			// @ts-expect-error We're lying a bit with the types here; this will be transformed into a proper App.Error object later
 			error: check_incorrect_fail_use(err)
 		};

--- a/packages/kit/src/runtime/server/remote-functions.js
+++ b/packages/kit/src/runtime/server/remote-functions.js
@@ -10,7 +10,7 @@ import { create_remote_key, parse_remote_arg, split_remote_key } from '../shared
 import { stringify } from '#app/internal/transport';
 import { handle_error_and_jsonify } from './errors.js';
 import { normalize_error } from '../../utils/error.js';
-import { check_incorrect_fail_use } from './page/actions.js';
+import { check_incorrect_fail_use, get_action_location } from './page/actions.js';
 import { DEV } from 'esm-env';
 import { record_span } from '../telemetry/record_span.js';
 import { deserialize_binary_form } from '../form-utils.js';
@@ -533,6 +533,7 @@ export async function handle_remote_form_post(event, state, manifest, id) {
  * @returns {Promise<ActionResult>}
  */
 async function handle_remote_form_post_internal(event, state, manifest, id) {
+	const location = get_action_location(event.url);
 	// `hash` and `name` can never contain a `/`, but the JSON-stringified key of a
 	// keyed (`form.for(key)`) instance can — rejoin the remaining segments
 	const [hash, name, ...rest] = id.split('/');
@@ -552,6 +553,7 @@ async function handle_remote_form_post_internal(event, state, manifest, id) {
 		});
 		return {
 			type: 'error',
+			location,
 			// We're lying a bit with the types here; this will be transformed into a proper App.Error object later
 			error: new SvelteKitError(
 				405,
@@ -584,7 +586,8 @@ async function handle_remote_form_post_internal(event, state, manifest, id) {
 		// It is instead available on `myForm.result`, setting of which happens within the remote `form` function.
 		return {
 			type: 'success',
-			status: 200
+			status: 200,
+			location
 		};
 	} catch (e) {
 		const err = normalize_error(e);
@@ -599,6 +602,7 @@ async function handle_remote_form_post_internal(event, state, manifest, id) {
 
 		return {
 			type: 'error',
+			location,
 			// @ts-expect-error We're lying a bit with the types here; this will be transformed into a proper App.Error object later
 			error: check_incorrect_fail_use(err)
 		};

--- a/packages/kit/test/apps/basics/src/app.d.ts
+++ b/packages/kit/test/apps/basics/src/app.d.ts
@@ -19,6 +19,7 @@ declare global {
 	}
 
 	interface Window {
+		nav_marker: boolean;
 		shallow_navigation_log: Array<{
 			hook: string;
 			params?: Record<string, unknown> | null;

--- a/packages/kit/test/apps/basics/src/routes/actions/cross-page/+layout.server.js
+++ b/packages/kit/test/apps/basics/src/routes/actions/cross-page/+layout.server.js
@@ -1,0 +1,4 @@
+/** @type {import('./$types').LayoutServerLoad} */
+export function load() {
+	return { layout_loaded_at: Math.random() };
+}

--- a/packages/kit/test/apps/basics/src/routes/actions/cross-page/destination/+error.svelte
+++ b/packages/kit/test/apps/basics/src/routes/actions/cross-page/destination/+error.svelte
@@ -1,0 +1,5 @@
+<script>
+	import { page } from '$app/state';
+</script>
+
+<h1 class="destination-error">destination error: {page.error?.message}</h1>

--- a/packages/kit/test/apps/basics/src/routes/actions/cross-page/destination/+page.js
+++ b/packages/kit/test/apps/basics/src/routes/actions/cross-page/destination/+page.js
@@ -1,6 +1,8 @@
 /** @type {import('./$types').PageLoad} */
-export function load({ url }) {
+export function load({ url, data }) {
 	if (url.searchParams.has('throw-in-load')) {
 		throw new Error('universal load should not run for an action error');
 	}
+
+	return data;
 }

--- a/packages/kit/test/apps/basics/src/routes/actions/cross-page/destination/+page.js
+++ b/packages/kit/test/apps/basics/src/routes/actions/cross-page/destination/+page.js
@@ -1,0 +1,6 @@
+/** @type {import('./$types').PageLoad} */
+export function load({ url }) {
+	if (url.searchParams.has('throw-in-load')) {
+		throw new Error('universal load should not run for an action error');
+	}
+}

--- a/packages/kit/test/apps/basics/src/routes/actions/cross-page/destination/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/actions/cross-page/destination/+page.server.js
@@ -1,0 +1,31 @@
+import { error, fail, redirect } from '@sveltejs/kit';
+
+/** @type {import('./$types').PageServerLoad} */
+export function load({ url }) {
+	if (url.searchParams.has('throw-in-load')) {
+		throw new Error('server load should not run for an action error');
+	}
+
+	return {
+		loaded_at: Date.now(),
+		search: url.search
+	};
+}
+
+/** @type {import('./$types').Actions} */
+export const actions = {
+	success: async ({ request }) => {
+		const fields = await request.formData();
+		return { source: 'destination', username: fields.get('username') };
+	},
+	failure: async ({ request }) => {
+		const fields = await request.formData();
+		return fail(400, { problem: 'invalid', username: fields.get('username') });
+	},
+	redirect: () => {
+		redirect(303, '/actions/cross-page/redirected');
+	},
+	error: () => {
+		error(500, 'cross-page action error');
+	}
+};

--- a/packages/kit/test/apps/basics/src/routes/actions/cross-page/destination/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/actions/cross-page/destination/+page.svelte
@@ -1,0 +1,17 @@
+<script>
+	import { page } from '$app/state';
+
+	/** @type {import('./$types').ActionData} */
+	export let form;
+
+	/** @type {import('./$types').PageData} */
+	export let data;
+</script>
+
+<h1 class="destination">destination</h1>
+
+<pre class="destination-form">{JSON.stringify(form)}</pre>
+<span class="status">{page.status}</span>
+<span class="loaded-at">{data.loaded_at}</span>
+<pre class="layout-loaded-at">{data.layout_loaded_at}</pre>
+<pre class="load-search">{data.search}</pre>

--- a/packages/kit/test/apps/basics/src/routes/actions/cross-page/redirected/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/actions/cross-page/redirected/+page.svelte
@@ -1,0 +1,1 @@
+<h1 class="redirected">redirected</h1>

--- a/packages/kit/test/apps/basics/src/routes/actions/cross-page/refreshall-false/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/actions/cross-page/refreshall-false/+page.svelte
@@ -1,0 +1,17 @@
+<script>
+	import { enhance } from '$app/forms';
+</script>
+
+<h1 class="source">source (refreshAll: false)</h1>
+
+<form
+	method="POST"
+	action="/actions/cross-page/destination?/success"
+	use:enhance={() =>
+		async ({ update }) => {
+			await update({ refreshAll: false });
+		}}
+>
+	<input name="username" type="text" value="paolo" />
+	<button class="submit-success">Submit</button>
+</form>

--- a/packages/kit/test/apps/basics/src/routes/actions/cross-page/same-page/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/actions/cross-page/same-page/+page.server.js
@@ -1,0 +1,16 @@
+import { fail } from '@sveltejs/kit';
+
+/** @type {import('./$types').PageServerLoad} */
+export function load({ url }) {
+	return { search: url.search, loaded_at: Math.random() };
+}
+
+/** @type {import('./$types').Actions} */
+export const actions = {
+	del: async ({ url }) => {
+		return { where: url.pathname };
+	},
+	fail: () => {
+		return fail(400, { failed: true });
+	}
+};

--- a/packages/kit/test/apps/basics/src/routes/actions/cross-page/same-page/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/actions/cross-page/same-page/+page.svelte
@@ -1,0 +1,36 @@
+<script>
+	import { enhance } from '$app/forms';
+
+	/** @type {any} */
+	export let form;
+	/** @type {any} */
+	export let data;
+</script>
+
+<h1 class="same-page">same page</h1>
+
+<pre class="load-search">{data.search}</pre>
+<pre class="loaded-at">{data.loaded_at}</pre>
+<pre class="form-json">{JSON.stringify(form ?? null)}</pre>
+
+<form method="POST" action="?/del" use:enhance>
+	<button class="submit-relative">Submit</button>
+</form>
+
+<form method="POST" action="?b=2&a=1&/del" use:enhance>
+	<button class="submit-reordered">Submit</button>
+</form>
+
+<form method="POST" action="?/fail" use:enhance>
+	<button class="submit-failure">Submit failure</button>
+</form>
+
+<form
+	method="POST"
+	action="?/fail"
+	use:enhance={() =>
+		async ({ update }) =>
+			update({ refreshAll: true })}
+>
+	<button class="submit-failure-refresh">Submit failure and refresh</button>
+</form>

--- a/packages/kit/test/apps/basics/src/routes/actions/cross-page/source/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/actions/cross-page/source/+page.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { applyAction, enhance } from '$app/forms';
+	import { enhance } from '$app/forms';
 
 	/** @type {any} */
 	export let form;
@@ -74,33 +74,10 @@
 
 <form
 	method="POST"
-	action="/actions/cross-page/destination?/failure"
-	use:enhance={() =>
-		async ({ result }) => {
-			await applyAction(result, { navigate: false });
-		}}
->
-	<input name="username" type="text" value="paolo" />
-	<button class="submit-stay-apply-action">Submit</button>
-</form>
-
-<form
-	method="POST"
 	action="/actions/cross-page/destination?/redirect"
 	use:enhance={() =>
 		async ({ update }) =>
 			update({ navigate: false })}
 >
 	<button class="submit-redirect-stay">Submit redirect</button>
-</form>
-
-<form
-	method="POST"
-	action="/actions/cross-page/destination?/redirect"
-	use:enhance={() =>
-		async ({ result }) => {
-			await applyAction(result, { navigate: false });
-		}}
->
-	<button class="submit-redirect-stay-apply-action">Submit redirect</button>
 </form>

--- a/packages/kit/test/apps/basics/src/routes/actions/cross-page/source/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/actions/cross-page/source/+page.svelte
@@ -1,0 +1,106 @@
+<script>
+	import { applyAction, enhance } from '$app/forms';
+
+	/** @type {any} */
+	export let form;
+	/** @type {any} */
+	export let data;
+</script>
+
+<h1 class="source">source</h1>
+
+<pre class="source-form">{JSON.stringify(form ?? null)}</pre>
+<pre class="layout-loaded-at">{data.layout_loaded_at}</pre>
+
+<!-- enhanced forms, one per result type -->
+<form method="POST" action="/actions/cross-page/destination?/success" use:enhance>
+	<input class="username-success" name="username" type="text" value="paolo" />
+	<button class="submit-success">Submit</button>
+</form>
+
+<form method="POST" action="/actions/cross-page/destination?/failure" use:enhance>
+	<input class="username-failure" name="username" type="text" value="paolo" />
+	<button class="submit-failure">Submit</button>
+</form>
+
+<form method="POST" action="/actions/cross-page/destination?/redirect" use:enhance>
+	<button class="submit-redirect">Submit</button>
+</form>
+
+<form method="POST" action="/actions/cross-page/destination?throw-in-load&/error" use:enhance>
+	<button class="submit-error">Submit</button>
+</form>
+
+<!-- unenhanced copies, so that the no-JS runs exercise the same fixtures -->
+<form method="POST" action="/actions/cross-page/destination?/success">
+	<input class="username-native-success" name="username" type="text" value="paolo" />
+	<button class="native-success">Submit</button>
+</form>
+
+<form method="POST" action="/actions/cross-page/destination?/failure">
+	<input class="username-native-failure" name="username" type="text" value="paolo" />
+	<button class="native-failure">Submit</button>
+</form>
+
+<form method="POST" action="/actions/cross-page/destination?/redirect">
+	<button class="native-redirect">Submit</button>
+</form>
+
+<form method="POST" action="/actions/cross-page/destination?throw-in-load&/error">
+	<button class="native-error">Submit</button>
+</form>
+
+<!-- action carrying an extra param: only `?/success` is stripped -->
+<form
+	method="POST"
+	action="/actions/cross-page/destination?redirectTo=%2Fdashboard&/success"
+	use:enhance
+>
+	<input class="username-extra" name="username" type="text" value="paolo" />
+	<button class="submit-extra-params">Submit</button>
+</form>
+
+<!-- escape hatches: stay on this page and apply the result here -->
+<form
+	method="POST"
+	action="/actions/cross-page/destination?/failure"
+	use:enhance={() =>
+		async ({ update }) =>
+			update({ navigate: false })}
+>
+	<input class="username-stay" name="username" type="text" value="paolo" />
+	<button class="submit-stay">Submit</button>
+</form>
+
+<form
+	method="POST"
+	action="/actions/cross-page/destination?/failure"
+	use:enhance={() =>
+		async ({ result }) => {
+			await applyAction(result, { navigate: false });
+		}}
+>
+	<input name="username" type="text" value="paolo" />
+	<button class="submit-stay-apply-action">Submit</button>
+</form>
+
+<form
+	method="POST"
+	action="/actions/cross-page/destination?/redirect"
+	use:enhance={() =>
+		async ({ update }) =>
+			update({ navigate: false })}
+>
+	<button class="submit-redirect-stay">Submit redirect</button>
+</form>
+
+<form
+	method="POST"
+	action="/actions/cross-page/destination?/redirect"
+	use:enhance={() =>
+		async ({ result }) => {
+			await applyAction(result, { navigate: false });
+		}}
+>
+	<button class="submit-redirect-stay-apply-action">Submit redirect</button>
+</form>

--- a/packages/kit/test/apps/basics/src/routes/actions/update-form/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/actions/update-form/+page.svelte
@@ -7,7 +7,12 @@
 
 	/** @param {'success' | 'failure'} type */
 	function update(type) {
-		applyAction({ type, status: 200, data: { count: count++ } });
+		applyAction({
+			type,
+			status: 200,
+			data: { count: count++ },
+			location: '/actions/enhance'
+		});
 	}
 	function redirect() {
 		applyAction({ type: 'redirect', status: 303, location: '/' });

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -1567,28 +1567,23 @@ test.describe('Actions', () => {
 		await expect(page.locator('pre.destination-form')).toHaveText(JSON.stringify(null));
 	});
 
-	for (const [name, selector, redirect_selector] of [
-		['update', 'button.submit-stay', 'button.submit-redirect-stay'],
-		['applyAction', 'button.submit-stay-apply-action', 'button.submit-redirect-stay-apply-action']
-	]) {
-		test(`${name} navigate option applies the result to the current page`, async ({ page }) => {
-			await page.goto('/actions/cross-page/source');
-			await page.locator(selector).click();
+	test('update navigate option applies the result to the current page', async ({ page }) => {
+		await page.goto('/actions/cross-page/source');
+		await page.locator('button.submit-stay').click();
 
-			await expect(page.locator('pre.source-form')).toHaveText(
-				JSON.stringify({ problem: 'invalid', username: 'paolo' })
-			);
-			expect(new URL(page.url()).pathname).toBe('/actions/cross-page/source');
-		});
+		await expect(page.locator('pre.source-form')).toHaveText(
+			JSON.stringify({ problem: 'invalid', username: 'paolo' })
+		);
+		expect(new URL(page.url()).pathname).toBe('/actions/cross-page/source');
+	});
 
-		test(`${name} navigate option does not suppress redirects`, async ({ page }) => {
-			await page.goto('/actions/cross-page/source');
-			await page.locator(redirect_selector).click();
+	test('update navigate option does not suppress redirects', async ({ page }) => {
+		await page.goto('/actions/cross-page/source');
+		await page.locator('button.submit-redirect-stay').click();
 
-			await expect(page.locator('h1.redirected')).toHaveText('redirected');
-			expect(new URL(page.url()).pathname).toBe('/actions/cross-page/redirected');
-		});
-	}
+		await expect(page.locator('h1.redirected')).toHaveText('redirected');
+		expect(new URL(page.url()).pathname).toBe('/actions/cross-page/redirected');
+	});
 
 	test('update({ refreshAll: false }) still navigates to the cross-page action', async ({
 		page

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -1462,6 +1462,145 @@ test.describe('Actions', () => {
 		await page.evaluate('window.svelte_tick()');
 		await expect(pre).toHaveText('prop: 1, state: 1');
 	});
+
+	test('cross-page action navigation is client-side', async ({ page }) => {
+		await page.goto('/actions/cross-page/source');
+		await page.evaluate(() => (window.nav_marker = true));
+
+		await page.locator('button.submit-success').click();
+
+		await expect(page.locator('pre.destination-form')).toHaveText(
+			JSON.stringify({ source: 'destination', username: 'paolo' })
+		);
+		expect(await page.evaluate(() => window.nav_marker)).toBe(true);
+	});
+
+	test('same-page action drops query params omitted from the action', async ({ page }) => {
+		await page.goto('/actions/cross-page/same-page?page=2');
+		await page.locator('button.submit-relative').click();
+
+		await expect(page.locator('pre.form-json')).toHaveText(
+			JSON.stringify({ where: '/actions/cross-page/same-page' })
+		);
+
+		const url = new URL(page.url());
+		expect(url.pathname).toBe('/actions/cross-page/same-page');
+		expect(url.search).toBe('');
+	});
+
+	test('semantically identical action query refreshes without navigating', async ({ page }) => {
+		await page.goto('/actions/cross-page/same-page?a=1&b=2');
+		const loaded_at = await page.locator('pre.loaded-at').textContent();
+		await page.evaluate(() => (window.nav_marker = true));
+
+		await page.locator('button.submit-reordered').click();
+
+		await expect(page.locator('pre.form-json')).toHaveText(
+			JSON.stringify({ where: '/actions/cross-page/same-page' })
+		);
+		await expect(page.locator('pre.loaded-at')).not.toHaveText(loaded_at);
+		expect(await page.evaluate(() => window.nav_marker)).toBe(true);
+		expect(new URL(page.url()).search).toBe('?a=1&b=2');
+	});
+
+	test('failures do not refresh by default but can opt in', async ({ page }) => {
+		await page.goto('/actions/cross-page/same-page');
+		let loaded_at = await page.locator('pre.loaded-at').textContent();
+
+		await page.locator('button.submit-failure').click();
+		await expect(page.locator('pre.form-json')).toHaveText(JSON.stringify({ failed: true }));
+		await expect(page.locator('pre.loaded-at')).toHaveText(loaded_at);
+
+		loaded_at = await page.locator('pre.loaded-at').textContent();
+		await page.locator('button.submit-failure-refresh').click();
+		await expect(page.locator('pre.form-json')).toHaveText(JSON.stringify({ failed: true }));
+		await expect(page.locator('pre.loaded-at')).not.toHaveText(loaded_at);
+	});
+
+	test('cross-page refresh defaults depend on the result type', async ({ page }) => {
+		await page.goto('/actions/cross-page/source');
+		let layout_loaded_at = await page.locator('pre.layout-loaded-at').textContent();
+
+		await page.locator('button.submit-failure').click();
+		await expect(page.locator('pre.destination-form')).toHaveText(
+			JSON.stringify({ problem: 'invalid', username: 'paolo' })
+		);
+		await expect(page.locator('pre.layout-loaded-at')).toHaveText(layout_loaded_at);
+
+		await page.goto('/actions/cross-page/source');
+		layout_loaded_at = await page.locator('pre.layout-loaded-at').textContent();
+		await page.locator('button.submit-success').click();
+		await expect(page.locator('pre.layout-loaded-at')).not.toHaveText(layout_loaded_at);
+	});
+
+	test('cross-page action navigation strips only the named-action param', async ({ page }) => {
+		await page.goto('/actions/cross-page/source');
+		await page.locator('button.submit-extra-params').click();
+
+		await expect(page.locator('pre.destination-form')).toHaveText(
+			JSON.stringify({ source: 'destination', username: 'paolo' })
+		);
+
+		const url = new URL(page.url());
+		expect(url.pathname).toBe('/actions/cross-page/destination');
+		expect(url.searchParams.get('redirectTo')).toBe('/dashboard');
+		expect([...url.searchParams.keys()].some((key) => key.startsWith('/'))).toBe(false);
+
+		// the destination's `load` sees the stripped URL
+		await expect(page.locator('pre.load-search')).toHaveText('?redirectTo=%2Fdashboard');
+	});
+
+	test('cross-page action navigation pushes a history entry', async ({ page }) => {
+		await page.goto('/actions/cross-page/source');
+		await page.locator('button.submit-success').click();
+
+		await expect(page.locator('pre.destination-form')).toHaveText(
+			JSON.stringify({ source: 'destination', username: 'paolo' })
+		);
+
+		await page.goBack();
+		await expect(page.locator('h1.source')).toHaveText('source');
+		expect(new URL(page.url()).pathname).toBe('/actions/cross-page/source');
+
+		// form data is ephemeral — going forward again renders the destination without it
+		await page.goForward();
+		await expect(page.locator('pre.destination-form')).toHaveText(JSON.stringify(null));
+	});
+
+	for (const [name, selector, redirect_selector] of [
+		['update', 'button.submit-stay', 'button.submit-redirect-stay'],
+		['applyAction', 'button.submit-stay-apply-action', 'button.submit-redirect-stay-apply-action']
+	]) {
+		test(`${name} navigate option applies the result to the current page`, async ({ page }) => {
+			await page.goto('/actions/cross-page/source');
+			await page.locator(selector).click();
+
+			await expect(page.locator('pre.source-form')).toHaveText(
+				JSON.stringify({ problem: 'invalid', username: 'paolo' })
+			);
+			expect(new URL(page.url()).pathname).toBe('/actions/cross-page/source');
+		});
+
+		test(`${name} navigate option does not suppress redirects`, async ({ page }) => {
+			await page.goto('/actions/cross-page/source');
+			await page.locator(redirect_selector).click();
+
+			await expect(page.locator('h1.redirected')).toHaveText('redirected');
+			expect(new URL(page.url()).pathname).toBe('/actions/cross-page/redirected');
+		});
+	}
+
+	test('update({ refreshAll: false }) still navigates to the cross-page action', async ({
+		page
+	}) => {
+		await page.goto('/actions/cross-page/refreshall-false');
+		await page.locator('button.submit-success').click();
+
+		await expect(page.locator('pre.destination-form')).toHaveText(
+			JSON.stringify({ source: 'destination', username: 'paolo' })
+		);
+		expect(new URL(page.url()).pathname).toBe('/actions/cross-page/destination');
+	});
 });
 
 test.describe('Assets', () => {

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -1490,7 +1490,7 @@ test.describe('Actions', () => {
 
 	test('semantically identical action query refreshes without navigating', async ({ page }) => {
 		await page.goto('/actions/cross-page/same-page?a=1&b=2');
-		const loaded_at = await page.locator('pre.loaded-at').textContent();
+		const loaded_at = await page.locator('pre.loaded-at').innerText();
 		await page.evaluate(() => (window.nav_marker = true));
 
 		await page.locator('button.submit-reordered').click();
@@ -1505,13 +1505,13 @@ test.describe('Actions', () => {
 
 	test('failures do not refresh by default but can opt in', async ({ page }) => {
 		await page.goto('/actions/cross-page/same-page');
-		let loaded_at = await page.locator('pre.loaded-at').textContent();
+		let loaded_at = await page.locator('pre.loaded-at').innerText();
 
 		await page.locator('button.submit-failure').click();
 		await expect(page.locator('pre.form-json')).toHaveText(JSON.stringify({ failed: true }));
 		await expect(page.locator('pre.loaded-at')).toHaveText(loaded_at);
 
-		loaded_at = await page.locator('pre.loaded-at').textContent();
+		loaded_at = await page.locator('pre.loaded-at').innerText();
 		await page.locator('button.submit-failure-refresh').click();
 		await expect(page.locator('pre.form-json')).toHaveText(JSON.stringify({ failed: true }));
 		await expect(page.locator('pre.loaded-at')).not.toHaveText(loaded_at);
@@ -1519,7 +1519,7 @@ test.describe('Actions', () => {
 
 	test('cross-page refresh defaults depend on the result type', async ({ page }) => {
 		await page.goto('/actions/cross-page/source');
-		let layout_loaded_at = await page.locator('pre.layout-loaded-at').textContent();
+		let layout_loaded_at = await page.locator('pre.layout-loaded-at').innerText();
 
 		await page.locator('button.submit-failure').click();
 		await expect(page.locator('pre.destination-form')).toHaveText(
@@ -1528,7 +1528,7 @@ test.describe('Actions', () => {
 		await expect(page.locator('pre.layout-loaded-at')).toHaveText(layout_loaded_at);
 
 		await page.goto('/actions/cross-page/source');
-		layout_loaded_at = await page.locator('pre.layout-loaded-at').textContent();
+		layout_loaded_at = await page.locator('pre.layout-loaded-at').innerText();
 		await page.locator('button.submit-success').click();
 		await expect(page.locator('pre.layout-loaded-at')).not.toHaveText(layout_loaded_at);
 	});

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -874,8 +874,33 @@ test.describe('Shadowed pages', () => {
 			}
 		});
 
-		expect(response.status()).toBe(204);
-		expect(await response.text()).toBe('');
+		expect(response.status()).toBe(200);
+		expect(await response.json()).toEqual({
+			type: 'success',
+			status: 204,
+			location: '/shadowed/simple/post'
+		});
+	});
+
+	test('action response includes the stripped landing location', async ({ baseURL, request }) => {
+		const response = await request.post(
+			'/actions/cross-page/destination?redirectTo=%2Fdashboard&/failure',
+			{
+				form: { username: 'paolo' },
+				headers: {
+					accept: 'application/json',
+					origin: new URL(baseURL).origin
+				}
+			}
+		);
+
+		expect(response.status()).toBe(400);
+		expect(await response.json()).toEqual({
+			type: 'failure',
+			status: 400,
+			location: '/actions/cross-page/destination?redirectTo=%2Fdashboard',
+			data: '[{"problem":1,"username":2},"invalid","paolo"]'
+		});
 	});
 
 	test('Action fail() returns matching HTTP status code', async ({ baseURL, request }) => {

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -648,6 +648,7 @@ test.describe('Errors', () => {
 		expect(res_json?.status()).toBe(405);
 		expect(await res_json.json()).toEqual({
 			type: 'error',
+			location: '/errors/missing-actions',
 			error: {
 				message: process.env.DEV
 					? 'POST method not allowed. No form actions exist for the page at /errors/missing-actions (405 Method Not Allowed)'

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1474,6 +1474,75 @@ test.describe('Actions', () => {
 		expect(response.status()).toBe(404);
 	});
 
+	test('cross-page action success navigates to action page', async ({
+		page,
+		javaScriptEnabled
+	}) => {
+		await page.goto('/actions/cross-page/source');
+
+		await page
+			.locator(javaScriptEnabled ? 'button.submit-success' : 'button.native-success')
+			.click();
+
+		await expect(page.locator('pre.destination-form')).toHaveText(
+			JSON.stringify({ source: 'destination', username: 'paolo' })
+		);
+		await expect(page.locator('span.status')).toHaveText('200');
+
+		const url = new URL(page.url());
+		expect(url.pathname).toBe('/actions/cross-page/destination');
+		// enhanced submissions strip the `?/name` param; native ones can't
+		expect(url.search).toBe(javaScriptEnabled ? '' : '?/success');
+	});
+
+	test('cross-page action failure navigates with failure data and status', async ({
+		page,
+		javaScriptEnabled
+	}) => {
+		await page.goto('/actions/cross-page/source');
+
+		await page
+			.locator(javaScriptEnabled ? 'button.submit-failure' : 'button.native-failure')
+			.click();
+
+		await expect(page.locator('pre.destination-form')).toHaveText(
+			JSON.stringify({ problem: 'invalid', username: 'paolo' })
+		);
+		await expect(page.locator('span.status')).toHaveText('400');
+
+		const url = new URL(page.url());
+		expect(url.pathname).toBe('/actions/cross-page/destination');
+		expect(url.search).toBe(javaScriptEnabled ? '' : '?/failure');
+	});
+
+	test('cross-page action redirect is followed', async ({ page, javaScriptEnabled }) => {
+		await page.goto('/actions/cross-page/source');
+
+		await page
+			.locator(javaScriptEnabled ? 'button.submit-redirect' : 'button.native-redirect')
+			.click();
+
+		await expect(page.locator('h1.redirected')).toHaveText('redirected');
+		expect(new URL(page.url()).pathname).toBe('/actions/cross-page/redirected');
+	});
+
+	test('cross-page action error renders the destination error boundary', async ({
+		page,
+		javaScriptEnabled
+	}) => {
+		await page.goto('/actions/cross-page/source');
+
+		await page.locator(javaScriptEnabled ? 'button.submit-error' : 'button.native-error').click();
+
+		await expect(page.locator('h1.destination-error')).toHaveText(
+			'destination error: cross-page action error'
+		);
+
+		const url = new URL(page.url());
+		expect(url.pathname).toBe('/actions/cross-page/destination');
+		expect(url.search).toBe(javaScriptEnabled ? '?throw-in-load=' : '?throw-in-load&/error');
+	});
+
 	for (const name of ['toString', 'constructor', '__proto__', 'hasOwnProperty']) {
 		test(`submitting to a form action named '${name}' (an Object.prototype member) returns http status code 404`, async ({
 			baseURL,

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1898,15 +1898,21 @@ declare module '@sveltejs/kit' {
 	 *   };
 	 * }}
 	 * ```
+	 *
+	 * Success and failure results carry the root-relative `pathname + search` of the action URL, with
+	 * the `?/actionName` parameter removed. Redirect results carry the redirect target. Server-generated
+	 * error results also carry the action location, while client-generated errors such as network
+	 * failures do not. [`applyAction`](https://svelte.dev/docs/kit/$app-forms#applyAction) navigates to
+	 * the location when present, or updates the current page in place.
 	 */
 	export type ActionResult<
 		Success extends Record<string, unknown> | undefined = Record<string, any>,
 		Failure extends Record<string, unknown> | undefined = Record<string, any>
 	> =
-		| { type: 'success'; status: number; data?: Success }
-		| { type: 'failure'; status: number; data?: Failure }
+		| { type: 'success'; status: number; data?: Success; location: string }
+		| { type: 'failure'; status: number; data?: Failure; location: string }
 		| { type: 'redirect'; status: number; location: string }
-		| { type: 'error'; status?: number; error: App.Error };
+		| { type: 'error'; status?: number; error: App.Error; location?: string };
 
 	/**
 	 * The object returned by the [`error`](https://svelte.dev/docs/kit/@sveltejs-kit#error) function.
@@ -1947,10 +1953,15 @@ declare module '@sveltejs/kit' {
 				result: ActionResult<Success, Failure>;
 				/**
 				 * Call this to get the default behavior of a form submission response.
-				 * @param options Set `reset: false` if you don't want the `<form>` values to be reset after a successful submission.
-				 * @param invalidateAll Set `invalidateAll: false` if you don't want the action to call `invalidateAll` after submission.
+				 * @param options Set `reset: false` if you don't want the `<form>` values to be reset after a successful submission. `refreshAll` defaults to `true` for successful results and `false` for failures. When the submission navigates, setting it to `false` still runs the destination's `load` functions but may reuse shared layout data. Set `navigate: false` to apply non-redirect results to the current page instead of navigating to `result.location`. Redirects are always followed.
 				 */
-				update: (options?: { reset?: boolean; invalidateAll?: boolean }) => Promise<void>;
+				update: (options?: {
+					reset?: boolean;
+					refreshAll?: boolean;
+					navigate?: boolean;
+					/** @deprecated Use `refreshAll` instead. */
+					invalidateAll?: boolean;
+				}) => Promise<void>;
 		  }) => MaybePromise<void>)
 	>;
 
@@ -3112,17 +3123,18 @@ declare module '$app/forms' {
 	 * If a function is returned, that function is called with the response from the server.
 	 * If nothing is returned, the fallback will be used.
 	 *
-	 * If this function or its return value isn't set, it
-	 * - falls back to updating the `form` prop with the returned data if the action is on the same page as the form
-	 * - updates `page.status`
-	 * - resets the `<form>` element and invalidates all data in case of successful submission with no redirect response
+	 * If this function or its return value isn't set, it emulates the browser-native behaviour, just without the full-page reload. It
+	 * - resets the `<form>` element and refreshes all data in case of a successful submission with no redirect response
+	 * - updates the `form` prop, `page.form` and `page.status` if the action is on the same page as the form
+	 * - navigates to the page the submission lands on — populating that page's `form` prop and `page.status` — on success and failure if that isn't the current page, just as a native form submission would, but with the `?/actionName` param stripped from the destination URL
 	 * - redirects in case of a redirect response
-	 * - redirects to the nearest error page in case of an unexpected error
+	 * - renders the nearest error page in case of an unexpected error — the one nearest the action's route, if the action is on a different page
 	 *
 	 * If you provide a custom function with a callback and want to use the default behavior, invoke `update` in your callback.
 	 * It accepts an options object
 	 * - `reset: false` if you don't want the `<form>` values to be reset after a successful submission
-	 * - `invalidateAll: false` if you don't want the action to call `invalidateAll` after submission
+	 * - `refreshAll` to control whether all data is refreshed after submission; it defaults to `true` for successes and `false` for failures
+	 * - `navigate: false` to apply non-redirect results to the current page rather than navigating to `result.location`; redirects are always followed
 	 * @param form_element The form element
 	 * @param submit Submit callback
 	 */
@@ -3130,10 +3142,18 @@ declare module '$app/forms' {
 		destroy(): void;
 	};
 	/**
-	 * This action updates the `form` property of the current page with the given data and updates `page.status`.
-	 * In case of an error, it redirects to the nearest error page.
+	 * Applies an `ActionResult` the way the browser would.
+	 *
+	 * For redirects it navigates to the redirect location. For every other result it navigates to
+	 * `result.location` — the page the submission should land on — populating that page's `form`
+	 * property and `page.status`, or rendering that route's nearest error page for `error` results.
+	 * When `result.location` is the page you're already on, this updates it in place instead of
+	 * navigating. Pass `navigate: false` to update the current page in place for non-redirect results.
+	 * Redirects are always followed.
 	 * */
-	export function applyAction<Success extends Record<string, unknown> | undefined, Failure extends Record<string, unknown> | undefined>(result: import("@sveltejs/kit").ActionResult<Success, Failure>): Promise<void>;
+	export function applyAction<Success extends Record<string, unknown> | undefined, Failure extends Record<string, unknown> | undefined>(result: import("@sveltejs/kit").ActionResult<Success, Failure>, options?: {
+		navigate?: boolean;
+	}): Promise<void>;
 
 	export {};
 }

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1902,8 +1902,7 @@ declare module '@sveltejs/kit' {
 	 * Success and failure results carry the root-relative `pathname + search` of the action URL, with
 	 * the `?/actionName` parameter removed. Redirect results carry the redirect target. Server-generated
 	 * error results also carry the action location, while client-generated errors such as network
-	 * failures do not. [`applyAction`](https://svelte.dev/docs/kit/$app-forms#applyAction) navigates to
-	 * the location when present, or updates the current page in place.
+	 * failures do not. `update` uses this location to emulate native form navigation.
 	 */
 	export type ActionResult<
 		Success extends Record<string, unknown> | undefined = Record<string, any>,
@@ -3142,18 +3141,11 @@ declare module '$app/forms' {
 		destroy(): void;
 	};
 	/**
-	 * Applies an `ActionResult` the way the browser would.
-	 *
-	 * For redirects it navigates to the redirect location. For every other result it navigates to
-	 * `result.location` — the page the submission should land on — populating that page's `form`
-	 * property and `page.status`, or rendering that route's nearest error page for `error` results.
-	 * When `result.location` is the page you're already on, this updates it in place instead of
-	 * navigating. Pass `navigate: false` to update the current page in place for non-redirect results.
-	 * Redirects are always followed.
+	 * Updates the `form` property of the current page with the given data and updates `page.status`.
+	 * In case of an error, it renders the nearest error page. In case of a redirect, it navigates to
+	 * the redirect location.
 	 * */
-	export function applyAction<Success extends Record<string, unknown> | undefined, Failure extends Record<string, unknown> | undefined>(result: import("@sveltejs/kit").ActionResult<Success, Failure>, options?: {
-		navigate?: boolean;
-	}): Promise<void>;
+	export function applyAction<Success extends Record<string, unknown> | undefined, Failure extends Record<string, unknown> | undefined>(result: import("@sveltejs/kit").ActionResult<Success, Failure>): Promise<void>;
 
 	export {};
 }


### PR DESCRIPTION
closes #9999

Enhanced form actions now follow native form navigation behavior: cross-page submissions navigate to the action page on success or failure, while same-page submissions refresh in place. Named-action parameters are removed from the destination URL, and action results include the resolved location so `update` and `applyAction` behave consistently. Both APIs support `navigate: false` for applying non-redirect results to the current page, while redirects are always followed. Successful submissions refresh data by default; failed submissions do not. This also removes the non-standard behavior we had where we special-cased "no action query params === refresh without removing the existing query params". If this behavior is needed, it's relatively easy to interpolate the current page's query params into the form's `action`.
