### PR TITLE
chore: bump `svelte2tsx`

### DIFF
--- a/.changeset/tiny-cases-help.md
+++ b/.changeset/tiny-cases-help.md
@@ -1,0 +1,6 @@
+---
+"@sveltejs/package": patch
+---
+
+chore: bump `svelte2tsx` to 0.7.60
+  

--- a/packages/package/package.json
+++ b/packages/package/package.json
@@ -22,7 +22,7 @@
 	"dependencies": {
 		"chokidar": "^5.0.0",
 		"semver": "^7.8.5",
-		"svelte2tsx": "~0.7.59"
+		"svelte2tsx": "~0.7.60"
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:^",

--- a/packages/package/tsconfig.json
+++ b/packages/package/tsconfig.json
@@ -6,8 +6,6 @@
 		"target": "es2022",
 		"module": "node16",
 		"moduleResolution": "node16",
-		// TODO: remove this when svelte2tsx has migrated to magic-string v1
-		"skipLibCheck": true,
 		"types": ["node"]
 	},
 	"include": ["*.js", "src/**/*", "test/index.spec.js"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1591,8 +1591,8 @@ importers:
         specifier: ^7.8.5
         version: 7.8.5
       svelte2tsx:
-        specifier: ~0.7.59
-        version: 0.7.59(svelte@5.56.8(@typescript-eslint/types@8.61.1))(typescript@6.0.3)
+        specifier: ~0.7.60
+        version: 0.7.60(svelte@5.56.8(@typescript-eslint/types@8.61.1))(typescript@6.0.3)
     devDependencies:
       '@sveltejs/kit':
         specifier: workspace:^
@@ -4242,8 +4242,8 @@ packages:
       typescript:
         optional: true
 
-  svelte2tsx@0.7.59:
-    resolution: {integrity: sha512-Itj7Wz9WIiGFl/uJa58+rf43ajezaljKK/KTOHq5abUjto56xe+o5SOzLwSoeJ5hma9NZEstpZiazFW2q1nZPQ==}
+  svelte2tsx@0.7.60:
+    resolution: {integrity: sha512-aefUopCWAA3AT+6K6PQj5JP19+C2dj31qSh06p+nLjVsizwYqGHtTarvhYsCFWl5tSzrD19GL0s+2FcB3K26Lg==}
     peerDependencies:
       svelte: ^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0
       typescript: ^4.9.4 || ^5.0.0 || ^6.0.0
@@ -6893,7 +6893,7 @@ snapshots:
       postcss-load-config: 3.1.4(postcss@8.5.26)
       typescript: 6.0.3
 
-  svelte2tsx@0.7.59(svelte@5.56.8(@typescript-eslint/types@8.61.1))(typescript@6.0.3):
+  svelte2tsx@0.7.60(svelte@5.56.8(@typescript-eslint/types@8.61.1))(typescript@6.0.3):
     dependencies:
       dedent-js: 1.0.1
       scule: 1.3.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,7 @@ minimumReleaseAgeExclude:
   - zimmerframe
   - prettier-plugin-svelte
   - svelte-check
+  - svelte2tsx
   - esm-env
   - vite-imagetools
   - imagetools-core


### PR DESCRIPTION
bumps `svelte2tsx` so we no longer have that type issue of it trying to import magic-string
