### PR TITLE
feat: add `snapshot` helper to `$app/navigation`

### DIFF
--- a/.changeset/snapshot-helper.md
+++ b/.changeset/snapshot-helper.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: add `snapshot` helper to `$app/navigation`

--- a/packages/kit/src/runtime/app/navigation.js
+++ b/packages/kit/src/runtime/app/navigation.js
@@ -10,5 +10,6 @@ export {
 	preloadCode,
 	preloadData,
 	pushState,
-	replaceState
+	replaceState,
+	snapshot
 } from '../client/client.js';

--- a/packages/kit/src/runtime/app/navigation.js
+++ b/packages/kit/src/runtime/app/navigation.js
@@ -10,6 +10,6 @@ export {
 	preloadCode,
 	preloadData,
 	pushState,
-	replaceState,
-	snapshot
+	replaceState
 } from '../client/client.js';
+export { snapshot } from '../client/snapshots.js';

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2534,13 +2534,17 @@ export function snapshot(options) {
 
 	let id = options.id;
 	if (id === undefined) {
+		// restore any lowered third-party limit, else every callsite collapses to one id
+		const limit = Error.stackTraceLimit;
+		if (typeof limit === 'number' && limit < 3) Error.stackTraceLimit = 3;
 		let stack = new Error().stack?.split('\n') ?? [];
+		if (typeof limit === 'number' && limit < 3) Error.stackTraceLimit = limit;
+
 		if (stack[0]?.trim() === 'Error') stack = stack.slice(1);
 
-		// frames above the callsite differ between hydration and client-side re-mounting
-		let frame = stack[1] ?? stack[0];
-		// strip Vite query strings so snapshots survive module invalidation and dependency updates
-		frame = frame?.replace(/\?[^)\s]*(?=:\d+:\d+\)?$)/, '');
+		// only the callsite frame is stable: frames above it differ between hydration and
+		// re-mounting, and Vite query strings (stripped here) change on module invalidation
+		const frame = stack[1]?.replace(/\?[^)\s]*(?=:\d+:\d+\)?$)/, '');
 
 		if (!frame) {
 			throw new Error(

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -712,11 +712,6 @@ function capture_navigation_snapshot(index) {
 	);
 }
 
-/** @param {number} index */
-function delete_navigation_snapshot(index) {
-	delete navigation_snapshots[index];
-}
-
 /**
  * @param {number} index
  * @param {Set<SnapshotRegistration>} [reset_registrations]
@@ -2112,7 +2107,7 @@ async function navigate({
 	capture_scroll(previous_history_index);
 	capture_snapshot(previous_navigation_index);
 	if (replace_state) {
-		delete_navigation_snapshot(previous_history_index);
+		delete navigation_snapshots[previous_history_index];
 	} else {
 		capture_navigation_snapshot(previous_history_index);
 	}
@@ -2555,8 +2550,12 @@ export function snapshot(options) {
 	const registration = { ...options, id };
 
 	onMount(() => {
-		if (DEV && Array.from(snapshot_registrations).some((snapshot) => snapshot.id === id)) {
-			throw new Error(`A snapshot with id "${id}" is already registered. Pass a unique \`id\`.`);
+		if (DEV && Array.from(snapshot_registrations).some((existing) => existing.id === id)) {
+			throw new Error(
+				options.id === undefined
+					? 'snapshot() was called multiple times from the same call site. Pass a unique `id` to distinguish the instances.'
+					: `A snapshot with id "${options.id}" is already registered. Pass a unique \`id\`.`
+			);
 		}
 
 		if (started && !is_navigating && !updating) {
@@ -3026,7 +3025,7 @@ async function update_state(intent, state, { replace, persist_state, reset }, ca
 	}
 
 	if (replace) {
-		delete_navigation_snapshot(current_history_index);
+		delete navigation_snapshots[current_history_index];
 	} else {
 		capture_scroll(current_history_index);
 		capture_navigation_snapshot(current_history_index);

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -32,6 +32,7 @@ import {
 } from './constants.js';
 import { validate_page_exports } from '../../utils/exports.js';
 import { noop } from '../../utils/functions.js';
+import { hash } from '../../utils/hash.js';
 import {
 	INVALIDATED_PARAM,
 	TRAILING_SLASH_PARAM,
@@ -2538,13 +2539,15 @@ export function snapshot(options) {
 
 		// Strip Vite query strings so snapshots survive module invalidation and dependency updates.
 		stack = stack.map((frame) => frame.replace(/\?[^)\s]*(?=:\d+:\d+\)?$)/, ''));
-		id = stack.join('\n');
+		const trace = stack.join('\n');
 
-		if (!id) {
+		if (!trace) {
 			throw new Error(
 				'Could not generate a snapshot id from the stack trace. Pass an `id` instead.'
 			);
 		}
+
+		id = hash(trace);
 	}
 
 	const registration = { ...options, id };

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2537,17 +2537,18 @@ export function snapshot(options) {
 		let stack = new Error().stack?.split('\n') ?? [];
 		if (stack[0]?.trim() === 'Error') stack = stack.slice(1);
 
-		// Strip Vite query strings so snapshots survive module invalidation and dependency updates.
-		stack = stack.map((frame) => frame.replace(/\?[^)\s]*(?=:\d+:\d+\)?$)/, ''));
-		const trace = stack.join('\n');
+		// frames above the callsite differ between hydration and client-side re-mounting
+		let frame = stack[1] ?? stack[0];
+		// strip Vite query strings so snapshots survive module invalidation and dependency updates
+		frame = frame?.replace(/\?[^)\s]*(?=:\d+:\d+\)?$)/, '');
 
-		if (!trace) {
+		if (!frame) {
 			throw new Error(
 				'Could not generate a snapshot id from the stack trace. Pass an `id` instead.'
 			);
 		}
 
-		id = hash(trace);
+		id = hash(frame);
 	}
 
 	const registration = { ...options, id };

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -730,7 +730,7 @@ function restore_navigation_snapshot(index, reset_registrations) {
 }
 
 /** @param {Set<SnapshotRegistration>} registrations */
-function reset_navigation_snapshots(registrations) {
+function reset_snapshot_registrations(registrations) {
 	for (const registration of snapshot_registrations) {
 		if (registrations.has(registration)) {
 			registration.reset?.();
@@ -2280,7 +2280,7 @@ async function navigate({
 		restore_snapshot(current_navigation_index);
 		restore_navigation_snapshot(current_history_index, previous_snapshot_registrations);
 	} else {
-		reset_navigation_snapshots(previous_snapshot_registrations);
+		reset_snapshot_registrations(previous_snapshot_registrations);
 	}
 
 	navigating.current = null;
@@ -2518,11 +2518,30 @@ function add_navigation_callback(callbacks, callback) {
 }
 
 /**
+ * @param {string | undefined} stack
+ * @returns {string}
+ */
+function callsite_id(stack) {
+	let frames = stack?.split('\n') ?? [];
+	if (frames[0]?.trim() === 'Error') frames = frames.slice(1);
+
+	// only the callsite frame is stable: frames above it differ between hydration and
+	// re-mounting, and Vite query strings (stripped here) change on module invalidation
+	const frame = frames[1]?.replace(/\?[^)\s]*(?=:\d+:\d+\)?$)/, '');
+
+	if (!frame) {
+		throw new Error('Could not generate a snapshot id from the stack trace. Pass an `id` instead.');
+	}
+
+	return hash(frame);
+}
+
+/**
  * A lifecycle function that captures state before navigating and restores it when traversing history.
  *
  * By default, the snapshot `id` is generated from the call site. Pass an explicit `id` to keep snapshots stable across deployments or distinguish multiple uses of a shared helper.
  *
- * The optional `reset` callback runs when a new history entry is created. Captured values are serialized with the app's transport hook.
+ * The optional `reset` callback runs on navigations where there is no captured value to restore, such as when a new history entry is created. Captured values are serialized with the app's transport hook.
  *
  * `snapshot` must be called during a component initialization. It remains active as long as the component is mounted.
  * @template T
@@ -2536,23 +2555,12 @@ export function snapshot(options) {
 	if (id === undefined) {
 		// restore any lowered third-party limit, else every callsite collapses to one id
 		const limit = Error.stackTraceLimit;
-		if (typeof limit === 'number' && limit < 3) Error.stackTraceLimit = 3;
-		let stack = new Error().stack?.split('\n') ?? [];
-		if (typeof limit === 'number' && limit < 3) Error.stackTraceLimit = limit;
+		const lowered = typeof limit === 'number' && limit < 3;
+		if (lowered) Error.stackTraceLimit = 3;
+		const stack = new Error().stack;
+		if (lowered) Error.stackTraceLimit = limit;
 
-		if (stack[0]?.trim() === 'Error') stack = stack.slice(1);
-
-		// only the callsite frame is stable: frames above it differ between hydration and
-		// re-mounting, and Vite query strings (stripped here) change on module invalidation
-		const frame = stack[1]?.replace(/\?[^)\s]*(?=:\d+:\d+\)?$)/, '');
-
-		if (!frame) {
-			throw new Error(
-				'Could not generate a snapshot id from the stack trace. Pass an `id` instead.'
-			);
-		}
-
-		id = hash(frame);
+		id = callsite_id(stack);
 	}
 
 	const registration = { ...options, id };
@@ -3118,7 +3126,7 @@ async function update_state(intent, state, { replace, persist_state, reset }, ca
 		);
 	}
 
-	reset_navigation_snapshots(previous_snapshot_registrations);
+	reset_snapshot_registrations(previous_snapshot_registrations);
 
 	if (nav) {
 		navigating.current = null;
@@ -3458,8 +3466,6 @@ function _start_router() {
 				: null;
 
 			if (shallow) {
-				const previous_snapshot_registrations = new Set(snapshot_registrations);
-
 				// We don't need to navigate, we just need to update scroll and/or state.
 				// This happens with hash links and `pushState`/`replaceState`. The
 				// exception is if we haven't navigated yet, since we could have
@@ -3480,7 +3486,7 @@ function _start_router() {
 				current_history_index = history_index;
 				current_reset_index = reset_index;
 				if (reset && scroll) scrollTo(scroll.x, scroll.y);
-				restore_navigation_snapshot(current_history_index, previous_snapshot_registrations);
+				restore_navigation_snapshot(current_history_index, snapshot_registrations);
 				return;
 			}
 

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -31,12 +31,11 @@ import {
 } from './constants.js';
 import {
 	capture_navigation_snapshot,
+	current_registrations,
 	delete_navigation_snapshot,
 	init_snapshots,
 	persist_navigation_snapshots,
-	reset_snapshot_registrations,
-	restore_navigation_snapshot,
-	snapshot_registrations
+	restore_navigation_snapshot
 } from './snapshots.js';
 import { validate_page_exports } from '../../utils/exports.js';
 import { noop } from '../../utils/functions.js';
@@ -214,6 +213,8 @@ function reset_scroll_and_focus(url, scroll, reset, active_element) {
 function clear_onward_history(current_history_index, current_navigation_index) {
 	// if we navigated back, then pushed a new state, we can
 	// release memory by pruning the scroll/snapshot lookup
+	// the new entry reuses the first abandoned index, so its slot must start clean
+	delete_navigation_snapshot(current_history_index);
 	let i = current_history_index + 1;
 	while (history_info[i]) {
 		delete history_info[i];
@@ -1958,7 +1959,7 @@ async function navigate({
 	// store this before calling `accept()`, which may change the index
 	const previous_history_index = current_history_index;
 	const previous_navigation_index = current_navigation_index;
-	const previous_snapshot_registrations = new Set(snapshot_registrations);
+	const previous_snapshot_registrations = current_registrations();
 
 	accept();
 
@@ -2238,10 +2239,9 @@ async function navigate({
 
 	if (type === 'popstate') {
 		restore_snapshot(current_navigation_index);
-		restore_navigation_snapshot(current_history_index, previous_snapshot_registrations);
-	} else {
-		reset_snapshot_registrations(previous_snapshot_registrations);
 	}
+	// new and replaced entries have no stored values, so this only resets there
+	restore_navigation_snapshot(current_history_index, previous_snapshot_registrations);
 
 	navigating.current = null;
 
@@ -2907,7 +2907,7 @@ export async function replaceState(url, state) {
  */
 async function update_state(intent, state, { replace, persist_state, reset }, caller) {
 	const url = intent.url;
-	const previous_snapshot_registrations = new Set(snapshot_registrations);
+	const previous_snapshot_registrations = current_registrations();
 
 	if (DEV && !started) {
 		throw new Error(`Cannot call ${caller}(...) before router is initialized`);
@@ -3014,7 +3014,7 @@ async function update_state(intent, state, { replace, persist_state, reset }, ca
 		);
 	}
 
-	reset_snapshot_registrations(previous_snapshot_registrations);
+	restore_navigation_snapshot(current_history_index, previous_snapshot_registrations);
 
 	if (nav) {
 		navigating.current = null;
@@ -3374,7 +3374,7 @@ function _start_router() {
 				current_history_index = history_index;
 				current_reset_index = reset_index;
 				if (reset && scroll) scrollTo(scroll.x, scroll.y);
-				restore_navigation_snapshot(current_history_index, snapshot_registrations);
+				restore_navigation_snapshot(current_history_index, current_registrations());
 				return;
 			}
 

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -26,6 +26,7 @@ import * as devalue from 'devalue';
 import {
 	HISTORY_INFO_KEY,
 	HISTORY_METADATA_KEY,
+	NAVIGATION_SNAPSHOT_KEY,
 	PRELOAD_PRIORITIES,
 	SNAPSHOT_KEY
 } from './constants.js';
@@ -63,6 +64,10 @@ import { init_transport, parse, stringify } from '#app/internal/transport';
  * }} HistoryMetadata
  */
 
+/**
+ * @typedef {{ id: string; capture: () => any; restore: (value: any) => void; reset?: () => void }} SnapshotRegistration
+ */
+
 export { load_css };
 const ICON_REL_ATTRIBUTES = new Set(['icon', 'shortcut icon', 'apple-touch-icon']);
 
@@ -93,6 +98,13 @@ const history_info = storage.get(HISTORY_INFO_KEY) ?? {};
  * @type {Record<string, any[]>}
  */
 const snapshots = storage.get(SNAPSHOT_KEY) ?? {};
+
+// Function snapshots use history indexes so shallow entries have distinct state.
+/** @type {Record<string, Record<string, string>>} */
+const navigation_snapshots = storage.get(NAVIGATION_SNAPSHOT_KEY) ?? {};
+
+/** @type {Set<SnapshotRegistration>} */
+const snapshot_registrations = new Set();
 
 /** @type {Props} */
 let props;
@@ -206,6 +218,7 @@ function clear_onward_history(current_history_index, current_navigation_index) {
 	let i = current_history_index + 1;
 	while (history_info[i]) {
 		delete history_info[i];
+		delete navigation_snapshots[i];
 		i += 1;
 	}
 
@@ -687,12 +700,57 @@ function restore_snapshot(index) {
 	});
 }
 
+/** @param {number} index */
+function capture_navigation_snapshot(index) {
+	if (snapshot_registrations.size === 0) {
+		delete navigation_snapshots[index];
+		return;
+	}
+
+	navigation_snapshots[index] = Object.fromEntries(
+		Array.from(snapshot_registrations, ({ id, capture }) => [id, stringify(capture())])
+	);
+}
+
+/** @param {number} index */
+function delete_navigation_snapshot(index) {
+	delete navigation_snapshots[index];
+}
+
+/**
+ * @param {number} index
+ * @param {Set<SnapshotRegistration>} [reset_registrations]
+ */
+function restore_navigation_snapshot(index, reset_registrations) {
+	const values = navigation_snapshots[index];
+
+	for (const registration of snapshot_registrations) {
+		if (values && Object.hasOwn(values, registration.id)) {
+			registration.restore(parse(values[registration.id]));
+		} else if (reset_registrations?.has(registration)) {
+			registration.reset?.();
+		}
+	}
+}
+
+/** @param {Set<SnapshotRegistration>} registrations */
+function reset_navigation_snapshots(registrations) {
+	for (const registration of snapshot_registrations) {
+		if (registrations.has(registration)) {
+			registration.reset?.();
+		}
+	}
+}
+
 function persist_state() {
 	capture_scroll(current_history_index);
 	storage.set(HISTORY_INFO_KEY, history_info);
 
 	capture_snapshot(current_navigation_index);
 	storage.set(SNAPSHOT_KEY, snapshots);
+
+	capture_navigation_snapshot(current_history_index);
+	storage.set(NAVIGATION_SNAPSHOT_KEY, navigation_snapshots);
 }
 
 /**
@@ -947,6 +1005,7 @@ async function initialize(result, target, should_hydrate) {
 	}
 
 	restore_snapshot(current_navigation_index);
+	restore_navigation_snapshot(current_history_index);
 
 	started = true;
 }
@@ -1943,6 +2002,7 @@ async function navigate({
 	// store this before calling `accept()`, which may change the index
 	const previous_history_index = current_history_index;
 	const previous_navigation_index = current_navigation_index;
+	const previous_snapshot_registrations = new Set(snapshot_registrations);
 
 	accept();
 
@@ -2051,6 +2111,11 @@ async function navigate({
 
 	capture_scroll(previous_history_index);
 	capture_snapshot(previous_navigation_index);
+	if (replace_state) {
+		delete_navigation_snapshot(previous_history_index);
+	} else {
+		capture_navigation_snapshot(previous_history_index);
+	}
 
 	// ensure the url pathname matches the page's trailing slash option
 	if (navigation_result.props.page.url.pathname !== url.pathname) {
@@ -2217,6 +2282,9 @@ async function navigate({
 
 	if (type === 'popstate') {
 		restore_snapshot(current_navigation_index);
+		restore_navigation_snapshot(current_history_index, previous_snapshot_registrations);
+	} else {
+		reset_navigation_snapshots(previous_snapshot_registrations);
 	}
 
 	navigating.current = null;
@@ -2449,6 +2517,59 @@ function add_navigation_callback(callbacks, callback) {
 
 		return () => {
 			callbacks.delete(callback);
+		};
+	});
+}
+
+/**
+ * A lifecycle function that captures state before navigating and restores it when traversing history.
+ *
+ * By default, the snapshot `id` is generated from the call site. Pass an explicit `id` to keep snapshots stable across deployments or distinguish multiple uses of a shared helper.
+ *
+ * The optional `reset` callback runs when a new history entry is created. Captured values are serialized with the app's transport hook.
+ *
+ * `snapshot` must be called during a component initialization. It remains active as long as the component is mounted.
+ * @template T
+ * @param {{ id?: string; capture: () => T; restore: (value: T) => void; reset?: () => void }} options
+ * @returns {void}
+ */
+export function snapshot(options) {
+	if (!BROWSER) return;
+
+	let id = options.id;
+	if (id === undefined) {
+		let stack = new Error().stack?.split('\n') ?? [];
+		if (stack[0]?.trim() === 'Error') stack = stack.slice(1);
+
+		// Strip Vite query strings so snapshots survive module invalidation and dependency updates.
+		stack = stack.map((frame) => frame.replace(/\?[^)\s]*(?=:\d+:\d+\)?$)/, ''));
+		id = stack.join('\n');
+
+		if (!id) {
+			throw new Error(
+				'Could not generate a snapshot id from the stack trace. Pass an `id` instead.'
+			);
+		}
+	}
+
+	const registration = { ...options, id };
+
+	onMount(() => {
+		if (DEV && Array.from(snapshot_registrations).some((snapshot) => snapshot.id === id)) {
+			throw new Error(`A snapshot with id "${id}" is already registered. Pass a unique \`id\`.`);
+		}
+
+		if (started && !is_navigating && !updating) {
+			const values = navigation_snapshots[current_history_index];
+			if (values && Object.hasOwn(values, id)) {
+				registration.restore(parse(values[id]));
+			}
+		}
+
+		snapshot_registrations.add(registration);
+
+		return () => {
+			snapshot_registrations.delete(registration);
 		};
 	});
 }
@@ -2883,6 +3004,7 @@ export async function replaceState(url, state) {
  */
 async function update_state(intent, state, { replace, persist_state, reset }, caller) {
 	const url = intent.url;
+	const previous_snapshot_registrations = new Set(snapshot_registrations);
 
 	if (DEV && !started) {
 		throw new Error(`Cannot call ${caller}(...) before router is initialized`);
@@ -2903,7 +3025,12 @@ async function update_state(intent, state, { replace, persist_state, reset }, ca
 		updating = true;
 	}
 
-	if (!replace) capture_scroll(current_history_index);
+	if (replace) {
+		delete_navigation_snapshot(current_history_index);
+	} else {
+		capture_scroll(current_history_index);
+		capture_navigation_snapshot(current_history_index);
+	}
 	if (reset) current_reset_index += 1;
 
 	// as above, serialize-then-parse to prevent bugs
@@ -2959,33 +3086,37 @@ async function update_state(intent, state, { replace, persist_state, reset }, ca
 		url
 	};
 
-	if (!nav) return;
+	if (nav) {
+		const { activeElement } = document;
 
-	const { activeElement } = document;
+		await settled();
 
-	await settled();
+		if (navigation_token !== nav_token) {
+			// a new navigation happened while we were waiting for the DOM to update, so abort
+			nav.reject(new Error('navigation aborted'));
+			return;
+		}
 
-	if (navigation_token !== nav_token) {
-		// a new navigation happened while we were waiting for the DOM to update, so abort
-		nav.reject(new Error('navigation aborted'));
-		return;
+		reset_scroll_and_focus(url, reset ? null : scroll_state(), reset, activeElement);
+
+		is_navigating = false;
+		nav.fulfil(undefined);
+
+		if (nav.navigation.to) {
+			nav.navigation.to.scroll = scroll_state();
+		}
+
+		after_navigate_callbacks.forEach((fn) =>
+			fn(/** @type {import('@sveltejs/kit').AfterNavigate} */ (nav.navigation))
+		);
 	}
 
-	reset_scroll_and_focus(url, reset ? null : scroll_state(), reset, activeElement);
+	reset_navigation_snapshots(previous_snapshot_registrations);
 
-	is_navigating = false;
-	nav.fulfil(undefined);
-
-	if (nav.navigation.to) {
-		nav.navigation.to.scroll = scroll_state();
+	if (nav) {
+		navigating.current = null;
+		updating = false;
 	}
-
-	after_navigate_callbacks.forEach((fn) =>
-		fn(/** @type {import('@sveltejs/kit').AfterNavigate} */ (nav.navigation))
-	);
-
-	navigating.current = null;
-	updating = false;
 }
 
 /**
@@ -3320,6 +3451,8 @@ function _start_router() {
 				: null;
 
 			if (shallow) {
+				const previous_snapshot_registrations = new Set(snapshot_registrations);
+
 				// We don't need to navigate, we just need to update scroll and/or state.
 				// This happens with hash links and `pushState`/`replaceState`. The
 				// exception is if we haven't navigated yet, since we could have
@@ -3336,9 +3469,11 @@ function _start_router() {
 				update_url(url);
 
 				capture_scroll(current_history_index);
+				capture_navigation_snapshot(current_history_index);
 				current_history_index = history_index;
 				current_reset_index = reset_index;
 				if (reset && scroll) scrollTo(scroll.x, scroll.y);
+				restore_navigation_snapshot(current_history_index, previous_snapshot_registrations);
 				return;
 			}
 

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -26,13 +26,20 @@ import * as devalue from 'devalue';
 import {
 	HISTORY_INFO_KEY,
 	HISTORY_METADATA_KEY,
-	NAVIGATION_SNAPSHOT_KEY,
 	PRELOAD_PRIORITIES,
 	SNAPSHOT_KEY
 } from './constants.js';
+import {
+	capture_navigation_snapshot,
+	delete_navigation_snapshot,
+	init_snapshots,
+	persist_navigation_snapshots,
+	reset_snapshot_registrations,
+	restore_navigation_snapshot,
+	snapshot_registrations
+} from './snapshots.js';
 import { validate_page_exports } from '../../utils/exports.js';
 import { noop } from '../../utils/functions.js';
-import { hash } from '../../utils/hash.js';
 import {
 	INVALIDATED_PARAM,
 	TRAILING_SLASH_PARAM,
@@ -63,10 +70,6 @@ import { init_transport, parse, stringify } from '#app/internal/transport';
  *   persistState: boolean;
  *   resetIndex: number;
  * }} HistoryMetadata
- */
-
-/**
- * @typedef {{ id: string; capture: () => any; restore: (value: any) => void; reset?: () => void }} SnapshotRegistration
  */
 
 export { load_css };
@@ -100,12 +103,7 @@ const history_info = storage.get(HISTORY_INFO_KEY) ?? {};
  */
 const snapshots = storage.get(SNAPSHOT_KEY) ?? {};
 
-// Function snapshots use history indexes so shallow entries have distinct state.
-/** @type {Record<string, Record<string, string>>} */
-const navigation_snapshots = storage.get(NAVIGATION_SNAPSHOT_KEY) ?? {};
-
-/** @type {Set<SnapshotRegistration>} */
-const snapshot_registrations = new Set();
+init_snapshots(() => (started && !is_navigating && !updating ? current_history_index : null));
 
 /** @type {Props} */
 let props;
@@ -219,7 +217,7 @@ function clear_onward_history(current_history_index, current_navigation_index) {
 	let i = current_history_index + 1;
 	while (history_info[i]) {
 		delete history_info[i];
-		delete navigation_snapshots[i];
+		delete_navigation_snapshot(i);
 		i += 1;
 	}
 
@@ -701,43 +699,6 @@ function restore_snapshot(index) {
 	});
 }
 
-/** @param {number} index */
-function capture_navigation_snapshot(index) {
-	if (snapshot_registrations.size === 0) {
-		delete navigation_snapshots[index];
-		return;
-	}
-
-	navigation_snapshots[index] = Object.fromEntries(
-		Array.from(snapshot_registrations, ({ id, capture }) => [id, stringify(capture())])
-	);
-}
-
-/**
- * @param {number} index
- * @param {Set<SnapshotRegistration>} [reset_registrations]
- */
-function restore_navigation_snapshot(index, reset_registrations) {
-	const values = navigation_snapshots[index];
-
-	for (const registration of snapshot_registrations) {
-		if (values && Object.hasOwn(values, registration.id)) {
-			registration.restore(parse(values[registration.id]));
-		} else if (reset_registrations?.has(registration)) {
-			registration.reset?.();
-		}
-	}
-}
-
-/** @param {Set<SnapshotRegistration>} registrations */
-function reset_snapshot_registrations(registrations) {
-	for (const registration of snapshot_registrations) {
-		if (registrations.has(registration)) {
-			registration.reset?.();
-		}
-	}
-}
-
 function persist_state() {
 	capture_scroll(current_history_index);
 	storage.set(HISTORY_INFO_KEY, history_info);
@@ -745,8 +706,7 @@ function persist_state() {
 	capture_snapshot(current_navigation_index);
 	storage.set(SNAPSHOT_KEY, snapshots);
 
-	capture_navigation_snapshot(current_history_index);
-	storage.set(NAVIGATION_SNAPSHOT_KEY, navigation_snapshots);
+	persist_navigation_snapshots(current_history_index);
 }
 
 /**
@@ -2108,7 +2068,7 @@ async function navigate({
 	capture_scroll(previous_history_index);
 	capture_snapshot(previous_navigation_index);
 	if (replace_state) {
-		delete navigation_snapshots[previous_history_index];
+		delete_navigation_snapshot(previous_history_index);
 	} else {
 		capture_navigation_snapshot(previous_history_index);
 	}
@@ -2513,78 +2473,6 @@ function add_navigation_callback(callbacks, callback) {
 
 		return () => {
 			callbacks.delete(callback);
-		};
-	});
-}
-
-/**
- * @param {string | undefined} stack
- * @returns {string}
- */
-function callsite_id(stack) {
-	let frames = stack?.split('\n') ?? [];
-	if (frames[0]?.trim() === 'Error') frames = frames.slice(1);
-
-	// only the callsite frame is stable: frames above it differ between hydration and
-	// re-mounting, and Vite query strings (stripped here) change on module invalidation
-	const frame = frames[1]?.replace(/\?[^)\s]*(?=:\d+:\d+\)?$)/, '');
-
-	if (!frame) {
-		throw new Error('Could not generate a snapshot id from the stack trace. Pass an `id` instead.');
-	}
-
-	return hash(frame);
-}
-
-/**
- * A lifecycle function that captures state before navigating and restores it when traversing history.
- *
- * By default, the snapshot `id` is generated from the call site. Pass an explicit `id` to keep snapshots stable across deployments or distinguish multiple uses of a shared helper.
- *
- * The optional `reset` callback runs on navigations where there is no captured value to restore, such as when a new history entry is created. Captured values are serialized with the app's transport hook.
- *
- * `snapshot` must be called during a component initialization. It remains active as long as the component is mounted.
- * @template T
- * @param {{ id?: string; capture: () => T; restore: (value: T) => void; reset?: () => void }} options
- * @returns {void}
- */
-export function snapshot(options) {
-	if (!BROWSER) return;
-
-	let id = options.id;
-	if (id === undefined) {
-		// restore any lowered third-party limit, else every callsite collapses to one id
-		const limit = Error.stackTraceLimit;
-		const lowered = typeof limit === 'number' && limit < 3;
-		if (lowered) Error.stackTraceLimit = 3;
-		const stack = new Error().stack;
-		if (lowered) Error.stackTraceLimit = limit;
-
-		id = callsite_id(stack);
-	}
-
-	const registration = { ...options, id };
-
-	onMount(() => {
-		if (DEV && Array.from(snapshot_registrations).some((existing) => existing.id === id)) {
-			throw new Error(
-				options.id === undefined
-					? 'snapshot() was called multiple times from the same call site. Pass a unique `id` to distinguish the instances.'
-					: `A snapshot with id "${options.id}" is already registered. Pass a unique \`id\`.`
-			);
-		}
-
-		if (started && !is_navigating && !updating) {
-			const values = navigation_snapshots[current_history_index];
-			if (values && Object.hasOwn(values, id)) {
-				registration.restore(parse(values[id]));
-			}
-		}
-
-		snapshot_registrations.add(registration);
-
-		return () => {
-			snapshot_registrations.delete(registration);
 		};
 	});
 }
@@ -3041,7 +2929,7 @@ async function update_state(intent, state, { replace, persist_state, reset }, ca
 	}
 
 	if (replace) {
-		delete navigation_snapshots[current_history_index];
+		delete_navigation_snapshot(current_history_index);
 	} else {
 		capture_scroll(current_history_index);
 		capture_navigation_snapshot(current_history_index);

--- a/packages/kit/src/runtime/client/constants.js
+++ b/packages/kit/src/runtime/client/constants.js
@@ -1,4 +1,5 @@
 export const SNAPSHOT_KEY = 'sveltekit:snapshot';
+export const NAVIGATION_SNAPSHOT_KEY = 'sveltekit:navigation-snapshot';
 export const HISTORY_INFO_KEY = 'sveltekit:history-info';
 export const HISTORY_METADATA_KEY = 'sveltekit:metadata';
 

--- a/packages/kit/src/runtime/client/snapshots.js
+++ b/packages/kit/src/runtime/client/snapshots.js
@@ -14,7 +14,16 @@ import { parse, stringify } from '#app/internal/transport';
 const navigation_snapshots = storage.get(NAVIGATION_SNAPSHOT_KEY) ?? {};
 
 /** @type {Set<SnapshotRegistration>} */
-export const snapshot_registrations = new Set();
+const snapshot_registrations = new Set();
+
+/**
+ * The registrations mounted right now. Take before navigating and pass to
+ * `restore_navigation_snapshot` — only these are eligible for `reset`.
+ * @returns {Set<SnapshotRegistration>}
+ */
+export function current_registrations() {
+	return new Set(snapshot_registrations);
+}
 
 // injected by client.js: the live history index while the router is idle, null mid-navigation
 /** @type {() => number | null} */
@@ -48,15 +57,6 @@ export function restore_navigation_snapshot(index, reset_registrations) {
 		if (values && Object.hasOwn(values, registration.id)) {
 			registration.restore(parse(values[registration.id]));
 		} else if (reset_registrations?.has(registration)) {
-			registration.reset?.();
-		}
-	}
-}
-
-/** @param {Set<SnapshotRegistration>} registrations */
-export function reset_snapshot_registrations(registrations) {
-	for (const registration of snapshot_registrations) {
-		if (registrations.has(registration)) {
 			registration.reset?.();
 		}
 	}

--- a/packages/kit/src/runtime/client/snapshots.js
+++ b/packages/kit/src/runtime/client/snapshots.js
@@ -1,0 +1,147 @@
+import { BROWSER, DEV } from 'esm-env';
+import { onMount } from 'svelte';
+import * as storage from './session-storage.js';
+import { NAVIGATION_SNAPSHOT_KEY } from './constants.js';
+import { hash } from '../../utils/hash.js';
+import { parse, stringify } from '#app/internal/transport';
+
+/**
+ * @typedef {{ id: string; capture: () => any; restore: (value: any) => void; reset?: () => void }} SnapshotRegistration
+ */
+
+// Function snapshots use history indexes so shallow entries have distinct state.
+/** @type {Record<string, Record<string, string>>} */
+const navigation_snapshots = storage.get(NAVIGATION_SNAPSHOT_KEY) ?? {};
+
+/** @type {Set<SnapshotRegistration>} */
+export const snapshot_registrations = new Set();
+
+// injected by client.js: the live history index while the router is idle, null mid-navigation
+/** @type {() => number | null} */
+let get_idle_history_index = () => null;
+
+/** @param {() => number | null} fn */
+export function init_snapshots(fn) {
+	get_idle_history_index = fn;
+}
+
+/** @param {number} index */
+export function capture_navigation_snapshot(index) {
+	if (snapshot_registrations.size === 0) {
+		delete navigation_snapshots[index];
+		return;
+	}
+
+	navigation_snapshots[index] = Object.fromEntries(
+		Array.from(snapshot_registrations, ({ id, capture }) => [id, stringify(capture())])
+	);
+}
+
+/**
+ * @param {number} index
+ * @param {Set<SnapshotRegistration>} [reset_registrations]
+ */
+export function restore_navigation_snapshot(index, reset_registrations) {
+	const values = navigation_snapshots[index];
+
+	for (const registration of snapshot_registrations) {
+		if (values && Object.hasOwn(values, registration.id)) {
+			registration.restore(parse(values[registration.id]));
+		} else if (reset_registrations?.has(registration)) {
+			registration.reset?.();
+		}
+	}
+}
+
+/** @param {Set<SnapshotRegistration>} registrations */
+export function reset_snapshot_registrations(registrations) {
+	for (const registration of snapshot_registrations) {
+		if (registrations.has(registration)) {
+			registration.reset?.();
+		}
+	}
+}
+
+/** @param {number} index */
+export function delete_navigation_snapshot(index) {
+	delete navigation_snapshots[index];
+}
+
+/** @param {number} index */
+export function persist_navigation_snapshots(index) {
+	capture_navigation_snapshot(index);
+	storage.set(NAVIGATION_SNAPSHOT_KEY, navigation_snapshots);
+}
+
+/**
+ * @param {string | undefined} stack
+ * @returns {string}
+ */
+function callsite_id(stack) {
+	let frames = stack?.split('\n') ?? [];
+	if (frames[0]?.trim() === 'Error') frames = frames.slice(1);
+
+	// only the callsite frame is stable: frames above it differ between hydration and
+	// re-mounting, and Vite query strings (stripped here) change on module invalidation
+	const frame = frames[1]?.replace(/\?[^)\s]*(?=:\d+:\d+\)?$)/, '');
+
+	if (!frame) {
+		throw new Error('Could not generate a snapshot id from the stack trace. Pass an `id` instead.');
+	}
+
+	return hash(frame);
+}
+
+/**
+ * A lifecycle function that captures state before navigating and restores it when traversing history.
+ *
+ * By default, the snapshot `id` is generated from the call site. Pass an explicit `id` to keep snapshots stable across deployments or distinguish multiple uses of a shared helper.
+ *
+ * The optional `reset` callback runs on navigations where there is no captured value to restore, such as when a new history entry is created. Captured values are serialized with the app's transport hook.
+ *
+ * `snapshot` must be called during a component initialization. It remains active as long as the component is mounted.
+ * @template T
+ * @param {{ id?: string; capture: () => T; restore: (value: T) => void; reset?: () => void }} options
+ * @returns {void}
+ */
+export function snapshot(options) {
+	if (!BROWSER) return;
+
+	let id = options.id;
+	if (id === undefined) {
+		// restore any lowered third-party limit, else every callsite collapses to one id
+		const limit = Error.stackTraceLimit;
+		const lowered = typeof limit === 'number' && limit < 3;
+		if (lowered) Error.stackTraceLimit = 3;
+		const stack = new Error().stack;
+		if (lowered) Error.stackTraceLimit = limit;
+
+		id = callsite_id(stack);
+	}
+
+	const registration = { ...options, id };
+
+	onMount(() => {
+		if (DEV && Array.from(snapshot_registrations).some((existing) => existing.id === id)) {
+			throw new Error(
+				options.id === undefined
+					? 'snapshot() was called multiple times from the same call site. Pass a unique `id` to distinguish the instances.'
+					: `A snapshot with id "${options.id}" is already registered. Pass a unique \`id\`.`
+			);
+		}
+
+		const index = get_idle_history_index();
+		if (index !== null) {
+			const values = navigation_snapshots[index];
+			if (values && Object.hasOwn(values, id)) {
+				registration.restore(parse(values[id]));
+			}
+		}
+
+		snapshot_registrations.add(registration);
+
+		return () => {
+			snapshot_registrations.delete(registration);
+		};
+	});
+}

--- a/packages/kit/test/apps/basics/src/routes/snapshot/helper/+layout.svelte
+++ b/packages/kit/test/apps/basics/src/routes/snapshot/helper/+layout.svelte
@@ -1,0 +1,20 @@
+<script>
+	import { snapshot } from '$app/navigation';
+
+	let { children } = $props();
+	let value = $state('');
+
+	snapshot({
+		id: 'snapshot-helper-layout',
+		capture: () => value,
+		restore: (snapshot) => (value = snapshot),
+		reset: () => (value = '')
+	});
+</script>
+
+<label>
+	layout
+	<input data-testid="layout" bind:value />
+</label>
+
+{@render children()}

--- a/packages/kit/test/apps/basics/src/routes/snapshot/helper/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/snapshot/helper/+page.svelte
@@ -9,10 +9,7 @@
 	let order = $state([]);
 
 	snapshot({
-		capture: () => {
-			order.length = 0;
-			return message;
-		},
+		capture: () => message,
 		restore: (value) => {
 			message = value;
 			order.push('restore');

--- a/packages/kit/test/apps/basics/src/routes/snapshot/helper/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/snapshot/helper/+page.svelte
@@ -1,0 +1,55 @@
+<script>
+	import { afterNavigate, goto, snapshot } from '$app/navigation';
+	import { Foo } from '#lib';
+
+	let message = $state('');
+	let manual = $state('');
+	let foo = $state(new Foo('initial'));
+	/** @type {string[]} */
+	let order = $state([]);
+
+	snapshot({
+		capture: () => {
+			order.length = 0;
+			return message;
+		},
+		restore: (value) => {
+			message = value;
+			order.push('restore');
+		}
+	});
+
+	snapshot({
+		id: 'snapshot-helper-manual',
+		capture: () => manual,
+		restore: (value) => (manual = value)
+	});
+
+	snapshot({
+		id: 'snapshot-helper-transport',
+		capture: () => foo,
+		restore: (value) => (foo = value)
+	});
+
+	afterNavigate(() => {
+		order.push('afterNavigate');
+	});
+</script>
+
+<label>
+	default
+	<input data-testid="default" bind:value={message} />
+</label>
+
+<label>
+	manual
+	<input data-testid="manual" bind:value={manual} />
+</label>
+
+<button onclick={() => void goto('', { shallow: true, state: { active: true } })}> shallow </button>
+<button onclick={() => (foo = new Foo('restored'))}>change transport value</button>
+
+<a href="/snapshot/helper/b">b</a>
+
+<p data-testid="transport">{foo.bar()}</p>
+<p data-testid="order">{order.join(',')}</p>

--- a/packages/kit/test/apps/basics/src/routes/snapshot/helper/b/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/snapshot/helper/b/+page.svelte
@@ -1,0 +1,3 @@
+<h1>b</h1>
+
+<a href="/snapshot/helper">a</a>

--- a/packages/kit/test/apps/basics/src/routes/snapshot/stale/Stale.svelte
+++ b/packages/kit/test/apps/basics/src/routes/snapshot/stale/Stale.svelte
@@ -1,0 +1,13 @@
+<script>
+	import { snapshot } from '$app/navigation';
+
+	let value = $state('');
+
+	snapshot({
+		id: 'stale-check',
+		capture: () => value,
+		restore: (v) => (value = v)
+	});
+</script>
+
+<input data-testid="stale-input" bind:value />

--- a/packages/kit/test/apps/basics/src/routes/snapshot/stale/a/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/snapshot/stale/a/+page.svelte
@@ -1,0 +1,1 @@
+<a href="/snapshot/stale/b">b</a>

--- a/packages/kit/test/apps/basics/src/routes/snapshot/stale/b/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/snapshot/stale/b/+page.svelte
@@ -1,0 +1,13 @@
+<script>
+	import Stale from '../Stale.svelte';
+
+	let shown = $state(false);
+</script>
+
+<button data-testid="toggle" onclick={() => (shown = !shown)}>toggle</button>
+
+{#if shown}
+	<Stale />
+{/if}
+
+<a href="/snapshot/stale/a">a</a>

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -1336,6 +1336,50 @@ test.describe('Snapshots', () => {
 
 		await expect(page.locator('[data-testid="order"]')).toHaveText('afterNavigate,restore');
 	});
+
+	test('captures and restores function snapshots', async ({ page, clicknav }) => {
+		await page.goto('/snapshot/helper');
+		await page.locator('[data-testid="default"]').fill('default value');
+		await page.locator('[data-testid="manual"]').fill('manual value');
+		await page.locator('[data-testid="layout"]').fill('layout value');
+
+		await clicknav('[href="/snapshot/helper/b"]');
+		await expect(page.locator('[data-testid="layout"]')).toHaveValue('');
+
+		await page.goBack();
+
+		await expect(page.locator('[data-testid="default"]')).toHaveValue('default value');
+		await expect(page.locator('[data-testid="manual"]')).toHaveValue('manual value');
+		await expect(page.locator('[data-testid="layout"]')).toHaveValue('layout value');
+		await expect(page.locator('[data-testid="order"]')).toHaveText('afterNavigate,restore');
+	});
+
+	test('persists function snapshots with transport support', async ({ page }) => {
+		await page.goto('/snapshot/helper');
+		await page.locator('[data-testid="default"]').fill('reload value');
+		await page.getByRole('button', { name: 'change transport value' }).click();
+
+		await page.reload();
+
+		await expect(page.locator('[data-testid="default"]')).toHaveValue('reload value');
+		await expect(page.locator('[data-testid="transport"]')).toHaveText('restored!');
+		await expect(page.locator('[data-testid="order"]')).toHaveText('afterNavigate,restore');
+	});
+
+	test('captures and restores function snapshots on shallow navigations', async ({ page }) => {
+		await page.goto('/snapshot/helper');
+		const input = page.locator('[data-testid="default"]');
+
+		await input.fill('one');
+		await page.getByRole('button', { name: 'shallow', exact: true }).click();
+		await input.fill('two');
+
+		await page.goBack();
+		await expect(input).toHaveValue('one');
+
+		await page.goForward();
+		await expect(input).toHaveValue('two');
+	});
 });
 
 test.describe('Streaming', () => {

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -1366,6 +1366,33 @@ test.describe('Snapshots', () => {
 		await expect(page.locator('[data-testid="order"]')).toHaveText('afterNavigate,restore');
 	});
 
+	test('starts fresh when a pushed entry reuses an abandoned history index', async ({
+		page,
+		clicknav
+	}) => {
+		await page.goto('/snapshot/stale/a');
+		await clicknav('[href="/snapshot/stale/b"]');
+
+		await page.locator('[data-testid="toggle"]').click();
+		await page.locator('[data-testid="stale-input"]').fill('abandoned value');
+
+		await clicknav('[href="/snapshot/stale/a"]');
+
+		// jump straight back two entries so the abandoned entry is never revisited
+		const index = await page.evaluate(() => history.state['sveltekit:metadata'].historyIndex);
+		await page.evaluate(() => history.go(-2));
+		await page.waitForFunction(
+			(previous) => history.state['sveltekit:metadata'].historyIndex === previous - 2,
+			index
+		);
+		await page.waitForTimeout(200);
+
+		// pushing reuses the abandoned entry's index, whose snapshot must not leak
+		await clicknav('[href="/snapshot/stale/b"]');
+		await page.locator('[data-testid="toggle"]').click();
+		await expect(page.locator('[data-testid="stale-input"]')).toHaveValue('');
+	});
+
 	test('captures and restores function snapshots on shallow navigations', async ({ page }) => {
 		await page.goto('/snapshot/helper');
 		const input = page.locator('[data-testid="default"]');

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -3145,7 +3145,7 @@ declare module '$app/navigation' {
 	 *
 	 * By default, the snapshot `id` is generated from the call site. Pass an explicit `id` to keep snapshots stable across deployments or distinguish multiple uses of a shared helper.
 	 *
-	 * The optional `reset` callback runs when a new history entry is created. Captured values are serialized with the app's transport hook.
+	 * The optional `reset` callback runs on navigations where there is no captured value to restore, such as when a new history entry is created. Captured values are serialized with the app's transport hook.
 	 *
 	 * `snapshot` must be called during a component initialization. It remains active as long as the component is mounted.
 	 * */

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -3141,6 +3141,21 @@ declare module '$app/forms' {
 declare module '$app/navigation' {
 	import type { RouteId } from '$app/types';
 	/**
+	 * A lifecycle function that captures state before navigating and restores it when traversing history.
+	 *
+	 * By default, the snapshot `id` is generated from the call site. Pass an explicit `id` to keep snapshots stable across deployments or distinguish multiple uses of a shared helper.
+	 *
+	 * The optional `reset` callback runs when a new history entry is created. Captured values are serialized with the app's transport hook.
+	 *
+	 * `snapshot` must be called during a component initialization. It remains active as long as the component is mounted.
+	 * */
+	export function snapshot<T>(options: {
+		id?: string;
+		capture: () => T;
+		restore: (value: T) => void;
+		reset?: () => void;
+	}): void;
+	/**
 	 * A lifecycle function that runs the supplied `callback` when the current component mounts, and also whenever we navigate to a URL.
 	 *
 	 * `afterNavigate` must be called during a component initialization. It remains active as long as the component is mounted.


### PR DESCRIPTION
Implements #16670. Default ids hash the callsite's stack frame; a build-time transform (like remote function ids) could replace that later without breaking anything, since ids are just cache keys.

Supersedes #16346: capture happens at beforeunload, where sessionStorage is synchronous and IndexedDB isn't. Structured clone also strips prototypes from transport-class values, so IndexedDB wouldn't remove the need for devalue. Costs `File` snapshots.

Deprecating `export const snapshot` is a separate PR.