### PR TITLE
fix: only print prerender progress newline when necessary

### DIFF
--- a/.changeset/eager-pans-wash.md
+++ b/.changeset/eager-pans-wash.md
@@ -1,0 +1,6 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: only print prerender progress newline when necessary
+  

--- a/packages/kit/src/core/postbuild/prerender.js
+++ b/packages/kit/src/core/postbuild/prerender.js
@@ -1,7 +1,6 @@
 import process from 'node:process';
 import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
-import { clearLine, moveCursor } from 'node:readline';
 import { pathToFileURL } from 'node:url';
 import { walk } from '../../utils/filesystem.js';
 import { posixify } from '../../utils/os.js';
@@ -283,26 +282,31 @@ async function prerender({
 		// currently requesting, then clearing the line once the response comes in.
 		// This avoids the wall of text that happens when you prerender
 		// many pages and log each response
-		let current = false;
-		let mid_line = false;
-		const stdout_write = process.stdout.write;
-		const stderr_write = process.stderr.write;
+		const { stdout, stderr } = process;
 
-		/** @type {ProxyHandler<typeof stdout_write>} */
-		const track_output = {
+		let current = false;
+		let needs_newline = true;
+
+		const write = stdout.write;
+
+		/** @param {string} value */
+		const print = (value) => write.call(stdout, value);
+
+		/** @type {ProxyHandler<typeof stdout.write>} */
+		const intercept = {
 			apply(target, this_arg, args) {
 				const chunk = args[0];
 				if (chunk.length > 0) {
 					current = false;
-					mid_line =
+					needs_newline =
 						typeof chunk === 'string' ? !chunk.endsWith('\n') : chunk[chunk.length - 1] !== 10;
 				}
 				return Reflect.apply(target, this_arg, args);
 			}
 		};
 
-		process.stdout.write = new Proxy(stdout_write, track_output);
-		process.stderr.write = new Proxy(stderr_write, track_output);
+		stdout.write = new Proxy(stdout.write, intercept);
+		stderr.write = new Proxy(stderr.write, intercept);
 
 		progress = {
 			clear: () => {
@@ -310,25 +314,21 @@ async function prerender({
 				// the previous progress log, because that will corrupt things
 				if (!current) return;
 
-				moveCursor(process.stdout, 0, -1);
-				clearLine(process.stdout, 0);
+				print('\x1B[1A'); // move cursor to start of progress update
+				print('\x1B[2K'); // clear current line
 			},
 
 			update: (path) => {
-				if (mid_line) {
-					// app output ended mid-line — start a fresh one rather than appending to it
-					stdout_write.call(process.stdout, '\n');
-				}
+				// if we're in the middle of a line, start a new one
+				if (needs_newline) print('\n');
 
-				stdout_write.call(process.stdout, `crawling ${path}\n`);
+				print(`crawling ${path}\n`);
 				current = true;
-				mid_line = false;
+				needs_newline = false;
 			},
 
 			updated: 0
 		};
-
-		console.log('');
 	}
 
 	/** @type {Set<string>} */


### PR DESCRIPTION
Fixes a small bug introduced in #16750 — the `moveCursor` and `clearLine` calls were _themselves_ being intercepted, so `mid_line` was always true, and we'd just print newline after newline

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
