### PR TITLE
 feat: allow adapters to override getRequest and setResponse

### DIFF
--- a/.changeset/rare-schools-itch.md
+++ b/.changeset/rare-schools-itch.md
@@ -1,0 +1,6 @@
+---
+"@sveltejs/kit": minor
+---
+
+feat: allow adapters to override getRequest and setResponse
+  

--- a/.changeset/rare-schools-itch.md
+++ b/.changeset/rare-schools-itch.md
@@ -2,5 +2,5 @@
 "@sveltejs/kit": minor
 ---
 
-feat: allow adapters to override getRequest and setResponse
+feat: allow adapters to override `getRequest` and `setResponse` during `vite dev` and `vite preview`
   

--- a/documentation/docs/25-build-and-deploy/99-writing-adapters.md
+++ b/documentation/docs/25-build-and-deploy/99-writing-adapters.md
@@ -42,16 +42,16 @@ export default function (options) {
 				// Return `false if it can't, or throw a descriptive error.
 			}
 		},
-		getRequest(options) {
-			const request = getRequest(options);
-			// modify the Request object here if needed
-			return request;
-		},
-		setResponse(res, response) {
-			// handle WebSockets here, for example
-			setResponse(res, response);
-		},
 		vite: {
+			getRequest(options) {
+				const request = getRequest(options);
+				// modify the Request object here if needed
+				return request;
+			},
+			setResponse(res, response) {
+				// handle WebSockets here, for example
+				setResponse(res, response);
+			},
 			plugins: {
 				// add plugins here to integrate with Vite
 				pre: [],
@@ -64,7 +64,7 @@ export default function (options) {
 }
 ```
 
-Of these, `name` and `adapt` are required. `emulate`, `vite`, `getRequest`, `setResponse`, and `supports` are optional.
+Of these, `name` and `adapt` are required. `emulate`, `vite`, and `supports` are optional.
 
 Within the `adapt` method, there are a number of things that an adapter should do:
 

--- a/documentation/docs/25-build-and-deploy/99-writing-adapters.md
+++ b/documentation/docs/25-build-and-deploy/99-writing-adapters.md
@@ -13,6 +13,8 @@ type AdapterSpecificOptions = any;
 
 // @filename: index.js
 // ---cut---
+import { getRequest, setResponse } from '@sveltejs/kit/node';
+
 /** @param {AdapterSpecificOptions} options */
 export default function (options) {
 	/** @type {import('@sveltejs/kit').Adapter} */
@@ -40,6 +42,15 @@ export default function (options) {
 				// Return `false if it can't, or throw a descriptive error.
 			}
 		},
