### PR TITLE
fix: strip trailing slashes from prerendered paths in edge function exclude list

### DIFF
--- a/.changeset/lazy-pugs-refuse.md
+++ b/.changeset/lazy-pugs-refuse.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-netlify': patch
+---
+
+fix: strip trailing slashes from prerendered paths in the edge function exclude list, so the root page is served statically when using a base path

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -387,7 +387,9 @@ async function generate_edge_functions({ builder }) {
 		// Contains static files
 		`/${builder.getAppPath()}/immutable/*`,
 		`/${builder.getAppPath()}/version.json`,
-		...builder.prerendered.paths,
+		// the root page with a base path and `trailingSlash: 'always'` pages are recorded
+		// with a trailing slash, which Netlify treats as required rather than optional
+		...builder.prerendered.paths.map((path) => (path === '/' ? path : path.replace(/\/$/, ''))),
 		...Array.from(assets).flatMap((asset) => {
 			if (asset.endsWith('/index.html')) {
 				const dir = asset.replace(/\/index\.html$/, '');

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -387,8 +387,7 @@ async function generate_edge_functions({ builder }) {
 		// Contains static files
 		`/${builder.getAppPath()}/immutable/*`,
 		`/${builder.getAppPath()}/version.json`,
-		// the root page with a base path and `trailingSlash: 'always'` pages are recorded
-		// with a trailing slash, which Netlify treats as required rather than optional
+		// the base root and `trailingSlash: 'always'` pages are recorded with a trailing slash
 		...builder.prerendered.paths.map((path) => (path === '/' ? path : path.replace(/\/$/, ''))),
 		...Array.from(assets).flatMap((asset) => {
 			if (asset.endsWith('/index.html')) {


### PR DESCRIPTION
Fixes #13310. Netlify treats a trailing slash in `excludedPath` as required rather than optional, but the prerendered root is recorded as `/base/` when a base path is set, and `trailingSlash: 'always'` pages as `/foo/`, so they were never excluded and hit the edge function.

Alternative to #16472.
