### PR TITLE
fix: rewrite TypeScript glob extensions (svelte-package)

### DIFF
--- a/.changeset/pre/green-globs-shift.md
+++ b/.changeset/pre/green-globs-shift.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/package': patch
+---
+
+fix: rewrite `.ts` extensions in `import.meta.glob` patterns when `rewriteRelativeImportExtensions` is enabled

--- a/packages/package/src/typescript.js
+++ b/packages/package/src/typescript.js
@@ -97,6 +97,10 @@ export async function emit_dts(input, output, final_output, cwd, alias, files, t
 export async function transpile_ts(tsconfig, filename, source, cache) {
 	const ts = await try_load_ts();
 	const options = await load_tsconfig(tsconfig, filename, cache, ts);
+	const transformers = options.rewriteRelativeImportExtensions
+		? { before: [rewrite_import_meta_glob_extensions(ts)] }
+		: undefined;
+
 	// transpileModule treats NodeNext as CommonJS because it doesn't read the package.json. Therefore we need to override it.
 	// Also see https://github.com/microsoft/TypeScript/issues/53022 (the filename workaround doesn't work).
 	return ts.transpileModule(source, {
@@ -105,8 +109,105 @@ export async function transpile_ts(tsconfig, filename, source, cache) {
 			module: ts.ModuleKind.ESNext,
 			moduleResolution: ts.ModuleResolutionKind.NodeNext
 		},
-		fileName: filename
+		fileName: filename,
+		transformers
 	}).outputText;
+}
+
+/**
+ * Rewrite relative TypeScript glob patterns because `svelte-package` emits
+ * TypeScript modules as JavaScript.
+ *
+ * @param {typeof import('typescript')} ts
+ * @returns {import('typescript').TransformerFactory<import('typescript').SourceFile>}
+ */
+function rewrite_import_meta_glob_extensions(ts) {
+	return (context) => {
+		/** @param {import('typescript').Node} node */
+		const visit = (node) => {
+			if (!ts.isCallExpression(node) || !is_import_meta_glob(ts, node)) {
+				return ts.visitEachChild(node, visit, context);
+			}
+
+			const [patterns, ...rest] = node.arguments;
+			const rewritten = rewrite_glob_patterns(ts, patterns);
+
+			if (!rewritten || rewritten === patterns) {
+				return ts.visitEachChild(node, visit, context);
+			}
+
+			return ts.visitEachChild(
+				ts.factory.updateCallExpression(node, node.expression, node.typeArguments, [
+					rewritten,
+					...rest
+				]),
+				visit,
+				context
+			);
+		};
+
+		return (source_file) => ts.visitEachChild(source_file, visit, context);
+	};
+}
+
+/**
+ * @param {typeof import('typescript')} ts
+ * @param {import('typescript').CallExpression} call
+ */
+function is_import_meta_glob(ts, call) {
+	const expression = call.expression;
+	return (
+		!call.questionDotToken &&
+		ts.isPropertyAccessExpression(expression) &&
+		!expression.questionDotToken &&
+		expression.name.text === 'glob' &&
+		ts.isMetaProperty(expression.expression) &&
+		expression.expression.keywordToken === ts.SyntaxKind.ImportKeyword &&
+		expression.expression.name.text === 'meta'
+	);
+}
+
+/**
+ * @param {typeof import('typescript')} ts
+ * @param {import('typescript').Expression | undefined} patterns
+ * @returns {import('typescript').Expression | undefined}
+ */
+function rewrite_glob_patterns(ts, patterns) {
+	if (!patterns) return patterns;
+
+	if (ts.isStringLiteralLike(patterns)) {
+		return rewrite_glob_pattern(ts, patterns);
+	}
+
+	if (!ts.isArrayLiteralExpression(patterns)) return patterns;
+	if (!patterns.elements.every((element) => ts.isStringLiteralLike(element))) return patterns;
+
+	const elements = patterns.elements.map((element) =>
+		rewrite_glob_pattern(ts, /** @type {import('typescript').StringLiteralLike} */ (element))
+	);
+
+	if (elements.every((element, index) => element === patterns.elements[index])) return patterns;
+
+	return ts.factory.updateArrayLiteralExpression(patterns, elements);
+}
+
+/**
+ * @param {typeof import('typescript')} ts
+ * @param {import('typescript').StringLiteralLike} pattern
+ */
+function rewrite_glob_pattern(ts, pattern) {
+	const path = pattern.text.startsWith('!') ? pattern.text.slice(1) : pattern.text;
+
+	if (!(path.startsWith('./') || path.startsWith('../')) || !path.endsWith('.ts')) {
+		return pattern;
+	}
+
+	const rewritten = pattern.text.slice(0, -3) + '.js';
+	const literal = ts.isStringLiteral(pattern)
+		? ts.factory.createStringLiteral(rewritten, pattern.getText().startsWith("'"))
+		: ts.factory.createNoSubstitutionTemplateLiteral(rewritten);
+
+	return ts.setTextRange(literal, pattern);
 }
 
 async function try_load_ts() {

--- a/packages/package/test/fixtures/typescript-ts-extension-rewrites/expected/Demo.svelte
+++ b/packages/package/test/fixtures/typescript-ts-extension-rewrites/expected/Demo.svelte
@@ -3,3 +3,5 @@
 </script>
 
 {helper()}{helper2()}
+
+<pre>import.meta.glob('./helper*.ts')</pre>

--- a/packages/package/test/fixtures/typescript-ts-extension-rewrites/expected/index.js
+++ b/packages/package/test/fixtures/typescript-ts-extension-rewrites/expected/index.js
@@ -1,3 +1,18 @@
 import { helper } from "./helper.js";
 import { helper2 } from "./helper2.js";
+import.meta.glob('./helper*.js');
+import.meta.glob(["./helper*.js", '!./helper2.js'], { eager: true });
+import.meta.glob(`../lib/*.js`);
+import.meta.glob('./it\'s.js');
+import.meta.glob("./escaped.js");
+const pattern = "./helper*.ts";
+import.meta.glob(pattern);
+import.meta.glob(["./helper*.ts", pattern]);
+import.meta.glob?.("./optional-call.ts");
+import.meta?.glob("./optional-access.ts");
+import.meta["glob"]("./element-access.ts");
+const text = "import.meta.glob('./helper*.ts')";
+const glob = { glob: (_pattern) => text };
+glob.glob("./helper*.ts");
+// import.meta.glob('./helper*.ts') must remain unchanged in comments.
 export { helper, helper2 };

--- a/packages/package/test/fixtures/typescript-ts-extension-rewrites/src/lib/Demo.svelte
+++ b/packages/package/test/fixtures/typescript-ts-extension-rewrites/src/lib/Demo.svelte
@@ -4,3 +4,5 @@
 </script>
 
 {helper()}{helper2()}
+
+<pre>import.meta.glob('./helper*.ts')</pre>

--- a/packages/package/test/fixtures/typescript-ts-extension-rewrites/src/lib/index.ts
+++ b/packages/package/test/fixtures/typescript-ts-extension-rewrites/src/lib/index.ts
@@ -1,3 +1,23 @@
 import { helper } from '#lib/helper.ts';
 import { helper2 } from './helper2.ts';
+
+import.meta.glob('./helper*.ts');
+import.meta.glob(["./helper*.ts", '!./helper2.ts'], { eager: true });
+import.meta.glob(`../lib/*.ts`);
+import.meta.glob('./it\'s.ts');
+import.meta.glob("./escaped\u002ets");
+
+const pattern = './helper*.ts';
+import.meta.glob(pattern);
+import.meta.glob(['./helper*.ts', pattern]);
+import.meta.glob?.('./optional-call.ts');
+import.meta?.glob('./optional-access.ts');
+import.meta['glob']('./element-access.ts');
+
+const text = "import.meta.glob('./helper*.ts')";
+const glob = { glob: (_pattern: string) => text };
+glob.glob('./helper*.ts');
+
+// import.meta.glob('./helper*.ts') must remain unchanged in comments.
+
 export { helper, helper2 };

--- a/packages/package/test/fixtures/typescript-ts-extension-rewrites/tsconfig.json
+++ b/packages/package/test/fixtures/typescript-ts-extension-rewrites/tsconfig.json
@@ -2,6 +2,7 @@
 	"compilerOptions": {
 		"target": "ESNext",
 		"module": "ESNext",
+		"types": ["vite/client"],
 		"allowImportingTsExtensions": true,
 		"rewriteRelativeImportExtensions": true
 	}

--- a/packages/package/test/index.spec.js
+++ b/packages/package/test/index.spec.js
@@ -7,6 +7,7 @@ import { test, expect } from 'vitest';
 
 import { build, watch } from '../src/index.js';
 import { load_config } from '../src/config.js';
+import { transpile_ts } from '../src/typescript.js';
 import { _create_validator } from '../src/validate.js';
 import { resolve_aliases } from '../src/utils.js';
 import { walk } from '../src/filesystem.js';
@@ -141,6 +142,19 @@ test('create package with typescript using nodenext', async () => {
 
 test('create package with .ts extension rewrites, including for aliases', async () => {
 	await test_make_package('typescript-ts-extension-rewrites');
+});
+
+test('does not rewrite import.meta.glob without .ts extension rewrites', async () => {
+	const source = "import './helper.ts';\nimport.meta.glob('./helper*.ts');\n";
+	const output = await transpile_ts(
+		join(import.meta.dirname, '..', 'tsconfig.json'),
+		join(import.meta.dirname, 'fixtures', 'no-ts-extension-rewrites.ts'),
+		source,
+		new Map()
+	);
+
+	expect(output).toContain("import './helper.ts';");
+	expect(output).toContain("import.meta.glob('./helper*.ts');");
 });
 
 // only run this test in newer Node versions


### PR DESCRIPTION
closes #9423

With `rewriteRelativeImportExtensions` enabled, `svelte-package` already emits `.ts` modules as `.js` and rewrites explicit imports. Static `import.meta.glob` patterns were left pointing at the source extension, so they no longer matched the packaged files.

This applies the same rewrite to relative static glob patterns, including arrays, negated patterns, and no-substitution template literals. Dynamic patterns and calls that are not Vite's exact `import.meta.glob` form remain unchanged.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

Validated with:
- `pnpm run format`
- `pnpm run lint`
- `pnpm run check`
- `pnpm -F @sveltejs/package test`
- `pnpm -F @sveltejs/kit test:unit`

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
