### PR TITLE
breaking: remove `#lib` definition from `paths`

### DIFF
--- a/.changeset/light-apples-sleep.md
+++ b/.changeset/light-apples-sleep.md
@@ -1,0 +1,6 @@
+---
+"@sveltejs/kit": major
+---
+
+breaking: remove `#lib` definition from `paths`; requires explicit module extensions as a result
+  

--- a/documentation/docs/20-core-concepts/20-load.md
+++ b/documentation/docs/20-core-concepts/20-load.md
@@ -51,13 +51,13 @@ A more realistic version of your blog post's `load` function, that only runs on 
 ```js
 /// file: src/routes/blog/[slug]/+page.server.js
 // @filename: ambient.d.ts
-declare module '#lib/server/database' {
+declare module '#lib/server/database.js' {
 	export function getPost(slug: string): Promise<{ title: string, content: string }>
 }
 
 // @filename: index.js
 // ---cut---
-import * as db from '#lib/server/database';
+import * as db from '#lib/server/database.js';
 
 /** @type {import('./$types').PageServerLoad} */
 export async function load({ params }) {
@@ -76,13 +76,13 @@ Your `+layout.svelte` files can also load data, via `+layout.js` or `+layout.ser
 ```js
 /// file: src/routes/blog/[slug]/+layout.server.js
 // @filename: ambient.d.ts
-declare module '#lib/server/database' {
+declare module '#lib/server/database.js' {
 	export function getPostSummaries(): Promise<Array<{ title: string, slug: string }>>
 }
 
 // @filename: index.js
 // ---cut---
-import * as db from '#lib/server/database';
+import * as db from '#lib/server/database.js';
 
 /** @type {import('./$types').LayoutServerLoad} */
 export async function load() {
@@ -297,13 +297,13 @@ A server `load` function can get [`cookies`](@sveltejs-kit#Cookies) as shown bel
 ```js
 /// file: src/routes/+layout.server.js
 // @filename: ambient.d.ts
