### PR TITLE
docs: use code fence

### DIFF
--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -467,7 +467,10 @@ export interface KitConfig {
 		 *
 		 * CSRF checks only apply in production, not in local development.
 		 * @default []
-		 * @example ['https://checkout.stripe.com', 'https://accounts.google.com']
+		 * @example
+		 * ```js
+		 * ['https://checkout.stripe.com', 'https://accounts.google.com']
+		 * ```
 		 */
 		trustedOrigins?: string[];
 	};

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -439,7 +439,10 @@ declare module '@sveltejs/kit' {
 			 *
 			 * CSRF checks only apply in production, not in local development.
 			 * @default []
-			 * @example ['https://checkout.stripe.com', 'https://accounts.google.com']
+			 * @example
+			 * ```js
+			 * ['https://checkout.stripe.com', 'https://accounts.google.com']
+			 * ```
 			 */
 			trustedOrigins?: string[];
 		};


### PR DESCRIPTION
using a code fence in the example avoids shiki from rendering them as actual clickable links, which prevents our static site generator from erroring on them. The actual type hover in the IDE looks the exact same.