### PR TITLE
chore: deprecate `export const snapshot`

### DIFF
--- a/.changeset/snapshot-deprecate.md
+++ b/.changeset/snapshot-deprecate.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+chore: deprecate `export const snapshot` in favour of the `snapshot` helper

--- a/documentation/docs/30-advanced/65-snapshots.md
+++ b/documentation/docs/30-advanced/65-snapshots.md
@@ -6,7 +6,42 @@ Ephemeral DOM state — like scroll positions on sidebars, the content of `<inpu
 
 For example, if the user fills out a form but navigates away and then back before submitting, or if the user refreshes the page, the values they filled in will be lost. In cases where it's valuable to preserve that input, you can take a _snapshot_ of DOM state, which can then be restored if the user navigates back.
 
-To do this, export a `snapshot` object with `capture` and `restore` methods from a `+page.svelte` or `+layout.svelte`:
+To do this, call `snapshot` from `$app/navigation` during component initialization:
+
+```svelte
+<!--- file: +page.svelte --->
+<script>
+	import { snapshot } from '$app/navigation';
+
+	let comment = $state('');
+
+	snapshot({
+		capture: () => comment,
+		restore: (value) => (comment = value)
+	});
+</script>
+
+<form method="POST">
+	<label for="comment">Comment</label>
+	<textarea id="comment" bind:value={comment} />
+	<button>Post comment</button>
+</form>
+```
+
+When you navigate away from this page — including via [shallow routing](shallow-routing) — the `capture` function is called immediately before the page updates, and the returned value is associated with the current entry in the browser's history stack. If you navigate back, the `restore` function is called with the stored value as soon as the page is updated.
+
+By default, the snapshot `id` is generated from the call site. Pass an explicit `id` to keep snapshots stable across deployments or distinguish multiple uses of a shared helper.
+
+The optional `reset` callback runs on navigations where there is no captured value to restore, such as when a new history entry is created.
+
+Captured values are serialized with [devalue](https://github.com/sveltejs/devalue), which handles JSON as well as types like `Date` and `Map`, and values handled by your [`transport`](hooks#Universal-hooks-transport) hook. The serialized data is persisted to `sessionStorage`, which allows the state to be restored when the page is reloaded, or when the user navigates back from a different site.
+
+> [!NOTE] Avoid returning very large objects from `capture` — once captured, objects will be retained in memory for the duration of the session, and in extreme cases may be too large to persist to `sessionStorage`.
+
+## export const snapshot
+
+> [!LEGACY]
+> Previously, snapshots were created by exporting a `snapshot` object with `capture` and `restore` methods from a `+page.svelte` or `+layout.svelte`. This form is deprecated in favour of the `snapshot` helper, which can be called from any component.
 
 ```svelte
 <!--- file: +page.svelte --->
@@ -19,16 +54,6 @@ To do this, export a `snapshot` object with `capture` and `restore` methods from
 		restore: (value) => comment = value
 	};
 </script>
