### PR TITLE
fix: don't crash on interactions inside a form whose controls shadow `nodeName`

### DIFF
--- a/.changeset/quiet-pans-shake.md
+++ b/.changeset/quiet-pans-shake.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: don't crash on interactions inside a form whose controls shadow `nodeName`

--- a/packages/kit/src/runtime/client/utils.js
+++ b/packages/kit/src/runtime/client/utils.js
@@ -105,7 +105,11 @@ function parent_element(element) {
  */
 export function find_anchor(element, target) {
 	while (element && element !== target) {
-		if (element.nodeName.toUpperCase() === 'A' && element.hasAttribute('href')) {
+		// don't read `nodeName` — a form control named `nodeName` shadows it on its form
+		if (
+			(element instanceof HTMLAnchorElement || element instanceof SVGAElement) &&
+			element.hasAttribute('href')
+		) {
 			return /** @type {HTMLAnchorElement | SVGAElement} */ (element);
 		}
 

--- a/packages/kit/test/apps/basics/src/routes/routing/clobbered-node-name/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/routing/clobbered-node-name/+page.svelte
@@ -1,0 +1,3 @@
+<form>
+	<input id="nodeName" />
+</form>

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -2638,6 +2638,19 @@ test.describe('binding_property_non_reactive warn', () => {
 });
 
 test.describe('routing', () => {
+	test('ignores form controls that shadow DOM properties of their form', async ({ page }) => {
+		/** @type {Error[]} */
+		const errors = [];
+		page.on('pageerror', (error) => errors.push(error));
+
+		await page.goto('/routing/clobbered-node-name');
+		await page.locator('#nodeName').hover();
+		await page.locator('#nodeName').dispatchEvent('touchstart');
+		await page.waitForTimeout(100);
+
+		expect(errors).toEqual([]);
+	});
+
 	test('navigating while navigation is in progress sets the correct URL', async ({ page }) => {
 		await page.goto('/routing/long-navigation');
 		await page.click('a[href="/routing"]');


### PR DESCRIPTION
Fixes #15419

Named form controls shadow DOM properties on their form, so `form.nodeName` can be an input element rather than a string. Same class as #7593, #8467 and #16138.
