### PR TITLE
fix: derive the fetch cache key in one place

### DIFF
--- a/.changeset/fetch-cache-key-consolidation.md
+++ b/.changeset/fetch-cache-key-consolidation.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: don't throw when serializing a `load` `fetch` whose request body can't be hashed

--- a/.changeset/fetch-cache-non-canonical-url.md
+++ b/.changeset/fetch-cache-non-canonical-url.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: reuse SSR-cached fetch responses during hydration when a cross-origin URL is not in canonical form

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1074,12 +1074,11 @@ function resolve_fetch_url(input, init, url) {
 	// we must fixup relative urls so they are resolved from the target page
 	const resolved = new URL(input instanceof Request ? input.url : input, url);
 
-	// match ssr serialized data url, which is important to find cached responses
-	// (the server serializes the normalized href)
+	// match the server's serialization of `fetched.url` (see load_data.js): a path for same-origin
+	// urls, so prerendered pages can be served from any origin, the normalized href otherwise
 	const requested =
 		resolved.origin === url.origin ? resolved.href.slice(url.origin.length) : resolved.href;
 
-	// prerendered pages may be served from any origin, so `initial_fetch` urls shouldn't be resolved
 	const promise = started
 		? subsequent_fetch(requested, resolved.href, init)
 		: initial_fetch(requested, init);

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1071,15 +1071,13 @@ async function load_node({ loader, parent, url, params, route, server_data_node 
  * @param {URL} url
  */
 function resolve_fetch_url(input, init, url) {
-	let requested = input instanceof Request ? input.url : input;
-
 	// we must fixup relative urls so they are resolved from the target page
-	const resolved = new URL(requested, url);
+	const resolved = new URL(input instanceof Request ? input.url : input, url);
 
 	// match ssr serialized data url, which is important to find cached responses
-	if (resolved.origin === url.origin) {
-		requested = resolved.href.slice(url.origin.length);
-	}
+	// (the server serializes the normalized href)
+	const requested =
+		resolved.origin === url.origin ? resolved.href.slice(url.origin.length) : resolved.href;
 
 	// prerendered pages may be served from any origin, so `initial_fetch` urls shouldn't be resolved
 	const promise = started

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -38,6 +38,7 @@ import {
 	INVALIDATED_PARAM,
 	TRAILING_SLASH_PARAM,
 	create_remote_key,
+	fetch_cache_url,
 	validate_depends,
 	validate_load_response
 } from '../shared.js';
@@ -1074,10 +1075,8 @@ function resolve_fetch_url(input, init, url) {
 	// we must fixup relative urls so they are resolved from the target page
 	const resolved = new URL(input instanceof Request ? input.url : input, url);
 
-	// match the server's serialization of `fetched.url` (see load_data.js): a path for same-origin
-	// urls, so prerendered pages can be served from any origin, the normalized href otherwise
-	const requested =
-		resolved.origin === url.origin ? resolved.href.slice(url.origin.length) : resolved.href;
+	// match the url under which the server serialized the response
+	const requested = fetch_cache_url(resolved, url);
 
 	const promise = started
 		? subsequent_fetch(requested, resolved.href, init)

--- a/packages/kit/src/runtime/client/fetcher.js
+++ b/packages/kit/src/runtime/client/fetcher.js
@@ -1,6 +1,6 @@
 import { BROWSER, DEV } from 'esm-env';
 import { noop } from '../../utils/functions.js';
-import { hash } from '../../utils/hash.js';
+import { fetch_cache_url, fetch_request_hash } from '../shared.js';
 import { base64_decode } from '../utils.js';
 
 let loading = 0;
@@ -157,10 +157,10 @@ export function dev_fetch(resource, opts) {
  * @param {RequestInfo | URL} input
  */
 function requested_url(input) {
-	const resolved = new URL(input instanceof Request ? input.url : input, location.href);
-	return resolved.origin === location.origin
-		? resolved.href.slice(location.origin.length)
-		: resolved.href;
+	return fetch_cache_url(
+		new URL(input instanceof Request ? input.url : input, location.href),
+		location
+	);
 }
 
 /**
@@ -173,19 +173,10 @@ function build_selector(resource, opts) {
 
 	let selector = `script[data-sveltekit-fetched][data-url=${url}]`;
 
-	if (opts?.headers || opts?.body) {
-		/** @type {import('types').StrictBody[]} */
-		const values = [];
+	const request_hash = fetch_request_hash(opts?.headers, opts?.body);
 
-		if (opts.headers) {
-			values.push([...new Headers(opts.headers)].join(','));
-		}
-
-		if (opts.body && (typeof opts.body === 'string' || ArrayBuffer.isView(opts.body))) {
-			values.push(opts.body);
-		}
-
-		selector += `[data-hash="${hash(...values)}"]`;
+	if (request_hash) {
+		selector += `[data-hash="${request_hash}"]`;
 	}
 
 	return selector;

--- a/packages/kit/src/runtime/client/fetcher.js
+++ b/packages/kit/src/runtime/client/fetcher.js
@@ -61,7 +61,7 @@ if (DEV && BROWSER) {
 		const method = input instanceof Request ? input.method : init?.method || 'GET';
 
 		if (method !== 'GET') {
-			cache.delete(build_selector(input));
+			cache.delete(build_selector(requested_url(input)));
 		}
 
 		return native_fetch(input, init);
@@ -71,7 +71,7 @@ if (DEV && BROWSER) {
 		const method = input instanceof Request ? input.method : init?.method || 'GET';
 
 		if (method !== 'GET') {
-			cache.delete(build_selector(input));
+			cache.delete(build_selector(requested_url(input)));
 		}
 
 		return native_fetch(input, init);
@@ -149,6 +149,18 @@ export function dev_fetch(resource, opts) {
 		configurable: true
 	});
 	return window.fetch(resource, patched_opts);
+}
+
+/**
+ * Mirror the url normalization in `resolve_fetch_url`, so that non-GET requests
+ * evict the cache entry regardless of how the url is spelled
+ * @param {RequestInfo | URL} input
+ */
+function requested_url(input) {
+	const resolved = new URL(input instanceof Request ? input.url : input, location.href);
+	return resolved.origin === location.origin
+		? resolved.href.slice(location.origin.length)
+		: resolved.href;
 }
 
 /**

--- a/packages/kit/src/runtime/server/page/load_data.js
+++ b/packages/kit/src/runtime/server/page/load_data.js
@@ -1,7 +1,7 @@
 import { DEV } from 'esm-env';
 import { noop } from '../../../utils/functions.js';
 import { disable_search, make_trackable } from '../../../utils/url.js';
-import { validate_depends, validate_load_response } from '../../shared.js';
+import { fetch_cache_url, validate_depends, validate_load_response } from '../../shared.js';
 import { with_request_store, merge_tracing } from '@sveltejs/kit/internal/server';
 import { record_span } from '../../telemetry/record_span.js';
 import { base64_encode } from '../../utils.js';
@@ -335,13 +335,12 @@ export function create_universal_fetch(event, state, fetched, csr, resolve_opts)
 					}
 
 					fetched.push({
-						url: same_origin ? url.href.slice(event.url.origin.length) : url.href,
+						url: fetch_cache_url(url, event.url),
 						method: event.request.method,
-						request_body: /** @type {string | ArrayBufferView | undefined} */ (
+						request_body:
 							input instanceof Request && cloned_body
 								? await stream_to_string(cloned_body)
-								: init?.body
-						),
+								: init?.body,
 						request_headers: cloned_headers,
 						response_body: body,
 						response,

--- a/packages/kit/src/runtime/server/page/serialize_data.js
+++ b/packages/kit/src/runtime/server/page/serialize_data.js
@@ -1,5 +1,5 @@
 import { escape_html } from '../../../utils/escape.js';
-import { hash } from '../../../utils/hash.js';
+import { fetch_request_hash } from '../../shared.js';
 
 /**
  * Inside a script element, only `</script` and `<!--` hold special meaning to the HTML parser.
@@ -77,19 +77,10 @@ export function serialize_data(fetched, filter, prerendering = false) {
 		attrs.push('data-b64');
 	}
 
-	if (fetched.request_headers || fetched.request_body) {
-		/** @type {import('types').StrictBody[]} */
-		const values = [];
+	const request_hash = fetch_request_hash(fetched.request_headers, fetched.request_body);
 
-		if (fetched.request_headers) {
-			values.push([...new Headers(fetched.request_headers)].join(','));
-		}
-
-		if (fetched.request_body) {
-			values.push(fetched.request_body);
-		}
-
-		attrs.push(`data-hash="${hash(...values)}"`);
+	if (request_hash) {
+		attrs.push(`data-hash="${request_hash}"`);
 	}
 
 	// Compute the time the response should be cached, taking into account max-age and age.

--- a/packages/kit/src/runtime/server/page/serialize_data.spec.js
+++ b/packages/kit/src/runtime/server/page/serialize_data.spec.js
@@ -81,6 +81,40 @@ test('computes ttl using cache-control and age headers', () => {
 	);
 });
 
+test('hashes string request bodies', () => {
+	const response_body = '';
+	assert.equal(
+		serialize_data(
+			{
+				url: 'foo',
+				method: 'GET',
+				request_body: 'the body',
+				response_body,
+				response: new Response(response_body)
+			},
+			() => false
+		),
+		'<script type="application/json" data-sveltekit-fetched data-url="foo" data-hash="1e82ux8">{"status":200,"statusText":"","headers":{},"body":""}</script>'
+	);
+});
+
+test('excludes request bodies the client cannot hash identically', () => {
+	const response_body = '';
+	assert.equal(
+		serialize_data(
+			{
+				url: 'foo',
+				method: 'GET',
+				request_body: new URLSearchParams({ key: 'value' }),
+				response_body,
+				response: new Response(response_body)
+			},
+			() => false
+		),
+		'<script type="application/json" data-sveltekit-fetched data-url="foo">{"status":200,"statusText":"","headers":{},"body":""}</script>'
+	);
+});
+
 test("doesn't compute ttl when vary * header is present", () => {
 	const raw = 'an "attr" & a \ud800';
 	const escaped = 'an &quot;attr&quot; &amp; a &#55296;';

--- a/packages/kit/src/runtime/server/page/types.d.ts
+++ b/packages/kit/src/runtime/server/page/types.d.ts
@@ -11,7 +11,7 @@ import { Csp } from './csp.js';
 export interface Fetched {
 	url: string;
 	method: string;
-	request_body?: string | ArrayBufferView | null;
+	request_body?: BodyInit | null;
 	request_headers?: HeadersInit | undefined;
 	response_body: string | undefined;
 	response: Response;

--- a/packages/kit/src/runtime/shared.js
+++ b/packages/kit/src/runtime/shared.js
@@ -1,6 +1,41 @@
 /** @import { Transport } from '@sveltejs/kit' */
 import * as devalue from 'devalue';
+import { hash } from '../utils/hash.js';
 import { base64_decode, base64_encode, text_encoder } from './utils.js';
+
+/**
+ * The url under which a `load` `fetch` response is serialized during SSR and found
+ * again by the client: a path for same-origin urls, so prerendered pages can be
+ * served from any origin, the normalized href otherwise
+ * @param {URL} url
+ * @param {{ origin: string }} base the page url
+ */
+export function fetch_cache_url(url, base) {
+	return url.origin === base.origin ? url.href.slice(base.origin.length) : url.href;
+}
+
+/**
+ * Hash of the request headers and body that distinguishes multiple `load` `fetch`es
+ * to the same url. Bodies that can't be hashed identically on the server and in the
+ * client (streams, `FormData`, ...) are excluded on both sides.
+ * @param {HeadersInit | undefined} headers
+ * @param {unknown} body
+ * @returns {string | null}
+ */
+export function fetch_request_hash(headers, body) {
+	/** @type {import('types').StrictBody[]} */
+	const values = [];
+
+	if (headers) {
+		values.push([...new Headers(headers)].join(','));
+	}
+
+	if (body && (typeof body === 'string' || ArrayBuffer.isView(body))) {
+		values.push(body);
+	}
+
+	return values.length > 0 ? hash(...values) : null;
+}
 
 /**
  * @param {string} route_id

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-external-non-canonical/+page.js
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-external-non-canonical/+page.js
@@ -1,0 +1,9 @@
+/** @type {import('./$types').PageLoad} */
+export async function load({ fetch, url }) {
+	const port = url.searchParams.get('port');
+	// no trailing slash, so it differs from the normalized href
+	const res = await fetch(`http://localhost:${port}`);
+
+	const { count } = await res.json();
+	return { count };
+}

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-external-non-canonical/+page.js
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-external-non-canonical/+page.js
@@ -5,5 +5,5 @@ export async function load({ fetch, url }) {
 	const res = await fetch(`http://localhost:${port}`);
 
 	const { count } = await res.json();
-	return { count };
+	return { count, port };
 }

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-external-non-canonical/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-external-non-canonical/+page.svelte
@@ -1,0 +1,6 @@
+<script>
+	/** @type {import('./$types').PageProps} */
+	let { data } = $props();
+</script>
+
+<h1>count: {data.count}</h1>

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-external-non-canonical/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-external-non-canonical/+page.svelte
@@ -1,6 +1,15 @@
 <script>
+	import { invalidate } from '$app/navigation';
+
 	/** @type {import('./$types').PageProps} */
 	let { data } = $props();
+
+	async function update() {
+		// no trailing slash, so it differs from the normalized cache key
+		await fetch(`http://localhost:${data.port}`, { method: 'POST' });
+		await invalidate(`http://localhost:${data.port}`);
+	}
 </script>
 
 <h1>count: {data.count}</h1>
+<button onclick={update}>update</button>

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -41,6 +41,27 @@ test.describe('Endpoints', () => {
 });
 
 test.describe('Load', () => {
+	test('does not refetch cross-origin urls in non-canonical form during hydration', async ({
+		page,
+		start_server
+	}) => {
+		let requests = 0;
+
+		const { port } = await start_server((req, res) => {
+			requests += 1;
+			res.writeHead(200, {
+				'Access-Control-Allow-Origin': '*',
+				'content-type': 'application/json'
+			});
+			res.end(JSON.stringify({ count: requests }));
+		});
+
+		await page.goto(`/load/fetch-external-non-canonical?port=${port}`);
+
+		await expect(page.locator('h1')).toHaveText('count: 1');
+		expect(requests).toBe(1);
+	});
+
 	test('load function is only called when necessary', async ({ app, page }) => {
 		test.slow();
 		await page.goto('/load/change-detection/one/a');

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -62,6 +62,29 @@ test.describe('Load', () => {
 		expect(requests).toBe(1);
 	});
 
+	test('busts cache if non-GET request to a non-canonical cross-origin url is made', async ({
+		page,
+		start_server
+	}) => {
+		let gets = 0;
+
+		const { port } = await start_server((req, res) => {
+			if (req.method === 'GET') gets += 1;
+			res.writeHead(200, {
+				'Access-Control-Allow-Origin': '*',
+				'cache-control': 'public, max-age=60',
+				'content-type': 'application/json'
+			});
+			res.end(JSON.stringify({ count: gets }));
+		});
+
+		await page.goto(`/load/fetch-external-non-canonical?port=${port}`);
+		await expect(page.locator('h1')).toHaveText('count: 1');
+
+		await page.locator('button').click();
+		await expect(page.locator('h1')).toHaveText('count: 2');
+	});
+
 	test('load function is only called when necessary', async ({ app, page }) => {
 		test.slow();
 		await page.goto('/load/change-detection/one/a');


### PR DESCRIPTION
Follow-up to #16339, draft until it merges since the diff includes its commits until then.

The fetch cache key was derived independently in four places (`push_fetched`, `serialize_data`, `resolve_fetch_url`, `build_selector`) and #14781 was drift between two of them. This derives it in one shared module instead. No change to the serialized format.

This also fixes a bug: the server hashed any truthy request body, so a `load` fetch with a `URLSearchParams` or `FormData` body threw during render. Both sides now use the client's rule and exclude bodies that can't be hashed identically.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
