### PR TITLE
fix: ignore `EEXIST` errors when symlinking traced files in adapter-vercel

### DIFF
--- a/.changeset/vercel-symlink-eexist.md
+++ b/.changeset/vercel-symlink-eexist.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-vercel': patch
+---
+
+fix: ignore `EEXIST` errors when symlinking traced files that resolve to the same destination

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -601,7 +601,13 @@ async function create_function_bundle(builder, entry, dir, config) {
 
 		if (source !== realpath) {
 			const realdest = path.join(dir, path.relative(ancestor, realpath));
-			fs.symlinkSync(path.relative(path.dirname(dest), realdest), dest, is_dir ? 'dir' : 'file');
+			try {
+				fs.symlinkSync(path.relative(path.dirname(dest), realdest), dest, is_dir ? 'dir' : 'file');
+			} catch (error) {
+				// different traced paths can resolve to the same destination
+				// (e.g. multiple pnpm symlink chains pointing at the same real file)
+				if (/** @type {NodeJS.ErrnoException} */ (error).code !== 'EEXIST') throw error;
+			}
 		} else if (!is_dir) {
 			fs.copyFileSync(source, dest);
 		}


### PR DESCRIPTION
closes #16806

In a pnpm workspace, `@vercel/nft` can trace the same dependency through two different symlink chains (e.g. `apps/app/node_modules/X` and `packages/ui/node_modules/X`) that both realpath to the same file in the pnpm store. `create_function_bundle` assumed traced file → destination is 1:1, so the second occurrence hit `fs.symlinkSync` on a `dest` that already existed and crashed the build with `EEXIST`.

Wraps the symlink in a try/catch that ignores `EEXIST` — both chains would produce an equivalent link, so skipping the duplicate is safe.