### PR TITLE
fix: don't destroy partial-line app output with the prerender progress line

### DIFF
--- a/.changeset/shiny-lines-guard.md
+++ b/.changeset/shiny-lines-guard.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: don't destroy partial-line app output with the prerender progress line

--- a/packages/kit/src/core/postbuild/prerender.js
+++ b/packages/kit/src/core/postbuild/prerender.js
@@ -284,22 +284,25 @@ async function prerender({
 		// This avoids the wall of text that happens when you prerender
 		// many pages and log each response
 		let current = false;
+		let mid_line = false;
 		const stdout_write = process.stdout.write;
 		const stderr_write = process.stderr.write;
 
-		process.stdout.write = new Proxy(stdout_write, {
+		/** @type {ProxyHandler<typeof stdout_write>} */
+		const track_output = {
 			apply(target, this_arg, args) {
-				current = false;
+				const chunk = args[0];
+				if (chunk.length > 0) {
+					current = false;
+					mid_line =
+						typeof chunk === 'string' ? !chunk.endsWith('\n') : chunk[chunk.length - 1] !== 10;
+				}
 				return Reflect.apply(target, this_arg, args);
 			}
-		});
+		};
 
-		process.stderr.write = new Proxy(stderr_write, {
-			apply(target, this_arg, args) {
-				current = false;
-				return Reflect.apply(target, this_arg, args);
-			}
-		});
+		process.stdout.write = new Proxy(stdout_write, track_output);
+		process.stderr.write = new Proxy(stderr_write, track_output);
 
 		progress = {
 			clear: () => {
@@ -312,8 +315,14 @@ async function prerender({
 			},
 
 			update: (path) => {
+				if (mid_line) {
+					// app output ended mid-line — start a fresh one rather than appending to it
+					stdout_write.call(process.stdout, '\n');
+				}
+
 				stdout_write.call(process.stdout, `crawling ${path}\n`);
 				current = true;
+				mid_line = false;
 			},
 
 			updated: 0


### PR DESCRIPTION
If app code writes to stdout without a trailing newline during prerendering on a TTY, the next progress line lands on the same row and the update after that clears the row:

```
rendering /partial...
rendering /dynamic/foo...   <- app output destroyed
```

The write proxies now track whether the last chunk ended mid-line, and the progress line starts a fresh row instead:

```
rendering /partial...
IMPORTANT APP OUTPUT (no newline)
rendering /dynamic/foo...
```

surfaced while reviewing #16748
