### PR TITLE
fix: wait for the redirect navigation before remote form submissions resolve

### DIFF
--- a/.changeset/kind-forms.md
+++ b/.changeset/kind-forms.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: wait for the redirect navigation before remote form submissions resolve

--- a/.changeset/soft-poems.md
+++ b/.changeset/soft-poems.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: wait for the redirect navigation before prerendered remote functions resolve

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -266,15 +266,11 @@ export function form(id) {
 							const should_refresh = refreshes === null && !response.r;
 
 							if (response.redirect) {
-								if (is_external_url(resolve_url(response.redirect), base, app.hash)) {
-									// Use internal version to allow redirects to external URLs
-									void _goto(response.redirect, {
-										refreshAll: should_refresh
-									});
-								} else {
-									await _goto(response.redirect, {
-										refreshAll: should_refresh
-									});
+								const url = resolve_url(response.redirect);
+								// _goto allows external redirects; those never resolve, so only await internal ones
+								const navigation = _goto(url, { refreshAll: should_refresh });
+								if (!is_external_url(url, base, app.hash)) {
+									await navigation;
 								}
 								return true;
 							}

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -5,6 +5,7 @@ import { app_dir, base } from '#app/paths';
 import { DEV } from 'esm-env';
 
 import {
+	app,
 	query_responses,
 	_goto,
 	set_nearest_error_page,
@@ -12,6 +13,7 @@ import {
 	refreshAll
 } from '../client.js';
 import { page } from '../state.svelte.js';
+import { is_external_url, resolve_url } from '../utils.js';
 import { tick } from 'svelte';
 import { categorize_updates, remote_request } from './shared.svelte.js';
 import { createAttachmentKey } from 'svelte/attachments';
@@ -133,7 +135,9 @@ export function form(id) {
 			if (await instance.submit()) {
 				await tick();
 				// We call reset from the prototype to avoid DOM clobbering
-				HTMLFormElement.prototype.reset.call(instance.element);
+				if (instance.element.isConnected) {
+					HTMLFormElement.prototype.reset.call(instance.element);
+				}
 			}
 		};
 
@@ -262,10 +266,16 @@ export function form(id) {
 							const should_refresh = refreshes === null && !response.r;
 
 							if (response.redirect) {
-								// Use internal version to allow redirects to external URLs
-								void _goto(response.redirect, {
-									refreshAll: should_refresh
-								});
+								if (is_external_url(resolve_url(response.redirect), base, app.hash)) {
+									// Use internal version to allow redirects to external URLs
+									void _goto(response.redirect, {
+										refreshAll: should_refresh
+									});
+								} else {
+									await _goto(response.redirect, {
+										refreshAll: should_refresh
+									});
+								}
 								return true;
 							}
 

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -5,7 +5,6 @@ import { app_dir, base } from '#app/paths';
 import { DEV } from 'esm-env';
 
 import {
-	app,
 	query_responses,
 	_goto,
 	set_nearest_error_page,
@@ -13,7 +12,6 @@ import {
 	refreshAll
 } from '../client.js';
 import { page } from '../state.svelte.js';
-import { is_external_url, resolve_url } from '../utils.js';
 import { tick } from 'svelte';
 import { categorize_updates, remote_request } from './shared.svelte.js';
 import { createAttachmentKey } from 'svelte/attachments';
@@ -266,12 +264,10 @@ export function form(id) {
 							const should_refresh = refreshes === null && !response.r;
 
 							if (response.redirect) {
-								const url = resolve_url(response.redirect);
-								// _goto allows external redirects; those never resolve, so only await internal ones
-								const navigation = _goto(url, { refreshAll: should_refresh });
-								if (!is_external_url(url, base, app.hash)) {
-									await navigation;
-								}
+								// Use internal version to allow redirects to external URLs
+								await _goto(response.redirect, {
+									refreshAll: should_refresh
+								});
 								return true;
 							}
 

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -275,7 +275,7 @@ export function form(id) {
 
 							if (succeeded) {
 								if (should_refresh) {
-									void refreshAll();
+									await refreshAll();
 								}
 							} else {
 								if (DEV) {

--- a/packages/kit/src/runtime/client/remote-functions/prerender.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/prerender.svelte.js
@@ -100,7 +100,7 @@ export function prerender(id) {
 
 				if (result.redirect) {
 					// Use internal version to allow redirects to external URLs
-					void _goto(result.redirect);
+					await _goto(result.redirect);
 					return;
 				}
 

--- a/packages/kit/test/apps/async/src/routes/remote/form/reset-on-redirect/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/reset-on-redirect/+page.svelte
@@ -1,10 +1,5 @@
 <script lang="ts">
 	import { redirect_form, reset_form } from './form.remote';
-
-	redirect_form.enhance(async ({ submit }) => {
-		await submit();
-		sessionStorage.setItem('submit-resolved-pathname', location.pathname);
-	});
 </script>
 
 <form {...reset_form}>
@@ -14,6 +9,11 @@
 
 <div id="result">{reset_form.result}</div>
 
-<form {...redirect_form}>
+<form
+	{...redirect_form.enhance(async ({ submit }) => {
+		await submit();
+		sessionStorage.setItem('submit-resolved-pathname', location.pathname);
+	})}
+>
 	<button id="redirect-other">Redirect to another page</button>
 </form>

--- a/packages/kit/test/apps/async/src/routes/remote/form/reset-on-redirect/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/reset-on-redirect/+page.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-	import { reset_form } from './form.remote';
+	import { redirect_form, reset_form } from './form.remote';
+
+	redirect_form.enhance(async ({ submit }) => {
+		await submit();
+		sessionStorage.setItem('submit-resolved-pathname', location.pathname);
+	});
 </script>
 
 <form {...reset_form}>
@@ -8,3 +13,7 @@
 </form>
 
 <div id="result">{reset_form.result}</div>
+
+<form {...redirect_form}>
+	<button id="redirect-other">Redirect to another page</button>
+</form>

--- a/packages/kit/test/apps/async/src/routes/remote/form/reset-on-redirect/form.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/form/reset-on-redirect/form.remote.ts
@@ -17,3 +17,7 @@ export const reset_form = form(
 		}
 	}
 );
+
+export const redirect_form = form(v.object({}), () => {
+	redirect(303, '/remote/form/redirect-target/destination');
+});

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -1332,6 +1332,17 @@ test.describe('client error boundaries', () => {
 		await page.locator('#redirect').click();
 		await expect(result).not.toHaveText('hello world');
 	});
+
+	test('remote form submit resolves after redirect navigation', async ({ page }) => {
+		await page.goto('/remote/form/reset-on-redirect');
+
+		await page.locator('#redirect-other').click();
+		await page.waitForURL('/remote/form/redirect-target/destination');
+
+		await expect
+			.poll(() => page.evaluate(() => sessionStorage.getItem('submit-resolved-pathname')))
+			.toBe('/remote/form/redirect-target/destination');
+	});
 });
 
 test.describe('fork', () => {


### PR DESCRIPTION
closes #16689

`submit()` now resolves after the redirect navigation, as discussed in the issue. This also keeps `pending` set until the redirect lands (#15725). External redirects still resolve immediately, since their navigations never settle.