### PR TITLE
chore: fix changesets release action

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,5 +9,6 @@
 	"access": "public",
 	"baseBranch": "version-3",
 	"bumpVersionsWithWorkspaceProtocolOnly": true,
-	"ignore": ["!(@sveltejs/*)"]
+	"ignore": ["!(@sveltejs/*)"],
+	"format": false
 }


### PR DESCRIPTION
changesets was trying to format the changelog files but we have ignored them in the oxfmt config https://github.com/sveltejs/kit/actions/runs/31478406211/job/93737461629#step:6:129

This PR disables the "auto-detect formatter and format" steps changesets tries to execute. Docs here https://changesets.dev/guide/config#format