### PR TITLE
chore: unify walk and list_files

### DIFF
--- a/.changeset/unify-walk-helpers.md
+++ b/.changeset/unify-walk-helpers.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+chore: unify the `walk` and `list_files` filesystem helpers

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -18,13 +18,12 @@ import { extname, resolve, join, dirname, relative } from 'node:path';
 import { pipeline } from 'node:stream';
 import { promisify } from 'node:util';
 import zlib from 'node:zlib';
-import { copy } from '../../utils/filesystem.js';
+import { copy, walk } from '../../utils/filesystem.js';
 import { posixify } from '../../utils/os.js';
 import { generate_manifest } from '../generate_manifest/index.js';
 import { get_route_segments } from '../../utils/routing.js';
 import generate_fallback from '../postbuild/fallback.js';
 import { write } from '../sync/utils.js';
-import { list_files } from '../utils.js';
 import { find_server_assets } from '../generate_manifest/find_server_assets.js';
 import { create_exported_declarations } from '../env.js';
 import { handle_issues, validate } from '../../exports/internal/env.js';
@@ -120,7 +119,7 @@ export function create_builder({
 				return [];
 			}
 
-			const files = list_files(directory, (file) => extensions.includes(extname(file)));
+			const files = [...walk(directory)].filter((file) => extensions.includes(extname(file)));
 
 			await Promise.all(
 				files.flatMap((file) => {

--- a/packages/kit/src/core/adapt/builder.spec.js
+++ b/packages/kit/src/core/adapt/builder.spec.js
@@ -3,8 +3,7 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { assert, expect, test } from 'vitest';
 import { create_builder } from './builder.js';
-import { posixify } from '../../utils/os.js';
-import { list_files } from '../utils.js';
+import { walk } from '../../utils/filesystem.js';
 
 test('copy files', () => {
 	const cwd = join(import.meta.dirname, 'fixtures/basic');
@@ -41,15 +40,15 @@ test('copy files', () => {
 
 	rmSync(dest, { recursive: true, force: true });
 
-	expect(builder.writeClient(dest)).toEqual(list_files(dest).map(posixify));
-	expect(
-		list_files(`${outDir}/output/client`).filter((file) => !file.startsWith('.vite/'))
-	).toEqual(list_files(dest));
+	expect(builder.writeClient(dest)).toEqual([...walk(dest)]);
+	expect([...walk(`${outDir}/output/client`)].filter((file) => !file.startsWith('.vite/'))).toEqual(
+		[...walk(dest)]
+	);
 
 	rmSync(dest, { recursive: true, force: true });
 
-	expect(builder.writeServer(dest)).toEqual(list_files(dest).map(posixify));
-	expect(list_files(`${outDir}/output/server`)).toEqual(list_files(dest));
+	expect(builder.writeServer(dest)).toEqual([...walk(dest)]);
+	expect([...walk(`${outDir}/output/server`)]).toEqual([...walk(dest)]);
 
 	rmSync(dest, { force: true, recursive: true });
 });

--- a/packages/kit/src/core/postbuild/prerender.js
+++ b/packages/kit/src/core/postbuild/prerender.js
@@ -3,7 +3,6 @@ import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'no
 import { dirname, join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { walk } from '../../utils/filesystem.js';
-import { posixify } from '../../utils/os.js';
 import { noop } from '../../utils/functions.js';
 import { decode_uri, is_root_relative, resolve } from '../../utils/url.js';
 import { escape_html } from '../../utils/escape.js';

--- a/packages/kit/src/core/postbuild/prerender.js
+++ b/packages/kit/src/core/postbuild/prerender.js
@@ -256,13 +256,13 @@ async function prerender({
 		return file;
 	}
 
-	const files = new Set(walk(`${out}/client`).map(posixify));
+	const files = new Set(walk(`${out}/client`));
 	files.add(`${config.appDir}/env.js`);
 
 	const immutable = `${config.appDir}/immutable`;
 	if (existsSync(`${out}/server/${immutable}`)) {
 		for (const file of walk(`${out}/server/${immutable}`)) {
-			files.add(posixify(`${config.appDir}/immutable/${file}`));
+			files.add(`${config.appDir}/immutable/${file}`);
 		}
 	}
 

--- a/packages/kit/src/core/sync/create_manifest_data/index.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.js
@@ -2,10 +2,10 @@ import { lookup } from '../../../utils/mime.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import { styleText } from 'node:util';
-import { resolve_entry } from '../../../utils/filesystem.js';
+import { resolve_entry, walk } from '../../../utils/filesystem.js';
 import { posixify } from '../../../utils/os.js';
 import { parse_route_id } from '../../../utils/routing.js';
-import { list_files, runtime_directory } from '../../utils.js';
+import { runtime_directory } from '../../utils.js';
 import { prevent_conflicts } from './conflict.js';
 import { sort_routes } from './sort.js';
 import {
@@ -74,7 +74,9 @@ export function is_app_route(route) {
  * @param {import('types').ValidatedConfig} config
  */
 export function create_assets(config) {
-	return list_files(config.files.assets).map((file) => ({
+	if (!fs.existsSync(config.files.assets)) return [];
+
+	return [...walk(config.files.assets)].map((file) => ({
 		file,
 		size: fs.statSync(path.resolve(config.files.assets, file)).size,
 		type: lookup(file) || null

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -42,12 +42,12 @@ export function write_all_types(config, manifest_data, root) {
 		posixify(path.relative(root, config.files.routes))
 	);
 	const expected_directories = new Set(
-		manifest_data.routes.map((route) => path.join(routes_dir, route.id))
+		manifest_data.routes.map((route) => path.posix.join(routes_dir, route.id))
 	);
 
 	if (fs.existsSync(types_dir)) {
 		for (const file of walk(types_dir)) {
-			const dir = path.dirname(file);
+			const dir = path.posix.dirname(file);
 			if (!expected_directories.has(dir)) {
 				fs.rmSync(path.join(types_dir, file), { force: true, recursive: true });
 			}

--- a/packages/kit/src/core/utils.js
+++ b/packages/kit/src/core/utils.js
@@ -1,4 +1,3 @@
-import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { styleText } from 'node:util';
@@ -84,31 +83,4 @@ export function get_mime_lookup(manifest_data) {
 	});
 
 	return mime;
-}
-
-/**
- * @param {string} dir
- * @param {(file: string) => boolean} [filter]
- */
-export function list_files(dir, filter) {
-	/** @type {string[]} */
-	const files = [];
-
-	/** @param {string} current */
-	function walk(current) {
-		for (const file of fs.readdirSync(path.resolve(dir, current))) {
-			const child = path.posix.join(current, file);
-			if (fs.statSync(path.resolve(dir, child)).isDirectory()) {
-				walk(child);
-			} else {
-				if (!filter || filter(child)) {
-					files.push(child);
-				}
-			}
-		}
-	}
-
-	if (fs.existsSync(dir)) walk('');
-
-	return files;
 }

--- a/packages/kit/src/utils/filesystem.js
+++ b/packages/kit/src/utils/filesystem.js
@@ -63,30 +63,18 @@ export function copy(source, target, opts = {}) {
 /**
  * Get a list of all files in a directory
  * @param {string} cwd - the directory to walk
- * @param {boolean} [dirs] - whether to include directories in the result
- * @returns {string[]} a list of all found files (and possibly directories) relative to `cwd`
+ * @param {string} [dir] - the subdirectory to walk, relative to `cwd`
+ * @returns {Generator<string>} the posix paths of all found files, relative to `cwd`
  */
-export function walk(cwd, dirs = false) {
-	/** @type {string[]} */
-	const all_files = [];
-
-	/** @param {string} dir */
-	function walk_dir(dir) {
-		const files = fs.readdirSync(path.join(cwd, dir));
-
-		for (const file of files) {
-			const joined = path.join(dir, file);
-			const stats = fs.statSync(path.join(cwd, joined));
-			if (stats.isDirectory()) {
-				if (dirs) all_files.push(joined);
-				walk_dir(joined);
-			} else {
-				all_files.push(joined);
-			}
+export function* walk(cwd, dir = '') {
+	for (const file of fs.readdirSync(path.join(cwd, dir))) {
+		const joined = dir ? `${dir}/${file}` : file;
+		if (fs.statSync(path.join(cwd, joined)).isDirectory()) {
+			yield* walk(cwd, joined);
+		} else {
+			yield joined;
 		}
 	}
-
-	return (walk_dir(''), all_files);
 }
 
 /**


### PR DESCRIPTION
`walk` in `utils/filesystem.js` and `list_files` in `core/utils.js` were the same recursive walk with minor drift. Merged into one generator that yields posix paths. `walk`'s `dirs` parameter had no callers.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