+		getRequest(options) {
+			const request = getRequest(options);
+			// modify the Request object here if needed
+			return request;
+		},
+		setResponse(res, response) {
+			// handle WebSockets here, for example
+			setResponse(res, response);
+		},
 		vite: {
 			plugins: {
 				// add plugins here to integrate with Vite
@@ -53,7 +64,7 @@ export default function (options) {
 }
 ```
 
-Of these, `name` and `adapt` are required. `emulate`, `vite`, and `supports` are optional.
+Of these, `name` and `adapt` are required. `emulate`, `vite`, `getRequest`, `setResponse`, and `supports` are optional.
 
 Within the `adapt` method, there are a number of things that an adapter should do:
 

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -53,23 +53,25 @@ export interface Adapter {
 		instrumentation?: () => boolean;
 	};
 	/**
-	 * This function overrides the default behavior to convert an `http.IncomingMessage` to a `Request` object.
-	 * To call the original setRequest function, import it from `@sveltejs/kit/node`.
-	 * @since 3.0.0
-	 */
-	getRequest?: typeof getRequest;
-	/**
-	 * This function overrides the default behavior to write a `Response` object to an `http.ServerResponse`.
-	 * To call the original setResponse function, import it from `@sveltejs/kit/node`.
-	 * @since 3.0.0
-	 */
-	setResponse?: typeof setResponse;
-	/**
 	 * Creates an `Emulator`, which allows the adapter to influence the environment
 	 * during dev, build and prerendering.
 	 */
 	emulate?: () => MaybePromise<Emulator>;
 	vite?: {
+		/**
+		 * This function overrides the default behavior in vite dev and preview mode
+		 * to convert an `http.IncomingMessage` to a `Request` object.
+		 * To call the original setRequest function, import it from `@sveltejs/kit/node`.
+		 * @since 3.0.0
+		 */
+		getRequest?: typeof getRequest;
+		/**
+		 * This function overrides the default behavior in vite dev and preview mode
+		 * to write a `Response` object to an `http.ServerResponse`.
+		 * To call the original setResponse function, import it from `@sveltejs/kit/node`.
+		 * @since 3.0.0
+		 */
+		setResponse?: typeof setResponse;
 		plugins?: {
 			/**
 			 * Vite plugins placed before any of SvelteKit's own plugins.

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -59,16 +59,16 @@ export interface Adapter {
 	emulate?: () => MaybePromise<Emulator>;
 	vite?: {
 		/**
-		 * This function overrides the default behavior in vite dev and preview mode
+		 * This function overrides the default behavior during Vite's dev and preview modes
 		 * to convert an `http.IncomingMessage` to a `Request` object.
-		 * To call the original setRequest function, import it from `@sveltejs/kit/node`.
+		 * To call the original `setRequest` function, import it from `@sveltejs/kit/node`.
 		 * @since 3.0.0
 		 */
 		getRequest?: typeof getRequest;
 		/**
-		 * This function overrides the default behavior in vite dev and preview mode
-		 * to write a `Response` object to an `http.ServerResponse`.
-		 * To call the original setResponse function, import it from `@sveltejs/kit/node`.
+		 * This function overrides the default behavior in Vite's dev and preview modes
+		 * to write a `Response` object to a `http.ServerResponse`.
+		 * To call the original `setResponse` function, import it from `@sveltejs/kit/node`.
 		 * @since 3.0.0
 		 */
 		setResponse?: typeof setResponse;

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -16,6 +16,7 @@ import { ValidatedConfig } from 'types';
 import { Plugin } from 'vite';
 import { RouteId as AppRouteId, LayoutParams as AppLayoutParams } from '$app/types';
 import { StandardSchemaV1 } from '@standard-schema/spec';
+import { getRequest, setResponse } from '@sveltejs/kit/node';
 
 export { PrerenderOption } from '../types/private.js';
 
@@ -51,6 +52,18 @@ export interface Adapter {
 		 */
 		instrumentation?: () => boolean;
 	};
+	/**
+	 * This function overrides the default behavior to convert an `http.IncomingMessage` to a `Request` object.
+	 * To call the original setRequest function, import it from `@sveltejs/kit/node`.
+	 * @since 3.0.0
+	 */
+	getRequest?: typeof getRequest;
+	/**
+	 * This function overrides the default behavior to write a `Response` object to an `http.ServerResponse`.
+	 * To call the original setResponse function, import it from `@sveltejs/kit/node`.
+	 * @since 3.0.0
+	 */
+	setResponse?: typeof setResponse;
 	/**
 	 * Creates an `Emulator`, which allows the adapter to influence the environment
 	 * during dev, build and prerendering.

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -603,7 +603,7 @@ export async function dev(
 					read: (file) => createReadableStream(from_fs(file))
 				});
 
-				const request = getRequest({
+				const request = (svelte_config.adapter.getRequest ?? getRequest)({
 					base,
 					request: req,
 					response: res
@@ -656,11 +656,11 @@ export async function dev(
 					// @ts-expect-error
 					serve_static_middleware.handle(req, res, () => {
 						log_dev_response(rendered.status, format_response(rendered.status, request));
-						setResponse(res, rendered);
+						(svelte_config.adapter.setResponse ?? setResponse)(res, rendered);
 					});
 				} else {
 					log_dev_response(rendered.status, format_response(rendered.status, request));
-					setResponse(res, rendered);
+					(svelte_config.adapter.setResponse ?? setResponse)(res, rendered);
 				}
 			} catch (e) {
 				const error = coalesce_to_error(e);

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -603,7 +603,7 @@ export async function dev(
 					read: (file) => createReadableStream(from_fs(file))
 				});
 
-				const request = (svelte_config.adapter?.getRequest ?? getRequest)({
+				const request = (svelte_config.adapter?.vite?.getRequest ?? getRequest)({
 					base,
 					request: req,
 					response: res
@@ -656,11 +656,11 @@ export async function dev(
 					// @ts-expect-error
 					serve_static_middleware.handle(req, res, () => {
 						log_dev_response(rendered.status, format_response(rendered.status, request));
-						(svelte_config.adapter?.setResponse ?? setResponse)(res, rendered);
+						(svelte_config.adapter?.vite?.setResponse ?? setResponse)(res, rendered);
 					});
 				} else {
 					log_dev_response(rendered.status, format_response(rendered.status, request));
-					(svelte_config.adapter?.setResponse ?? setResponse)(res, rendered);
+					(svelte_config.adapter?.vite?.setResponse ?? setResponse)(res, rendered);
 				}
 			} catch (e) {
 				const error = coalesce_to_error(e);

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -603,7 +603,7 @@ export async function dev(
 					read: (file) => createReadableStream(from_fs(file))
 				});
 
-				const request = (svelte_config.adapter.getRequest ?? getRequest)({
+				const request = (svelte_config.adapter?.getRequest ?? getRequest)({
 					base,
 					request: req,
 					response: res
@@ -656,11 +656,11 @@ export async function dev(
 					// @ts-expect-error
 					serve_static_middleware.handle(req, res, () => {
 						log_dev_response(rendered.status, format_response(rendered.status, request));
-						(svelte_config.adapter.setResponse ?? setResponse)(res, rendered);
+						(svelte_config.adapter?.setResponse ?? setResponse)(res, rendered);
 					});
 				} else {
 					log_dev_response(rendered.status, format_response(rendered.status, request));
-					(svelte_config.adapter.setResponse ?? setResponse)(res, rendered);
+					(svelte_config.adapter?.setResponse ?? setResponse)(res, rendered);
 				}
 			} catch (e) {
 				const error = coalesce_to_error(e);

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -205,13 +205,13 @@ export async function preview(vite, svelte_config) {
 		vite.middlewares.use(async (req, res) => {
 			const host = req.headers[':authority'] || req.headers.host;
 
-			const request = (svelte_config.adapter.getRequest ?? getRequest)({
+			const request = (svelte_config.adapter?.getRequest ?? getRequest)({
 				base: `${protocol}://${host}`,
 				request: req,
 				response: res
 			});
 
