### PR TITLE
chore: fix type resolution for @sveltejs/kit/params

### DIFF
--- a/packages/kit/src/runtime/client/types.d.ts
+++ b/packages/kit/src/runtime/client/types.d.ts
@@ -8,7 +8,7 @@ import {
 	TrailingSlash,
 	Uses
 } from 'types';
-import { ParamMatcher } from '@sveltejs/kit';
+import { ParamMatcher } from '@sveltejs/kit/params';
 import { Page } from '$app/state';
 import { RenderNode } from '../props.svelte.js';
 

--- a/packages/kit/tsconfig.json
+++ b/packages/kit/tsconfig.json
@@ -9,6 +9,7 @@
 		"paths": {
 			"@sveltejs/kit": ["./src/exports/public.d.ts"],
 			"@sveltejs/kit/env": ["./src/exports/env/index.js"],
+			"@sveltejs/kit/params": ["./src/exports/params/public.d.ts"],
 			"@sveltejs/kit/vite": ["./src/exports/vite/index.js"],
 			"@sveltejs/kit/node": ["./src/exports/node/index.js"],
 			"@sveltejs/kit/internal": ["./src/exports/internal/index.js"],


### PR DESCRIPTION
version-3 lint-all is red since #16716. The new `@sveltejs/kit/params` module was missing from the tsconfig `paths` map, and one import still pointed at the old location.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.