### PR TITLE
fix(adapter-node): disable tsconfig discovery

### DIFF
--- a/.changeset/clean-tools-adapt.md
+++ b/.changeset/clean-tools-adapt.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+fix: disable unnecessary tsconfig discovery when bundling generated server output

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -91,6 +91,7 @@ export default function (opts = {}) {
 			// will get included in the bundled code
 			const bundle = await rolldown({
 				input,
+				tsconfig: false,
 				external: [
 					// dependencies could have deep exports, so we need a regex
 					...Object.keys(pkg.dependencies || {}).map((d) => new RegExp(`^${d}(\\/.*)?$`)),


### PR DESCRIPTION
closes #16797

Adapter-node's final `rolldown()` pass bundles generated JavaScript, but it currently auto-discovers the app tsconfig. In a clean workspace build, a referenced package can legitimately lack its generated `.svelte-kit/tsconfig.json`; Rolldown then reports `Tsconfig not found` while resolving every generated adapter entry.

This sets `tsconfig: false` for the adapt-time bundle. The issue contains a reduced Alpine fixture and the stock-failure/patched-success logs. A plain Alpine app succeeds without the change, so the report does not attribute the problem to musl itself.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

The linked issue includes a minimal Docker fixture that fails with the stock adapter and succeeds when this option is added.

### Tests

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

Focused validation completed:

- `pnpm --dir packages/adapter-node lint`
- `pnpm --dir packages/adapter-node check`
- `pnpm --dir packages/adapter-node test:unit` (16 tests)
- Minimal Alpine fixture: negative stock build and positive patched build

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
