### PR TITLE
fix: read zero-length files at the end of a binary form payload

### DIFF
--- a/.changeset/chain-body-reads.md
+++ b/.changeset/chain-body-reads.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: keep at most one pending body read at a time when deserializing binary forms

--- a/.changeset/shared-read-range.md
+++ b/.changeset/shared-read-range.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correctly read zero-length files at the end of a binary form payload

--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -198,7 +198,9 @@ export async function deserialize_binary_form(request, form_id) {
 
 		let i = chunks.length;
 		while (i <= index) {
-			chunks[i] = reader.read().then((chunk) => chunk.value);
+			// chain reads so only one is ever pending — workerd forbids concurrent reads
+			const previous = chunks[i - 1] ?? Promise.resolve(undefined);
+			chunks[i] = previous.then(() => reader.read()).then((chunk) => chunk.value);
 			i++;
 		}
 		return chunks[index];

--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -210,47 +210,23 @@ export async function deserialize_binary_form(request, form_id) {
 	 * @returns {Promise<Uint8Array | null>}
 	 */
 	async function get_buffer(offset, length) {
-		/** @type {Uint8Array} */
-		let start_chunk;
-		let chunk_start = 0;
-		/** @type {number} */
-		let chunk_index;
-		for (chunk_index = 0; ; chunk_index++) {
-			const chunk = await get_chunk(chunk_index);
-			if (!chunk) return null;
+		/** @type {Uint8Array<ArrayBuffer>[]} */
+		const parts = [];
+		let total = 0;
+		for await (const part of read_range(get_chunk, offset, length)) {
+			parts.push(part);
+			total += part.byteLength;
+		}
+		if (total < length || parts.length === 0) return null;
+		// If the buffer is completely contained in one chunk, return the subarray as-is
+		if (parts.length === 1) return parts[0];
 
-			const chunk_end = chunk_start + chunk.byteLength;
-			// If this chunk contains the target offset
-			if (offset >= chunk_start && offset < chunk_end) {
-				start_chunk = chunk;
-				break;
-			}
-			chunk_start = chunk_end;
-		}
-		// If the buffer is completely contained in one chunk, do a subarray
-		if (offset + length <= chunk_start + start_chunk.byteLength) {
-			return start_chunk.subarray(offset - chunk_start, offset + length - chunk_start);
-		}
-		// Otherwise, copy the data into a new buffer
-		const chunks = [start_chunk.subarray(offset - chunk_start)];
-		let cursor = start_chunk.byteLength - offset + chunk_start;
-		while (cursor < length) {
-			chunk_index++;
-			let chunk = await get_chunk(chunk_index);
-			if (!chunk) return null;
-			if (chunk.byteLength > length - cursor) {
-				chunk = chunk.subarray(0, length - cursor);
-			}
-			chunks.push(chunk);
-			cursor += chunk.byteLength;
-		}
 		const buffer = new Uint8Array(length);
-		cursor = 0;
-		for (const chunk of chunks) {
-			buffer.set(chunk, cursor);
-			cursor += chunk.byteLength;
+		let cursor = 0;
+		for (const part of parts) {
+			buffer.set(part, cursor);
+			cursor += part.byteLength;
 		}
-
 		return buffer;
 	}
 
@@ -366,6 +342,32 @@ function deserialize_error(message) {
 	return new SvelteKitError(400, 'Bad Request', `Could not deserialize binary form: ${message}`);
 }
 
+/**
+ * Yields the chunks that make up the byte range `[offset, offset + length)`,
+ * trimmed to its boundaries. Ends early if the underlying data runs out.
+ * @param {(index: number) => Promise<Uint8Array<ArrayBuffer> | undefined>} get_chunk
+ * @param {number} offset
+ * @param {number} length
+ * @returns {AsyncGenerator<Uint8Array<ArrayBuffer>, void, void>}
+ */
+async function* read_range(get_chunk, offset, length) {
+	let chunk_start = 0;
+	for (let index = 0; ; index++) {
+		const chunk = await get_chunk(index);
+		if (!chunk) return;
+
+		const chunk_end = chunk_start + chunk.byteLength;
+		if (chunk_end > offset) {
+			yield chunk.subarray(
+				Math.max(0, offset - chunk_start),
+				Math.min(chunk.byteLength, offset + length - chunk_start)
+			);
+			if (offset + length <= chunk_end) return;
+		}
+		chunk_start = chunk_end;
+	}
+}
+
 /** @implements {File} */
 class LazyFile {
 	/** @type {(index: number) => Promise<Uint8Array<ArrayBuffer> | undefined>} */
@@ -436,49 +438,21 @@ class LazyFile {
 		return file;
 	}
 	stream() {
+		const range = read_range(this.#get_chunk, this.#offset, this.size);
 		let cursor = 0;
-		let chunk_index = 0;
 		return new ReadableStream({
-			start: async (controller) => {
-				let chunk_start = 0;
-				/** @type {Uint8Array} */
-				let start_chunk;
-				for (chunk_index = 0; ; chunk_index++) {
-					const chunk = await this.#get_chunk(chunk_index);
-					if (!chunk) return null;
-
-					const chunk_end = chunk_start + chunk.byteLength;
-					// If this chunk contains the target offset
-					if (this.#offset >= chunk_start && this.#offset < chunk_end) {
-						start_chunk = chunk;
-						break;
-					}
-					chunk_start = chunk_end;
-				}
-				// If the buffer is completely contained in one chunk, do a subarray
-				if (this.#offset + this.size <= chunk_start + start_chunk.byteLength) {
-					controller.enqueue(
-						start_chunk.subarray(this.#offset - chunk_start, this.#offset + this.size - chunk_start)
-					);
-					controller.close();
-				} else {
-					controller.enqueue(start_chunk.subarray(this.#offset - chunk_start));
-					cursor = start_chunk.byteLength - this.#offset + chunk_start;
-				}
-			},
 			pull: async (controller) => {
-				chunk_index++;
-				let chunk = await this.#get_chunk(chunk_index);
-				if (!chunk) {
-					controller.error('incomplete file data');
-					controller.close();
+				const { value, done } = await range.next();
+				if (done) {
+					if (cursor < this.size) {
+						controller.error('incomplete file data');
+					} else {
+						controller.close();
+					}
 					return;
 				}
-				if (chunk.byteLength > this.size - cursor) {
-					chunk = chunk.subarray(0, this.size - cursor);
-				}
-				controller.enqueue(chunk);
-				cursor += chunk.byteLength;
+				cursor += value.byteLength;
+				controller.enqueue(value);
 				if (cursor >= this.size) {
 					controller.close();
 				}

--- a/packages/kit/src/runtime/form-utils.spec.js
+++ b/packages/kit/src/runtime/form-utils.spec.js
@@ -791,40 +791,6 @@ describe('binary form serializer', () => {
 		expect(await res.data.empty.text()).toBe('');
 	});
 
-	test('reads two larger files concurrently from a chunked body', async () => {
-		const a_data = 'a'.repeat(200_000);
-		const b_data = 'b'.repeat(200_000);
-		const { blob } = serialize_binary_form(
-			{
-				a: new File([a_data], 'a.txt', { type: 'text/plain' }),
-				b: new File([b_data], 'b.txt', { type: 'text/plain' })
-			},
-			{}
-		);
-		const bytes = new Uint8Array(await blob.arrayBuffer());
-		const stream = new ReadableStream({
-			start(controller) {
-				for (let i = 0; i < bytes.length; i += 4096) {
-					controller.enqueue(bytes.subarray(i, i + 4096));
-				}
-				controller.close();
-			}
-		});
-		const res = await deserialize_binary_form(
-			new Request('http://test', {
-				method: 'POST',
-				body: stream,
-				// @ts-expect-error duplex required in node
-				duplex: 'half',
-				headers: {
-					'Content-Type': BINARY_FORM_CONTENT_TYPE
-				}
-			})
-		);
-		const [a, b] = await Promise.all([res.data.a.text(), res.data.b.text()]);
-		expect(a).toBe(a_data);
-		expect(b).toBe(b_data);
-	});
 });
 
 describe('deep_set', () => {

--- a/packages/kit/src/runtime/form-utils.spec.js
+++ b/packages/kit/src/runtime/form-utils.spec.js
@@ -774,6 +774,22 @@ describe('binary form serializer', () => {
 		expect(res.data.c.size).toBe(1);
 		expect(await res.data.c.text()).toBe('x');
 	});
+
+	test('reads a zero-length file at the end of the payload', async () => {
+		const { blob } = serialize_binary_form({ empty: new File([], 'empty.txt') }, {});
+		const res = await deserialize_binary_form(
+			new Request('http://test', {
+				method: 'POST',
+				body: blob,
+				headers: {
+					'Content-Type': BINARY_FORM_CONTENT_TYPE,
+					'Content-Length': blob.size.toString()
+				}
+			})
+		);
+		expect(res.data.empty.size).toBe(0);
+		expect(await res.data.empty.text()).toBe('');
+	});
 });
 
 describe('deep_set', () => {

--- a/packages/kit/src/runtime/form-utils.spec.js
+++ b/packages/kit/src/runtime/form-utils.spec.js
@@ -785,7 +785,8 @@ describe('binary form serializer', () => {
 					'Content-Type': BINARY_FORM_CONTENT_TYPE,
 					'Content-Length': blob.size.toString()
 				}
-			})
+			}),
+			''
 		);
 		expect(res.data.empty.size).toBe(0);
 		expect(await res.data.empty.text()).toBe('');

--- a/packages/kit/src/runtime/form-utils.spec.js
+++ b/packages/kit/src/runtime/form-utils.spec.js
@@ -790,6 +790,41 @@ describe('binary form serializer', () => {
 		expect(res.data.empty.size).toBe(0);
 		expect(await res.data.empty.text()).toBe('');
 	});
+
+	test('reads two larger files concurrently from a chunked body', async () => {
+		const a_data = 'a'.repeat(200_000);
+		const b_data = 'b'.repeat(200_000);
+		const { blob } = serialize_binary_form(
+			{
+				a: new File([a_data], 'a.txt', { type: 'text/plain' }),
+				b: new File([b_data], 'b.txt', { type: 'text/plain' })
+			},
+			{}
+		);
+		const bytes = new Uint8Array(await blob.arrayBuffer());
+		const stream = new ReadableStream({
+			start(controller) {
+				for (let i = 0; i < bytes.length; i += 4096) {
+					controller.enqueue(bytes.subarray(i, i + 4096));
+				}
+				controller.close();
+			}
+		});
+		const res = await deserialize_binary_form(
+			new Request('http://test', {
+				method: 'POST',
+				body: stream,
+				// @ts-expect-error duplex required in node
+				duplex: 'half',
+				headers: {
+					'Content-Type': BINARY_FORM_CONTENT_TYPE
+				}
+			})
+		);
+		const [a, b] = await Promise.all([res.data.a.text(), res.data.b.text()]);
+		expect(a).toBe(a_data);
+		expect(b).toBe(b_data);
+	});
 });
 
 describe('deep_set', () => {

--- a/packages/kit/src/runtime/form-utils.spec.js
+++ b/packages/kit/src/runtime/form-utils.spec.js
@@ -790,7 +790,6 @@ describe('binary form serializer', () => {
 		expect(res.data.empty.size).toBe(0);
 		expect(await res.data.empty.text()).toBe('');
 	});
-
 });
 
 describe('deep_set', () => {


### PR DESCRIPTION
closes #16116

`get_buffer` and `LazyFile#stream` each had their own copy of the chunk-range scan, now shared as a `read_range` async generator. This fixes reading a zero-length file at the exact end of the payload, which errored with 'incomplete file data' because the scan never found a chunk containing its offset. The new test fails without the change.

Body reads are also chained now so that at most one is pending at a time, which workerd requires. Verified against the #16116 repro app under wrangler: on 3.0.0-next.4 the upload fails as reported, with this patch applied both files read completely.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
