### PR TITLE
flattened config follow-ups

### DIFF
--- a/documentation/docs/60-appendix/35-migrating-to-sveltekit-3.md
+++ b/documentation/docs/60-appendix/35-migrating-to-sveltekit-3.md
@@ -55,6 +55,7 @@ The following options are obsolete and should be removed from your `vite.config.
 - `experimental.handleRenderingErrors` is no longer required ([details](#Error-handling-Rendering-errors-are-now-handled))
 - `experimental.instrumentation` is no longer required ([details](#Observability))
 - `experimental.tracing` is now a top level `tracing` option ([details](#Observability))
+- `vitePlugin` is removed — pass `vite-plugin-svelte` options like `inspector` directly to the plugin instead
 - `preloadStrategy` is removed — `modulepreload` is now supported everywhere and so is always used
 - `prerender.origin` is removed in favour of `paths.origin`
 - `csrf.checkOrigin` is removed in favour of `csrf.trustedOrigins`

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -501,6 +501,15 @@ test('errors on invalid forkPreloads values', () => {
 	}, /^config\.experimental\.forkPreloads should be true or false, if specified$/);
 });
 
+test('errors on removed vitePlugin namespace', () => {
+	assert_logs_error_and_throws(() => {
+		validate_config({
+			// @ts-expect-error - removed option expected to throw
+			vitePlugin: { inspector: true }
+		});
+	}, /`config\.vitePlugin` has been removed/);
+});
+
 test('split_config keeps SvelteKit options under the `kit` namespace', () => {
 	const adapter = { name: 'test', adapt: () => {} };
 	const { svelte_config, vite_plugin_svelte_config } = split_config({

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -307,7 +307,12 @@ const options = {
 	version: object({
 		name: string(Date.now().toString()),
 		pollInterval: number(3_600_000)
-	})
+	}),
+
+	vitePlugin: removed(
+		(keypath) =>
+			`\`${keypath}\` has been removed. Pass \`vite-plugin-svelte\` options directly to the \`sveltekit(...)\` Vite plugin`
+	)
 };
 
 /** @type {Validator<ValidatedConfig>} */

--- a/packages/package/src/cli.js
+++ b/packages/package/src/cli.js
@@ -84,7 +84,7 @@ try {
 	/** @type {Options} */
 	const options = {
 		cwd: process.cwd(),
-		input: values.input ?? config.kit?.files?.lib ?? 'src/lib',
+		input: values.input ?? config.files?.lib ?? 'src/lib',
 		output: values.output,
 		preserve_output: values['preserve-output'],
 		tsconfig: values.tsconfig,

--- a/packages/package/src/index.js
+++ b/packages/package/src/index.js
@@ -209,16 +209,12 @@ function normalize_options(options) {
 	const input = path.resolve(options.cwd, options.input);
 	const output = path.resolve(options.cwd, options.output);
 	const preserve_output = options.preserve_output;
-	const temp = path.resolve(
-		options.cwd,
-		options.config.kit?.outDir ?? '.svelte-kit',
-		'__package__'
-	);
+	const temp = path.resolve(options.cwd, options.config.outDir ?? '.svelte-kit', '__package__');
 	const extensions = options.config.extensions ?? ['.svelte'];
 	const tsconfig = options.tsconfig ? path.resolve(options.cwd, options.tsconfig) : undefined;
 
 	/** @type {Record<string, string>} */
-	const alias = { ...(options.config.kit?.alias ?? {}) };
+	const alias = { ...(options.config.alias ?? {}) };
 
 	// Read `#`-prefixed imports from package.json and add them as aliases
 	const pkg_path = path.resolve(options.cwd, 'package.json');

--- a/packages/package/src/types.d.ts
+++ b/packages/package/src/types.d.ts
@@ -8,16 +8,14 @@ export interface Options {
 	types: boolean;
 	tsconfig?: string;
 	config: {
+		alias?: Record<string, string>;
 		extensions?: string[];
-		kit?: {
-			alias?: Record<string, string>;
+		/** @deprecated SvelteKit 2 had this, which we still support */
+		files?: {
 			/** @deprecated SvelteKit 2 had this, which we still support */
-			files?: {
-				/** @deprecated SvelteKit 2 had this, which we still support */
-				lib?: string;
-			};
-			outDir?: string;
+			lib?: string;
 		};
+		outDir?: string;
 		preprocess?: PreprocessorGroup;
 	};
 }

--- a/packages/package/test/index.spec.js
+++ b/packages/package/test/index.spec.js
@@ -26,7 +26,7 @@ async function test_make_package(path, options) {
 	const config = await load_config();
 	process.chdir(original_cwd);
 
-	const input = resolve(cwd, config.kit?.files?.lib ?? 'src/lib');
+	const input = resolve(cwd, config.files?.lib ?? 'src/lib');
 
 	await build({
 		cwd,


### PR DESCRIPTION
Fixes for https://github.com/sveltejs/kit/pull/16752#issuecomment-5269502498. The cli.js `files.lib` fallback is dead either way now that the schema errors on it — flattened rather than deleted, delete if you prefer.