### PR TITLE
docs: make Private Types look a bit nicer

### DIFF
--- a/documentation/docs/98-reference/10-@sveltejs-kit.md
+++ b/documentation/docs/98-reference/10-@sveltejs-kit.md
@@ -8,4 +8,4 @@ title: @sveltejs/kit
 
 The following are referenced by the public types documented above, but cannot be imported directly:
 
-> TYPES: Private types
+> TYPES: Private types {depth=3}


### PR DESCRIPTION
this takes advantage of a small change on the `next` branch of `svelte.dev` — collapses all the Private Types under the header, which makes the page look a bit less chaotic