### PR TITLE
fix: yield to allow prerender updates to be visible

### DIFF
--- a/.changeset/lemon-pots-tease.md
+++ b/.changeset/lemon-pots-tease.md
@@ -1,0 +1,6 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: yield to allow prerender updates to be visible
+  

--- a/packages/kit/src/core/postbuild/prerender.js
+++ b/packages/kit/src/core/postbuild/prerender.js
@@ -275,8 +275,8 @@ async function prerender({
 	/** @type {Map<string, Promise<any>>} */
 	const remote_responses = new Map();
 
-	/** @type {(path: string) => void} */
-	let progress_line = noop;
+	/** @type {null | ((path: string) => void)} */
+	let progress_line = null;
 
 	if (is_tty) {
 		// Where possible, provide progress feedback by showing the path we're
@@ -354,7 +354,12 @@ async function prerender({
 		/** @type {Map<string, import('types').PrerenderDependency>} */
 		const dependencies = new Map();
 
-		progress_line(decoded);
+		if (progress_line) {
+			progress_line(decoded);
+
+			// without this, the update will rarely be visible, and progress will appear stuck
+			await new Promise((f) => setTimeout(f, 0));
+		}
 
 		const request = new Request(prerender_origin + encoded);
 

--- a/packages/kit/src/core/postbuild/prerender.js
+++ b/packages/kit/src/core/postbuild/prerender.js
@@ -312,12 +312,14 @@ async function prerender({
 			},
 
 			update: (path) => {
-				stdout_write.call(process.stdout, `rendering ${path}...\n`);
+				stdout_write.call(process.stdout, `crawling ${path}\n`);
 				current = true;
 			},
 
 			updated: 0
 		};
+
+		console.log('');
 	}
 
 	/** @type {Set<string>} */
@@ -360,14 +362,16 @@ async function prerender({
 		/** @type {Map<string, import('types').PrerenderDependency>} */
 		const dependencies = new Map();
 
-		if (progress && Date.now() - progress.updated > 50) {
-			progress.updated = Date.now();
-
+		if (progress) {
 			progress.clear();
 			progress.update(decoded);
 
-			// without this, the update will rarely be visible, and progress will appear stuck
-			await new Promise((f) => setTimeout(f, 0));
+			if (Date.now() - progress.updated > 50) {
+				progress.updated = Date.now();
+
+				// without this, the update will rarely be visible, and progress will appear stuck
+				await new Promise((f) => setTimeout(f, 0));
+			}
 		}
 
 		const request = new Request(prerender_origin + encoded);

--- a/packages/kit/src/core/postbuild/prerender.js
+++ b/packages/kit/src/core/postbuild/prerender.js
@@ -275,9 +275,8 @@ async function prerender({
 	/** @type {Map<string, Promise<any>>} */
 	const remote_responses = new Map();
 
-	/** @type {null | ((path: string) => void)} */
-	let progress_line = null;
-	let last_progress = 0;
+	/** @type {null | { clear: () => void; update: (path: string) => void; updated: number }} */
+	let progress = null;
 
 	if (is_tty) {
 		// Where possible, provide progress feedback by showing the path we're
@@ -302,16 +301,22 @@ async function prerender({
 			}
 		});
 
-		progress_line = (path) => {
-			// If app code writes to stdout or stderr, don't move the cursor to clear
-			// the previous progress log, because that will corrupt things
-			if (current) {
+		progress = {
+			clear: () => {
+				// If app code writes to stdout or stderr, don't move the cursor to clear
+				// the previous progress log, because that will corrupt things
+				if (!current) return;
+
 				moveCursor(process.stdout, 0, -1);
 				clearLine(process.stdout, 0);
-			}
+			},
 
-			stdout_write.call(process.stdout, `rendering ${path}...\n`);
-			current = true;
+			update: (path) => {
+				stdout_write.call(process.stdout, `rendering ${path}...\n`);
+				current = true;
+			},
+
+			updated: 0
 		};
 	}
 
@@ -355,9 +360,11 @@ async function prerender({
 		/** @type {Map<string, import('types').PrerenderDependency>} */
 		const dependencies = new Map();
 
-		if (progress_line && Date.now() - last_progress > 50) {
-			last_progress = Date.now();
-			progress_line(decoded);
+		if (progress && Date.now() - progress.updated > 50) {
+			progress.updated = Date.now();
+
+			progress.clear();
+			progress.update(decoded);
 
 			// without this, the update will rarely be visible, and progress will appear stuck
 			await new Promise((f) => setTimeout(f, 0));
@@ -700,6 +707,7 @@ async function prerender({
 	}
 
 	await q.done();
+	progress?.clear();
 
 	// handle invalid fragment links
 	for (const [key, referrers] of expected_hashlinks) {

--- a/packages/kit/src/core/postbuild/prerender.js
+++ b/packages/kit/src/core/postbuild/prerender.js
@@ -277,6 +277,7 @@ async function prerender({
 
 	/** @type {null | ((path: string) => void)} */
 	let progress_line = null;
+	let last_progress = 0;
 
 	if (is_tty) {
 		// Where possible, provide progress feedback by showing the path we're
@@ -354,7 +355,8 @@ async function prerender({
 		/** @type {Map<string, import('types').PrerenderDependency>} */
 		const dependencies = new Map();
 
-		if (progress_line) {
+		if (progress_line && Date.now() - last_progress > 50) {
+			last_progress = Date.now();
 			progress_line(decoded);
 
 			// without this, the update will rarely be visible, and progress will appear stuck


### PR DESCRIPTION
follow-up to #16744 — turns out we need this or `stdout` can buffer updates for long enough that progress appears stalled.

before:


https://github.com/user-attachments/assets/25019619-5d60-42e8-aa8c-bc051fba64ca

after:


https://github.com/user-attachments/assets/094891d1-4028-4033-8c2e-56ab3dbcf394



---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
