### PR TITLE
chore: dedupe build error tests

### DIFF
--- a/packages/kit/test/build-errors/package.json
+++ b/packages/kit/test/build-errors/package.json
@@ -5,7 +5,7 @@
 	"scripts": {
 		"test": "pnpm test:build",
 		"test:build": "vitest run",
-		"test:cross-platform:build": "node -e \"process.platform === 'linux' && process.exit(0)\" || pnpm test:build"
+		"test:cross-platform:build": "node -e \"process.exit(process.platform === 'linux' ? 0 : 1)\" || pnpm test:build"
 	},
 	"type": "module",
 	"devDependencies": {

--- a/packages/kit/test/build-errors/package.json
+++ b/packages/kit/test/build-errors/package.json
@@ -5,7 +5,7 @@
 	"scripts": {
 		"test": "pnpm test:build",
 		"test:build": "vitest run",
-		"test:cross-platform:build": "pnpm test:build"
+		"test:cross-platform:build": "node -e \"process.platform === 'linux' && process.exit(0)\" || pnpm test:build"
 	},
 	"type": "module",
 	"devDependencies": {


### PR DESCRIPTION
The build error tests are already run on linux in the `test-kit` job. There's no need to run them again on linux with the cross-platform firefox build job