-declare module '#lib/server/database' {
+declare module '#lib/server/database.js' {
 	export function getUser(sessionid: string | undefined): Promise<{ name: string, avatar: string }>
 }
 
 // @filename: index.js
 // ---cut---
-import * as db from '#lib/server/database';
+import * as db from '#lib/server/database.js';
 
 /** @type {import('./$types').LayoutServerLoad} */
 export async function load({ cookies }) {
@@ -578,13 +578,13 @@ For example, given a pair of `load` functions like these...
 ```js
 /// file: src/routes/blog/[slug]/+page.server.js
 // @filename: ambient.d.ts
-declare module '#lib/server/database' {
+declare module '#lib/server/database.js' {
 	export function getPost(slug: string): Promise<{ title: string, content: string }>
 }
 
 // @filename: index.js
 // ---cut---
-import * as db from '#lib/server/database';
+import * as db from '#lib/server/database.js';
 
 /** @type {import('./$types').PageServerLoad} */
 export async function load({ params }) {
@@ -597,13 +597,13 @@ export async function load({ params }) {
 ```js
 /// file: src/routes/blog/[slug]/+layout.server.js
 // @filename: ambient.d.ts
-declare module '#lib/server/database' {
+declare module '#lib/server/database.js' {
 	export function getPostSummaries(): Promise<Array<{ title: string, slug: string }>>
 }
 
 // @filename: index.js
 // ---cut---
-import * as db from '#lib/server/database';
+import * as db from '#lib/server/database.js';
 
 /** @type {import('./$types').LayoutServerLoad} */
 export async function load() {
@@ -756,7 +756,7 @@ Now, you can call `requireLogin` in any `load` function (or [form action](form-a
 /// file: +page.server.js
 // @filename: ambient.d.ts
 
-declare module '#lib/server/auth' {
+declare module '#lib/server/auth.js' {
 	interface User {
 		name: string;
 	}
@@ -766,7 +766,7 @@ declare module '#lib/server/auth' {
 
 // @filename: index.ts
 // ---cut---
-import { requireLogin } from '#lib/server/auth';
+import { requireLogin } from '#lib/server/auth.js';
 
 export function load() {
 	const user = requireLogin();

--- a/documentation/docs/20-core-concepts/30-form-actions.md
+++ b/documentation/docs/20-core-concepts/30-form-actions.md
@@ -109,11 +109,11 @@ Each action receives a `RequestEvent` object, allowing you to read the data with
 ```js
 /// file: src/routes/login/+page.server.js
 // @filename: ambient.d.ts
-declare module '#lib/server/db';
+declare module '#lib/server/db.js';
 
 // @filename: index.js
 // ---cut---
-import * as db from '#lib/server/db';
+import * as db from '#lib/server/db.js';
 
 /** @type {import('./$types').PageServerLoad} */
 export async function load({ cookies }) {
@@ -172,12 +172,12 @@ When using `use:enhance` (or making a `fetch` request with the `accept: applicat
 ```js
 /// file: src/routes/login/+page.server.js
 // @filename: ambient.d.ts
-declare module '#lib/server/db';
+declare module '#lib/server/db.js';
 
 // @filename: index.js
 // ---cut---
 +++import { fail } from '@sveltejs/kit';+++
-import * as db from '#lib/server/db';
+import * as db from '#lib/server/db.js';
 
 /** @satisfies {import('./$types').Actions} */
 export const actions = {
@@ -236,12 +236,12 @@ Redirects (and errors) work exactly the same as in [`load`](load#Redirects):
 // @errors: 2345
 /// file: src/routes/login/+page.server.js
 // @filename: ambient.d.ts
-declare module '#lib/server/db';
+declare module '#lib/server/db.js';
 
 // @filename: index.js
 // ---cut---
 import { fail, +++redirect+++ } from '@sveltejs/kit';
-import * as db from '#lib/server/db';
+import * as db from '#lib/server/db.js';
 
 /** @satisfies {import('./$types').Actions} */
 export const actions = {

--- a/documentation/docs/20-core-concepts/50-state-management.md
+++ b/documentation/docs/20-core-concepts/50-state-management.md
@@ -45,13 +45,13 @@ For the same reason, your `load` functions should be _pure_ — no side-effects 
 ```js
 /// file: +page.js
 // @filename: ambient.d.ts
-declare module '#lib/user' {
+declare module '#lib/user.js' {
 	export const user: { set: (value: any) => void };
 }
 
 // @filename: index.js
 // ---cut---
-import { user } from '#lib/user';
+import { user } from '#lib/user.js';
 
 /** @type {import('./$types').PageLoad} */
 export async function load({ fetch }) {

--- a/documentation/docs/20-core-concepts/60-remote-functions.md
+++ b/documentation/docs/20-core-concepts/60-remote-functions.md
@@ -46,13 +46,13 @@ The `query` function allows you to read dynamic data from the server.
 ```js
 /// file: src/routes/blog/data.remote.js
 // @filename: ambient.d.ts
-declare module '#lib/server/database' {
+declare module '#lib/server/database.js' {
 	export function sql(strings: TemplateStringsArray, ...values: any[]): Promise<any[]>;
 }
 // @filename: index.js
 // ---cut---
 import { query } from '$app/server';
-import * as db from '#lib/server/database';
+import * as db from '#lib/server/database.js';
 
 export const getPosts = query(async () => {
 	const posts = await db.sql`
@@ -66,7 +66,7 @@ export const getPosts = query(async () => {
 });
 ```
 
-> [!NOTE] Throughout this page, you'll see imports from fictional modules like `#lib/server/database` and `#lib/server/auth`. These are purely for illustrative purposes — you can use whatever database client and auth setup you like.
+> [!NOTE] Throughout this page, you'll see imports from fictional modules like `#lib/server/database.js` and `#lib/server/auth.js`. These are purely for illustrative purposes — you can use whatever database client and auth setup you like.
 >
 > The `db.sql` function above is a [tagged template function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates) that escapes any interpolated values.
 
@@ -139,7 +139,7 @@ Since `getPost` exposes an HTTP endpoint, it's important to validate this argume
 ```js
 /// file: src/routes/blog/data.remote.js
 // @filename: ambient.d.ts
-declare module '#lib/server/database' {
+declare module '#lib/server/database.js' {
 	export function sql(strings: TemplateStringsArray, ...values: any[]): Promise<any[]>;
 }
 // @filename: index.js
@@ -147,7 +147,7 @@ declare module '#lib/server/database' {
 import * as v from 'valibot';
 import { error } from '@sveltejs/kit';
 import { query } from '$app/server';
-import * as db from '#lib/server/database';
+import * as db from '#lib/server/database.js';
 
 export const getPosts = query(async () => { /* ... */ });
 
@@ -211,14 +211,14 @@ On the server, the callback receives an array of the arguments the function was 
 ```js
 /// file: weather.remote.js
 // @filename: ambient.d.ts
-declare module '#lib/server/database' {
+declare module '#lib/server/database.js' {
 	export function sql(strings: TemplateStringsArray, ...values: any[]): Promise<any[]>;
 }
 // @filename: index.js
 // ---cut---
 import * as v from 'valibot';
 import { query } from '$app/server';
-import * as db from '#lib/server/database';
+import * as db from '#lib/server/database.js';
 
 export const getWeather = query.batch(v.string(), async (cityIds) => {
 	const weather = await db.sql`
@@ -323,11 +323,11 @@ The `form` function makes it easy to write data to the server. It takes a callba
 ```ts
 /// file: src/routes/blog/data.remote.js
 // @filename: ambient.d.ts
-declare module '#lib/server/database' {
+declare module '#lib/server/database.js' {
 	export function sql(strings: TemplateStringsArray, ...values: any[]): Promise<any[]>;
 }
 
-declare module '#lib/server/auth' {
+declare module '#lib/server/auth.js' {
 	interface User {
 		name: string;
 	}
@@ -342,8 +342,8 @@ declare module '#lib/server/auth' {
 import * as v from 'valibot';
 import { error, redirect } from '@sveltejs/kit';
 import { query, form } from '$app/server';
-import * as db from '#lib/server/database';
-import * as auth from '#lib/server/auth';
+import * as db from '#lib/server/database.js';
+import * as auth from '#lib/server/auth.js';
 
 export const getPosts = query(async () => { /* ... */ });
 
@@ -568,7 +568,7 @@ In addition to declarative schema validation, you can programmatically mark fiel
 // @errors: 18046
 /// file: src/routes/shop/data.remote.js
 // @filename: ambient.d.ts
-declare module '#lib/server/database' {
+declare module '#lib/server/database.js' {
 	export function buy(qty: number): Promise<void>
 }
 // @filename: index.js
@@ -576,7 +576,7 @@ declare module '#lib/server/database' {
 import * as v from 'valibot';
 import { invalid } from '@sveltejs/kit';
 import { form } from '$app/server';
-import * as db from '#lib/server/database';
+import * as db from '#lib/server/database.js';
 
 export const buyHotcakes = form(
 	v.object({
@@ -739,11 +739,11 @@ The example above uses [`redirect(...)`](@sveltejs-kit#redirect), which sends th
 ```ts
 /// file: src/routes/blog/data.remote.js
 // @filename: ambient.d.ts
-declare module '#lib/server/database' {
+declare module '#lib/server/database.js' {
 	export function sql(strings: TemplateStringsArray, ...values: any[]): Promise<any[]>;
 }
 
-declare module '#lib/server/auth' {
+declare module '#lib/server/auth.js' {
 	interface User {
 		name: string;
 	}
@@ -757,8 +757,8 @@ declare module '#lib/server/auth' {
 import * as v from 'valibot';
 import { error, redirect } from '@sveltejs/kit';
 import { query, form } from '$app/server';
-import * as db from '#lib/server/database';
-import * as auth from '#lib/server/auth';
+import * as db from '#lib/server/database.js';
+import * as auth from '#lib/server/auth.js';
 
 export const getPosts = query(async () => { /* ... */ });
 
@@ -806,7 +806,7 @@ We can customize what happens when the form is submitted with the `enhance` meth
 <!--- file: src/routes/blog/new/+page.svelte --->
 <script>
 	import { createPost } from '../data.remote';
-	import { showToast } from '#lib/toast';
+	import { showToast } from '#lib/toast.js';
 </script>
 
 <h1>Create a new post</h1>
@@ -917,14 +917,14 @@ As with `query` and `form`, if the function accepts an argument, it should be [v
 ```ts
 /// file: likes.remote.js
 // @filename: ambient.d.ts
-declare module '#lib/server/database' {
+declare module '#lib/server/database.js' {
 	export function sql(strings: TemplateStringsArray, ...values: any[]): Promise<any[]>;
 }
 // @filename: index.js
 // ---cut---
 import * as v from 'valibot';
 import { query, command } from '$app/server';
-import * as db from '#lib/server/database';
+import * as db from '#lib/server/database.js';
 
 export const getLikes = query(v.string(), async (id) => {
 	const [row] = await db.sql`
@@ -951,7 +951,7 @@ Now simply call `addLike`, from (for example) an event handler:
 <!--- file: +page.svelte --->
 <script>
 	import { getLikes, addLike } from './likes.remote';
-	import { showToast } from '#lib/toast';
+	import { showToast } from '#lib/toast.js';
 
 	let { item } = $props();
 </script>
@@ -1132,13 +1132,13 @@ The `prerender` function is similar to `query`, except that it will be invoked a
 ```js
 /// file: src/routes/blog/data.remote.js
 // @filename: ambient.d.ts
-declare module '#lib/server/database' {
+declare module '#lib/server/database.js' {
 	export function sql(strings: TemplateStringsArray, ...values: any[]): Promise<any[]>;
 }
 // @filename: index.js
 // ---cut---
 import { prerender } from '$app/server';
-import * as db from '#lib/server/database';
+import * as db from '#lib/server/database.js';
 
 export const getPosts = prerender(async () => {
 	const posts = await db.sql`
@@ -1163,7 +1163,7 @@ As with queries, prerender functions can accept an argument, which should be [va
 ```js
 /// file: src/routes/blog/data.remote.js
 // @filename: ambient.d.ts
-declare module '#lib/server/database' {
+declare module '#lib/server/database.js' {
 	export function sql(strings: TemplateStringsArray, ...values: any[]): Promise<any[]>;
 }
 // @filename: index.js
@@ -1171,7 +1171,7 @@ declare module '#lib/server/database' {
 import * as v from 'valibot';
 import { error } from '@sveltejs/kit';
 import { prerender } from '$app/server';
-import * as db from '#lib/server/database';
+import * as db from '#lib/server/database.js';
 
 export const getPosts = prerender(async () => { /* ... */ });
 
@@ -1277,14 +1277,14 @@ interface User {
 	avatar: string;
 }
 
-declare module '#lib/server/database' {
+declare module '#lib/server/database.js' {
 	export function findUser(sessionId: string | undefined): Promise<User | null>;
 }
 
 // @filename: index.js
 // ---cut---
 import { getRequestEvent, query } from '$app/server';
-import { findUser } from '#lib/server/database';
+import { findUser } from '#lib/server/database.js';
 
 export const getProfile = query(async () => {
 	const user = await getUser();

--- a/documentation/docs/25-build-and-deploy/10-building-your-app.md
+++ b/documentation/docs/25-build-and-deploy/10-building-your-app.md
@@ -14,7 +14,7 @@ SvelteKit will load your `+page/layout(.server).js` files (and all files they im
 
 ```js
 +++import { building } from '$app/env';+++
-import { initialiseDatabase } from '#lib/server/database';
+import { initialiseDatabase } from '#lib/server/database.js';
 
 +++if (!building) {+++
 	initialiseDatabase();

--- a/documentation/docs/30-advanced/10-advanced-routing.md
+++ b/documentation/docs/30-advanced/10-advanced-routing.md
@@ -301,12 +301,12 @@ Not all use cases are suited for layout grouping, nor should you feel compelled 
 ```js
 /// file: src/routes/nested/route/+layout.js
 // @filename: ambient.d.ts
-declare module "#lib/reusable-load-function" {
+declare module "#lib/reusable-load-function.js" {
 	export function reusableLoad(event: import('@sveltejs/kit').LoadEvent): Promise<Record<string, any>>;
 }
 // @filename: index.js
 // ---cut---
-import { reusableLoad } from '#lib/reusable-load-function';
+import { reusableLoad } from '#lib/reusable-load-function.js';
 
 /** @type {import('./$types').PageLoad} */
 export function load(event) {

--- a/documentation/docs/30-advanced/20-hooks.md
+++ b/documentation/docs/30-advanced/20-hooks.md
@@ -294,7 +294,7 @@ This function runs once, when the server is created or the app starts in the bro
 ```js
 // @errors: 2307
 /// file: src/hooks.server.js
-import * as db from '#lib/server/database';
+import * as db from '#lib/server/database.js';
 
 /** @type {import('@sveltejs/kit').ServerInit} */
 export async function init() {
@@ -367,7 +367,7 @@ This is a collection of _transporters_, which allow you to pass custom types —
 ```js
 // @errors: 2307
 /// file: src/hooks.js
-import { Vector } from '#lib/math';
+import { Vector } from '#lib/math.js';
 
 /** @type {import('@sveltejs/kit').Transport} */
 export const transport = {

--- a/documentation/docs/30-advanced/25-errors.md
+++ b/documentation/docs/30-advanced/25-errors.md
@@ -17,14 +17,14 @@ An _app_ error is one created with the [`error`](@sveltejs-kit#error) helper imp
 ```js
 /// file: src/routes/blog/[slug]/+page.server.js
 // @filename: ambient.d.ts
-declare module '#lib/server/database' {
+declare module '#lib/server/database.js' {
 	export function getPost(slug: string): Promise<{ title: string, content: string } | undefined>
 }
 
 // @filename: index.js
 // ---cut---
 import { error } from '@sveltejs/kit';
-import * as db from '#lib/server/database';
+import * as db from '#lib/server/database.js';
 
 /** @type {import('./$types').PageServerLoad} */
 export async function load({ params }) {

--- a/documentation/docs/30-advanced/68-observability.md
+++ b/documentation/docs/30-advanced/68-observability.md
@@ -43,14 +43,14 @@ SvelteKit provides access to the `root` span and the `current` span on the reque
 /// file: #lib/authenticate.ts
 
 // @filename: ambient.d.ts
-declare module '#lib/auth-core' {
+declare module '#lib/auth-core.js' {
 	export function getAuthenticatedUser(): Promise<{ id: string }>
 }
 
 // @filename: index.js
 // ---cut---
 import { getRequestEvent } from '$app/server';
-import { getAuthenticatedUser } from '#lib/auth-core';
+import { getAuthenticatedUser } from '#lib/auth-core.js';
 
 async function authenticate() {
 	const user = await getAuthenticatedUser();

--- a/documentation/docs/60-appendix/35-migrating-to-sveltekit-3.md
+++ b/documentation/docs/60-appendix/35-migrating-to-sveltekit-3.md
@@ -83,7 +83,12 @@ The `$lib` alias is no longer generated automatically by SvelteKit. It is replac
 }
 ```
 
-...and replace `$lib` with `#lib` across your codebase.
+...and replace `$lib` with `#lib` across your codebase. Note that you will also have to add the module extensions (e.g. `.js` or `.ts`) to these imports.
+
+```js
+---import { foo } from '$lib/foo';--- 
++++import { foo } from '#lib/foo.js';+++ 
+```
 
 ## `$app/environment` (renamed)
 

--- a/packages/kit/src/core/sync/write_tsconfig/index.js
+++ b/packages/kit/src/core/sync/write_tsconfig/index.js
@@ -6,7 +6,6 @@ import { styleText } from 'node:util';
 import { write_if_changed } from '../utils.js';
 import {
 	ESSENTIAL_OPTIONS,
-	get_subpath_imports,
 	normalize_config,
 	RECOMMENDED_OPTIONS,
 	remove_trailing_slashstar
@@ -243,8 +242,7 @@ const alias_value = /^(.+?)((\/\*)|(\.\w+))?$/;
  */
 function get_paths(config, root) {
 	const alias = {
-		...config.alias,
-		...get_subpath_imports(root)
+		...config.alias
 	};
 
 	/** @type {Record<string, string[]>} */

--- a/packages/kit/src/core/sync/write_tsconfig/utils.js
+++ b/packages/kit/src/core/sync/write_tsconfig/utils.js
@@ -1,5 +1,4 @@
 import path from 'node:path';
-import { normalize_import_value, read_package_imports } from '../../../utils/imports.js';
 import { posixify } from '../../../utils/os.js';
 
 /**
@@ -75,27 +74,4 @@ export function remove_trailing_slashstar(file) {
 	} else {
 		return file;
 	}
-}
-
-/**
- * @param {string} root
- */
-export function get_subpath_imports(root) {
-	// Add all `#`-prefixed imports from package.json as path aliases
-	const imports = read_package_imports(root);
-
-	/** @type {Record<string, string>} */
-	const alias = {};
-
-	if (imports) {
-		for (const [key, raw_value] of Object.entries(imports)) {
-			if (!key.startsWith('#')) continue;
-			const value = normalize_import_value(raw_value);
-			if (value) {
-				alias[key] = value;
-			}
-		}
-	}
-
-	return alias;
 }

--- a/packages/kit/src/core/sync/write_tsconfig/utils.spec.js
+++ b/packages/kit/src/core/sync/write_tsconfig/utils.spec.js
@@ -1,5 +1,5 @@
 import { assert, describe, test } from 'vitest';
-import { get_subpath_imports, normalize_config } from './utils.js';
+import { normalize_config } from './utils.js';
 
 describe('normalize_config', () => {
 	test('normalizes rootDirs', () => {
@@ -57,14 +57,5 @@ describe('normalize_config', () => {
 		assert.equal(a, 1);
 		assert.equal(b, 2);
 		assert.equal(c, 3);
-	});
-});
-
-describe('get_subpath_imports', () => {
-	test('gets normalized subpath imports', () => {
-		assert.deepEqual(get_subpath_imports(import.meta.dirname + '/test-app'), {
-			'#lib': 'src/lib',
-			'#lib/*': 'src/lib/*'
-		});
 	});
 });


### PR DESCRIPTION
More harm than good as we realized; in cases where things don't go through Vite (e.g. when esbuild bundles things) it'll break in weird ways.
