### PR TITLE
fix: add dependency to compose plugin hook filters

### DIFF
--- a/.changeset/curly-webs-lie.md
+++ b/.changeset/curly-webs-lie.md
@@ -1,0 +1,6 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: correctly implement Vite plugin hook filters
+  

--- a/packages/enhanced-img/package.json
+++ b/packages/enhanced-img/package.json
@@ -47,7 +47,6 @@
 	"devDependencies": {
 		"@types/estree": "catalog:",
 		"@types/node": "catalog:",
-		"rolldown": "catalog:",
 		"svelte": "catalog:",
 		"typescript": "catalog:typescript-native",
 		"vite": "catalog:",

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -18,6 +18,7 @@
 	"homepage": "https://svelte.dev",
 	"type": "module",
 	"dependencies": {
+		"@rolldown/pluginutils": "^1.0.1",
 		"@standard-schema/spec": "^1.1.0",
 		"@sveltejs/acorn-typescript": "^1.0.12",
 		"acorn": "^8.18.0",
@@ -37,7 +38,6 @@
 		"@types/node": "catalog:",
 		"dts-buddy": "^0.8.3",
 		"jsdom": "catalog:",
-		"rolldown": "catalog:",
 		"svelte": "catalog:",
 		"svelte-preprocess": "catalog:",
 		"typescript": "~6.0.3",

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -212,7 +212,7 @@ export async function sveltekit(config) {
 	/** @type {Partial<Options>} */
 	const inline_vps_config = {
 		preprocess: svelte_config.preprocess,
-		...(svelte_config.vitePlugin ?? {}),
+		...svelte_config.vitePlugin,
 		// pass through any options that SvelteKit doesn't use itself, so that
 		// the options SvelteKit manages always take precedence
 		...split.vite_plugin_svelte_config,
@@ -1284,7 +1284,9 @@ function kit({ svelte_config }) {
 		configResolved() {
 			if (service_worker_entry_file) {
 				// @ts-expect-error transform is defined in this object
-				plugin_service_worker_env.transform.filter.id = exactRegex(service_worker_entry_file);
+				plugin_service_worker_env.transform.filter = {
+					id: exactRegex(service_worker_entry_file)
+				};
 			}
 		},
 		applyToEnvironment(environment) {

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -1,3 +1,4 @@
+/** @import { TopLevelFilterExpression } from '@rolldown/pluginutils' */
 /** @import { KitConfig } from '@sveltejs/kit' */
 /** @import { EnvVarConfig } from '@sveltejs/kit/env' */
 /** @import { Options, SvelteConfig } from '@sveltejs/vite-plugin-svelte' */
@@ -8,9 +9,17 @@ import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 import { styleText } from 'node:util';
+
+import {
+	and,
+	code,
+	exactRegex,
+	importerId,
+	include,
+	not,
+	prefixRegex
+} from '@rolldown/pluginutils';
 import MagicString from 'magic-string';
-import { loadEnv } from 'vite';
-import { exactRegex, prefixRegex } from 'rolldown/filter';
 
 import { copy, read, resolve_entry } from '../../utils/filesystem.js';
 import { posixify } from '../../utils/os.js';
@@ -375,9 +384,9 @@ function kit({ svelte_config }) {
 					? `globalThis.__sveltekit_${version_hash}`
 					: 'globalThis.__sveltekit_dev';
 
-				env = loadEnv(config_env.mode, kit.env.dir, '');
-
 				vite = await import_peer('vite', root);
+
+				env = vite.loadEnv(config_env.mode, kit.env.dir, '');
 
 				normalized_cwd = vite.normalizePath(root);
 				normalized_aliases = get_import_aliases(root, vite.normalizePath.bind(vite));
@@ -668,7 +677,7 @@ function kit({ svelte_config }) {
 
 		resolveId: {
 			filter: {
-				id: [prefixRegex('__sveltekit/')]
+				id: prefixRegex('__sveltekit/')
 			},
 			handler(id) {
 				if (id === '__sveltekit/manifest') {
@@ -761,13 +770,16 @@ function kit({ svelte_config }) {
 		},
 
 		resolveId: {
-			// TODO: use composable filter API here when supported:
-			// https://github.com/vitejs/rolldown-vite/issues/605
-			// filter: ([
-			// 	exclude(importerId(/index\.html$/)),
-			// 	include(importerId(/.+/))
-			// ]),
+			// composable filters are not accepted type-wise but still work during build
+			// see https://github.com/vitejs/rolldown-vite/issues/605
+			filter: /** @type {any} */ (
+				/** @satisfies {TopLevelFilterExpression[]} */ ([
+					include(and(importerId(/.+/), not(importerId(/index\.html$/))))
+				])
+			),
 			async handler(id, importer, options) {
+				// composable filters only work during build so we still need this guard for dev
+				// see https://github.com/vitejs/rolldown-vite/issues/605
 				if (importer && !importer.endsWith('index.html')) {
 					const resolved = await this.resolve(id, importer, { ...options, skipSelf: true });
 
@@ -1162,7 +1174,7 @@ function kit({ svelte_config }) {
 
 		resolveId: {
 			filter: {
-				id: [prefixRegex('__sveltekit/')]
+				id: prefixRegex('__sveltekit/')
 			},
 			handler(id) {
 				return `\0virtual:${id}`;
@@ -1269,13 +1281,17 @@ function kit({ svelte_config }) {
 	/** @type {Plugin} */
 	const plugin_service_worker_env = {
 		name: 'vite-plugin-sveltekit-service-worker-env',
+		configResolved() {
+			if (service_worker_entry_file) {
+				// @ts-expect-error transform is defined in this object
+				plugin_service_worker_env.transform.filter.id = exactRegex(service_worker_entry_file);
+			}
+		},
 		applyToEnvironment(environment) {
 			return !!service_worker_entry_file && environment.config.consumer === 'client';
 		},
 		transform: {
-			handler(code, id) {
-				if (id !== service_worker_entry_file) return;
-
+			handler(code) {
 				// prepend the service worker with an import that configures
 				// `env`, in case `$app/env/public` is imported. In production
 				// this is required: dynamic public env vars aren't known at
@@ -1601,17 +1617,26 @@ function kit({ svelte_config }) {
 			return environment.name !== 'serviceWorker';
 		},
 
-		renderChunk(code, chunk) {
-			if (code.includes('__SVELTEKIT_TRACK__')) {
-				return {
-					// Rolldown changes our single quotes to double quotes so we need it in the regex too
-					code: code.replace(/__SVELTEKIT_TRACK__\(['"](.+?)['"]\)/g, (_, label) => {
-						(tracked_features[chunk.name + '.js'] ??= []).push(label);
-						// put extra whitespace at the end of the comment to preserve the source size and avoid interfering with source maps
-						return `/* track ${label}            */`;
-					}),
-					map: null // TODO we may need to generate a sourcemap in future
-				};
+		renderChunk: {
+			// composable filters are not accepted type-wise but still work during build
+			// see https://github.com/vitejs/rolldown-vite/issues/605
+			filter: /** @type {any} */ (
+				/** @satisfies {TopLevelFilterExpression[]} */ ([include(code('__SVELTEKIT_TRACK__'))])
+			),
+			handler(code, chunk) {
+				// composable filters only work during build so we still need this guard for dev
+				// see https://github.com/vitejs/rolldown-vite/issues/605
+				if (code.includes('__SVELTEKIT_TRACK__')) {
+					return {
+						// Rolldown changes our single quotes to double quotes so we need it in the regex too
+						code: code.replace(/__SVELTEKIT_TRACK__\(['"](.+?)['"]\)/g, (_, label) => {
+							(tracked_features[chunk.name + '.js'] ??= []).push(label);
+							// put extra whitespace at the end of the comment to preserve the source size and avoid interfering with source maps
+							return `/* track ${label}            */`;
+						}),
+						map: null // TODO we may need to generate a sourcemap in future
+					};
+				}
 			}
 		},
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,9 +69,6 @@ catalogs:
     prettier-plugin-svelte:
       specifier: ^4.1.1
       version: 4.1.1
-    rolldown:
-      specifier: ^1.2.3
-      version: 1.2.3
     sirv-cli:
       specifier: ^3.0.1
       version: 3.0.1
@@ -491,9 +488,6 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 22.19.19
-      rolldown:
-        specifier: 'catalog:'
-        version: 1.2.3
       svelte:
         specifier: 'catalog:'
         version: 5.56.8(@typescript-eslint/types@8.61.1)
@@ -527,6 +521,9 @@ importers:
 
   packages/kit:
     dependencies:
+      '@rolldown/pluginutils':
+        specifier: ^1.0.1
+        version: 1.0.1
       '@standard-schema/spec':
         specifier: ^1.1.0
         version: 1.1.0
@@ -579,9 +576,6 @@ importers:
       jsdom:
         specifier: 'catalog:'
         version: 30.0.1
-      rolldown:
-        specifier: 'catalog:'
-        version: 1.2.3
       svelte:
         specifier: 'catalog:'
         version: 5.56.8(@typescript-eslint/types@8.61.1)


### PR DESCRIPTION
We were incorrectly installing `rolldown` as a dev dep, so the import to `rolldown/filters` and the hook filter helpers weren't available after installing sveltekit 3.

This PR fixes that by using the rolldown plugin utils dep. Also optimises some of the filters

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