-
-<form method="POST">
-	<label for="comment">Comment</label>
-	<textarea id="comment" bind:value={comment} />
-	<button>Post comment</button>
-</form>
 ```
 
-When you navigate away from this page, the `capture` function is called immediately before the page updates, and the returned value is associated with the current entry in the browser's history stack. If you navigate back, the `restore` function is called with the stored value as soon as the page is updated.
-
-The data must be serializable as JSON so that it can be persisted to `sessionStorage`. This allows the state to be restored when the page is reloaded, or when the user navigates back from a different site.
-
-> [!NOTE] Avoid returning very large objects from `capture` — once captured, objects will be retained in memory for the duration of the session, and in extreme cases may be too large to persist to `sessionStorage`.
+Values captured this way are serialized as JSON, and shallow navigations do not capture them.

--- a/documentation/docs/30-advanced/65-snapshots.md
+++ b/documentation/docs/30-advanced/65-snapshots.md
@@ -30,7 +30,15 @@ To do this, call `snapshot` from `$app/navigation` during component initializati
 
 When you navigate away from this page — including via [shallow routing](shallow-routing) — the `capture` function is called immediately before the page updates, and the returned value is associated with the current entry in the browser's history stack. If you navigate back, the `restore` function is called with the stored value as soon as the page is updated.
 
-By default, the snapshot `id` is generated from the call site. Pass an explicit `id` to keep snapshots stable across deployments or distinguish multiple uses of a shared helper.
+Snapshots must have a unique ID in order to survive across component remounts and page reloads. By default, this is generated from the stack trace when `snapshot(...)` is called, but you can also explicitly provide an `id` to (for example) keep snapshots stable across deployments, even if the stack trace differs because of changes to the source code, or to distinguish snapshots created via a shared wrapper function or in multiple instances of the same component:
+
+```js
+snapshot({
+	+++id: 'comment',+++
+	capture: () => comment,
+	restore: (value) => (comment = value)
+});
+```
 
 The optional `reset` callback runs on navigations where there is no captured value to restore, such as when a new history entry is created.
 

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -232,6 +232,7 @@ function update_types(config, routes, route, root, to_delete = new Set()) {
 			'type OptionalUnion<U extends Record<string, any>, A extends keyof U = U extends U ? keyof U : never> = U extends unknown ? { [P in Exclude<A, keyof U>]?: never } & U : never;',
 
 			// Re-export `Snapshot` from @sveltejs/kit — in future we could use this to infer <T> from the return type of `snapshot.capture`
+			'/** @deprecated Use the `snapshot` helper from `$app/navigation` instead. */',
 			'export type Snapshot<T = any> = Kit.Snapshot<T>;',
 
 			'export type ErrorProps = { error: App.Error };'

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -2009,6 +2009,7 @@ export type SubmitFunction<
 
 /**
  * The type of `export const snapshot` exported from a page or layout component.
+ * @deprecated Use the [`snapshot`](https://svelte.dev/docs/kit/$app-navigation#snapshot) helper from `$app/navigation` instead.
  */
 export interface Snapshot<T = any> {
 	capture: () => T;

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -99,6 +99,7 @@ const history_info = storage.get(HISTORY_INFO_KEY) ?? {};
 /**
  * navigation index -> any
  * @type {Record<string, any[]>}
+ * @deprecated TODO 4.0 get rid of this
  */
 const snapshots = storage.get(SNAPSHOT_KEY) ?? {};
 
@@ -688,7 +689,10 @@ function reset_invalidation() {
 
 let warned_snapshot_export = false;
 
-/** @param {number} index */
+/**
+ * @param {number} index
+ * @deprecated TODO 4.0 get rid of this
+ */
 function capture_snapshot(index) {
 	if (props.components.some((c) => c?.snapshot)) {
 		if (DEV && !warned_snapshot_export) {
@@ -701,7 +705,10 @@ function capture_snapshot(index) {
 	}
 }
 
-/** @param {number} index */
+/**
+ * @param {number} index
+ * @deprecated TODO 4.0 get rid of this
+ */
 function restore_snapshot(index) {
 	snapshots[index]?.forEach((value, i) => {
 		props.components[i]?.snapshot?.restore(value);

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -686,9 +686,17 @@ function reset_invalidation() {
 	force_invalidation = false;
 }
 
+let warned_snapshot_export = false;
+
 /** @param {number} index */
 function capture_snapshot(index) {
 	if (props.components.some((c) => c?.snapshot)) {
+		if (DEV && !warned_snapshot_export) {
+			warned_snapshot_export = true;
+			console.warn(
+				'`export const snapshot` is deprecated. Use the `snapshot` helper from `$app/navigation` instead.'
+			);
+		}
 		snapshots[index] = props.components.map((c) => c?.snapshot?.capture());
 	}
 }

--- a/packages/kit/src/runtime/props.svelte.js
+++ b/packages/kit/src/runtime/props.svelte.js
@@ -12,6 +12,7 @@ export class Props {
 	 * that currently live on the page — used for capturing and restoring snapshots.
 	 * It's updated/manipulated through `bind:this` in `Root.svelte`.
 	 * @type {Array<Record<string, any>>}
+	 * @deprecated only used for `export const snapshot` — TODO 4.0 get rid
 	 */
 	components = [];
 

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1966,6 +1966,7 @@ declare module '@sveltejs/kit' {
 
 	/**
 	 * The type of `export const snapshot` exported from a page or layout component.
+	 * @deprecated Use the [`snapshot`](https://svelte.dev/docs/kit/$app-navigation#snapshot) helper from `$app/navigation` instead.
 	 */
 	export interface Snapshot<T = any> {
 		capture: () => T;


### PR DESCRIPTION
Completes the deprecation half of #16670.