-			(svelte_config.adapter.setResponse ?? setResponse)(
+			(svelte_config.adapter?.setResponse ?? setResponse)(
 				res,
 				await server.respond(request, {
 					getClientAddress: () => {

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -205,13 +205,13 @@ export async function preview(vite, svelte_config) {
 		vite.middlewares.use(async (req, res) => {
 			const host = req.headers[':authority'] || req.headers.host;
 
-			const request = getRequest({
+			const request = (svelte_config.adapter.getRequest ?? getRequest)({
 				base: `${protocol}://${host}`,
 				request: req,
 				response: res
 			});
 
-			setResponse(
+			(svelte_config.adapter.setResponse ?? setResponse)(
 				res,
 				await server.respond(request, {
 					getClientAddress: () => {

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -205,13 +205,13 @@ export async function preview(vite, svelte_config) {
 		vite.middlewares.use(async (req, res) => {
 			const host = req.headers[':authority'] || req.headers.host;
 
-			const request = (svelte_config.adapter?.getRequest ?? getRequest)({
+			const request = (svelte_config.adapter?.vite?.getRequest ?? getRequest)({
 				base: `${protocol}://${host}`,
 				request: req,
 				response: res
 			});
 
-			(svelte_config.adapter?.setResponse ?? setResponse)(
+			(svelte_config.adapter?.vite?.setResponse ?? setResponse)(
 				res,
 				await server.respond(request, {
 					getClientAddress: () => {

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -4,8 +4,8 @@
 declare module '@sveltejs/kit' {
 	import type { Plugin } from 'vite';
 	import type { RouteId as AppRouteId, LayoutParams as AppLayoutParams } from '$app/types';
-	import type { getRequest, setResponse } from '@sveltejs/kit/node';
 	import type { StandardSchemaV1 } from '@standard-schema/spec';
+	import type { getRequest, setResponse } from '@sveltejs/kit/node';
 	import type { Config } from '@sveltejs/kit/vite';
 	// @ts-ignore this is an optional peer dependency so could be missing. Written like this so dts-buddy preserves the ts-ignore
 	type Span = import('@opentelemetry/api').Span;

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -40,23 +40,25 @@ declare module '@sveltejs/kit' {
 			instrumentation?: () => boolean;
 		};
 		/**
-		 * This function overrides the default behavior to convert an `http.IncomingMessage` to a `Request` object.
-		 * To call the original setRequest function, import it from `@sveltejs/kit/node`.
-		 * @since 3.0.0
-		 */
-		getRequest?: typeof getRequest;
-		/**
-		 * This function overrides the default behavior to write a `Response` object to an `http.ServerResponse`.
-		 * To call the original setResponse function, import it from `@sveltejs/kit/node`.
-		 * @since 3.0.0
-		 */
-		setResponse?: typeof setResponse;
-		/**
 		 * Creates an `Emulator`, which allows the adapter to influence the environment
 		 * during dev, build and prerendering.
 		 */
 		emulate?: () => MaybePromise<Emulator>;
 		vite?: {
+			/**
+			 * This function overrides the default behavior in vite dev and preview mode
+			 * to convert an `http.IncomingMessage` to a `Request` object.
+			 * To call the original setRequest function, import it from `@sveltejs/kit/node`.
+			 * @since 3.0.0
+			 */
+			getRequest?: typeof getRequest;
+			/**
+			 * This function overrides the default behavior in vite dev and preview mode
+			 * to write a `Response` object to an `http.ServerResponse`.
+			 * To call the original setResponse function, import it from `@sveltejs/kit/node`.
+			 * @since 3.0.0
+			 */
+			setResponse?: typeof setResponse;
 			plugins?: {
 				/**
 				 * Vite plugins placed before any of SvelteKit's own plugins.

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -4,6 +4,7 @@
 declare module '@sveltejs/kit' {
 	import type { Plugin } from 'vite';
 	import type { RouteId as AppRouteId, LayoutParams as AppLayoutParams } from '$app/types';
+	import type { getRequest, setResponse } from '@sveltejs/kit/node';
 	import type { StandardSchemaV1 } from '@standard-schema/spec';
 	import type { Config } from '@sveltejs/kit/vite';
 	// @ts-ignore this is an optional peer dependency so could be missing. Written like this so dts-buddy preserves the ts-ignore
@@ -38,6 +39,18 @@ declare module '@sveltejs/kit' {
 			 */
 			instrumentation?: () => boolean;
 		};
+		/**
+		 * This function overrides the default behavior to convert an `http.IncomingMessage` to a `Request` object.
+		 * To call the original setRequest function, import it from `@sveltejs/kit/node`.
+		 * @since 3.0.0
+		 */
+		getRequest?: typeof getRequest;
+		/**
+		 * This function overrides the default behavior to write a `Response` object to an `http.ServerResponse`.
+		 * To call the original setResponse function, import it from `@sveltejs/kit/node`.
+		 * @since 3.0.0
+		 */
+		setResponse?: typeof setResponse;
 		/**
 		 * Creates an `Emulator`, which allows the adapter to influence the environment
 		 * during dev, build and prerendering.

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -46,16 +46,16 @@ declare module '@sveltejs/kit' {
 		emulate?: () => MaybePromise<Emulator>;
 		vite?: {
 			/**
-			 * This function overrides the default behavior in vite dev and preview mode
+			 * This function overrides the default behavior during Vite's dev and preview modes
 			 * to convert an `http.IncomingMessage` to a `Request` object.
-			 * To call the original setRequest function, import it from `@sveltejs/kit/node`.
+			 * To call the original `setRequest` function, import it from `@sveltejs/kit/node`.
 			 * @since 3.0.0
 			 */
 			getRequest?: typeof getRequest;
 			/**
-			 * This function overrides the default behavior in vite dev and preview mode
-			 * to write a `Response` object to an `http.ServerResponse`.
-			 * To call the original setResponse function, import it from `@sveltejs/kit/node`.
+			 * This function overrides the default behavior in Vite's dev and preview modes
+			 * to write a `Response` object to a `http.ServerResponse`.
+			 * To call the original `setResponse` function, import it from `@sveltejs/kit/node`.
 			 * @since 3.0.0
 			 */
 			setResponse?: typeof setResponse;


### PR DESCRIPTION
This enables the cloudflare adapter to emulate the Request.cf property and later handle websockets responses.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
