### PR TITLE
fix: respect Vite default log level

### DIFF
--- a/.changeset/fix-vite-verbose.md
+++ b/.changeset/fix-vite-verbose.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: respect Vite default log level

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -635,7 +635,7 @@ function kit({ svelte_config }) {
 
 			const unsupported_plugins = vite_config.plugins.filter((plugin) => plugin.transformIndexHtml);
 			if (unsupported_plugins.length) {
-				const verbose = vite_config.logLevel === 'info';
+				const verbose = vite_config.logLevel === 'info' || vite_config.logLevel === undefined;
 				const log = logger({ verbose });
 
 				const list = unsupported_plugins
@@ -1689,7 +1689,7 @@ function kit({ svelte_config }) {
 			fs.rmSync(out, { force: true, recursive: true });
 			fs.mkdirSync(out, { recursive: true });
 
-			const verbose = builder.config.logLevel === 'info';
+			const verbose = builder.config.logLevel === 'info' || builder.config.logLevel === undefined;
 			const log = logger({ verbose });
 
 			let ssr_build = await builder.build(builder.environments.ssr);


### PR DESCRIPTION
For the longest time, we weren't logging stuff in build correctly. If the user hasn't set the log level explicitly, Vite saves the value as `undefined`, which should be treated the same as it being set to 'info' (the default value).

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.