### PR TITLE
use an alias instead of a resolveId hook

### DIFF
--- a/packages/kit/src/core/env.js
+++ b/packages/kit/src/core/env.js
@@ -252,28 +252,48 @@ export function create_sveltekit_env_public(variables, env, prelude) {
 }
 
 /**
- * Creates the prelude for the dev `<sveltekit:generated>/env/public/client.js` module. The values
- * are inlined as a fallback for contexts that render without the dev server, like vitest browser
- * mode, where nothing sets the global
+ * Creates the `<sveltekit:generated>/env/public/client.js` module used in development. The dynamic
+ * values are inlined as a fallback for contexts that render without the dev server, like vitest
+ * browser mode, where nothing sets the global
  * @param {Record<string, EnvVarConfig<any>> | null} variables
  * @param {Record<string, string>} env
  */
-export function create_dev_public_env_prelude(variables, env) {
+export function create_sveltekit_env_public_dev(variables, env) {
+	if (!variables) {
+		return '';
+	}
+
+	const dev_env = validate_public_env(variables, env, false);
+
+	return create_sveltekit_env_public(
+		variables,
+		env,
+		`const env = globalThis.__sveltekit_dev?.env ?? ${devalue.uneval(dev_env)};`
+	);
+}
+
+/**
+ * @param {Record<string, EnvVarConfig<any>> | null} variables
+ * @param {Record<string, string>} env
+ * @param {boolean} include_static
+ * @returns {Record<string, any>}
+ */
+function validate_public_env(variables, env, include_static) {
 	/** @type {Record<string, StandardSchemaV1.Issue[]>} */
 	const issues = {};
 
 	/** @type {Record<string, any>} */
-	const dev_env = {};
+	const values = {};
 
 	for (const [name, config] of Object.entries(variables ?? {})) {
-		if (!config.public || config.static) continue;
+		if (!config.public || (config.static && !include_static)) continue;
 
-		dev_env[name] = validate(variables ?? {}, env[name], name, issues);
+		values[name] = validate(variables ?? {}, env[name], name, issues);
 	}
 
 	handle_issues(issues);
 
-	return `const env = globalThis.__sveltekit_dev?.env ?? ${devalue.uneval(dev_env)};`;
+	return values;
 }
 
 /**
@@ -322,20 +342,9 @@ export function create_sveltekit_env_service_worker(
  * @param {string} global
  */
 export function create_sveltekit_env_service_worker_dev(variables, env, version, global) {
-	/** @type {string[]} */
-	const properties = [];
-
-	/** @type {Record<string, StandardSchemaV1.Issue[]>} */
-	const issues = {};
-
-	for (const [name, config] of Object.entries(variables ?? {})) {
-		if (!config.public) continue;
-
-		const value = validate(variables ?? {}, env[name], name, issues);
-		properties.push(`${name}: ${devalue.uneval(value)}`);
-	}
-
-	handle_issues(issues);
+	const properties = Object.entries(validate_public_env(variables, env, true)).map(
+		([name, value]) => `${name}: ${devalue.uneval(value)}`
+	);
 
 	return dedent`
 		${global} = {

--- a/packages/kit/src/core/env.js
+++ b/packages/kit/src/core/env.js
@@ -112,12 +112,13 @@ export async function load_explicit_env(kit, file, root, mode) {
 }
 
 /**
- * Creates the `__sveltekit/env` module
+ * Creates the `<sveltekit:generated>/env/config.js` module
  * @param {Record<string, EnvVarConfig<any> | undefined> | null} variables
  * @param {Record<string, string>} env
  * @param {string | null} entry
+ * @param {boolean} is_dev
  */
-export function create_sveltekit_env(variables, env, entry) {
+export function create_sveltekit_env(variables, env, entry, is_dev) {
 	const imports = entry
 		? [
 				`import { variables } from ${JSON.stringify(entry)};`,
@@ -170,33 +171,25 @@ export function create_sveltekit_env(variables, env, entry) {
 			}`
 	];
 
+	if (is_dev) {
+		// In dev, initialise the env immediately. Tools like `vite-node` load modules
+		// through the Vite config but don't run the SvelteKit dev server, which is what
+		// normally calls `set_env`. Without this, dynamic env vars imported from
+		// `$app/env/public` and `$app/env/private` would be `undefined` in such contexts.
+		/** @type {Record<string, string>} */
+		const dev_env = {};
+		for (const name of Object.keys(variables ?? {})) {
+			if (name in env) dev_env[name] = env[name];
+		}
+
+		blocks.push(`set_env(${devalue.uneval(dev_env)});`);
+	}
+
 	return blocks.join('\n\n');
 }
 
 /**
- * @param {Record<string, EnvVarConfig<any> | undefined> | null} variables
- * @param {Record<string, string>} env
- */
-export function create_sveltekit_env_dev(variables, env) {
-	// In dev, initialise the env immediately. Tools like `vite-node` load modules
-	// through the Vite config but don't run the SvelteKit dev server, which is what
-	// normally calls `set_env`. Without this, dynamic env vars imported from
-	// `$app/env/public` and `$app/env/private` would be `undefined` in such contexts.
-	/** @type {Record<string, string>} */
-	const dev_env = {};
-	for (const name of Object.keys(variables ?? {})) {
-		if (name in env) dev_env[name] = env[name];
-	}
-
-	return [
-		`import { set_env } from './config.js';`,
-		`set_env(${devalue.uneval(dev_env)});`,
-		`export * from './config.js';`
-	].join('\n\n');
-}
-
-/**
- * Creates the `__sveltekit/env/private` module
+ * Creates the `<sveltekit:generated>/env/private/server.js` module
  * @param {Record<string, EnvVarConfig<any>> | null} variables
  * @param {Record<string, string>} env
  */
@@ -223,11 +216,11 @@ export function create_sveltekit_env_private(variables, env) {
 
 	handle_issues(issues);
 
-	return `import { dynamic_private_env as env } from '__sveltekit/env';\n\n${exports.join('')}`;
+	return `import { dynamic_private_env as env } from '../config.js';\n\n${exports.join('')}`;
 }
 
 /**
- * Creates the `__sveltekit/env/public/*` modules
+ * Creates the `<sveltekit:generated>/env/public/*` modules
  * @param {Record<string, EnvVarConfig<any>> | null} variables
  * @param {Record<string, string>} env
  * @param {string} prelude
@@ -259,7 +252,7 @@ export function create_sveltekit_env_public(variables, env, prelude) {
 }
 
 /**
- * Creates the `__sveltekit/env/service-worker` module used in production. When an app uses
+ * Creates the `<sveltekit:generated>/env/service-worker.js` module used in production. When an app uses
  * dynamic public env vars, they're loaded at runtime via an import of the prerendered
  * `env.js`. If there are none, values are inlined.
  * @param {Record<string, EnvVarConfig<any>> | null} variables
@@ -297,7 +290,7 @@ export function create_sveltekit_env_service_worker(
 }
 
 /**
- * Creates the `__sveltekit/env/service-worker` module used in development
+ * Creates the `<sveltekit:generated>/env/service-worker.js` module used in development
  * @param {Record<string, EnvVarConfig<any>> | null} variables
  * @param {Record<string, string>} env
  * @param {string} version

--- a/packages/kit/src/core/env.js
+++ b/packages/kit/src/core/env.js
@@ -252,6 +252,31 @@ export function create_sveltekit_env_public(variables, env, prelude) {
 }
 
 /**
+ * Creates the prelude for the dev `<sveltekit:generated>/env/public/client.js` module. The values
+ * are inlined as a fallback for contexts that render without the dev server, like vitest browser
+ * mode, where nothing sets the global
+ * @param {Record<string, EnvVarConfig<any>> | null} variables
+ * @param {Record<string, string>} env
+ */
+export function create_dev_public_env_prelude(variables, env) {
+	/** @type {Record<string, StandardSchemaV1.Issue[]>} */
+	const issues = {};
+
+	/** @type {Record<string, any>} */
+	const dev_env = {};
+
+	for (const [name, config] of Object.entries(variables ?? {})) {
+		if (!config.public || config.static) continue;
+
+		dev_env[name] = validate(variables ?? {}, env[name], name, issues);
+	}
+
+	handle_issues(issues);
+
+	return `const env = globalThis.__sveltekit_dev?.env ?? ${devalue.uneval(dev_env)};`;
+}
+
+/**
  * Creates the `<sveltekit:generated>/env/service-worker.js` module used in production. When an app uses
  * dynamic public env vars, they're loaded at runtime via an import of the prerendered
  * `env.js`. If there are none, values are inlined.

--- a/packages/kit/src/core/postbuild/analyse.js
+++ b/packages/kit/src/core/postbuild/analyse.js
@@ -54,7 +54,7 @@ async function analyse({
 
 	// `set_env` lives in a separate module that imports the user's `src/env` config. We import it
 	// *after* `set_building()` so that `building`-dependent expressions resolve correctly
-	/** @type {typeof import('__sveltekit/env')} */
+	/** @type {typeof import('<sveltekit:generated>/env/config.js')} */
 	const { set_env } = await import(pathToFileURL(`${server_root}/server/env.js`).href);
 	set_env(env);
 

--- a/packages/kit/src/core/postbuild/prerender.js
+++ b/packages/kit/src/core/postbuild/prerender.js
@@ -62,7 +62,7 @@ async function prerender({
 
 	// `set_env` and `Server` live in modules that import the user's `src/env` config. We import them
 	// *after* `set_building()` so that `building`-dependent expressions resolve correctly
-	/** @type {typeof import('__sveltekit/env')} */
+	/** @type {typeof import('<sveltekit:generated>/env/config.js')} */
 	const { set_env } = await import(pathToFileURL(`${out}/server/env.js`).href);
 	set_env(env);
 

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -1154,6 +1154,21 @@ function kit({ svelte_config }) {
 			}
 		},
 
+		// TODO this really ought to be unnecessary — an environment-specific `define`
+		// would be preferable. For whatever reason (possibly a Vite bug?) that doesn't
+		// work, since instead we replace stuff ourselves
+		transform: {
+			filter: {
+				code: '__SVELTEKIT_PAYLOAD__'
+			},
+			handler(code) {
+				return {
+					code: code.replace('__SVELTEKIT_PAYLOAD__', kit_global),
+					map: null
+				};
+			}
+		},
+
 		generateBundle(_, bundle) {
 			const invalid_modules = new Set();
 			const modules = new Map([

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -1068,6 +1068,9 @@ function kit({ svelte_config }) {
 			const new_config = {
 				environments: {
 					serviceWorker: {
+						define: {
+							__SVELTEKIT_PAYLOAD__: kit_global
+						},
 						build: {
 							modulePreload: false,
 							rolldownOptions: {
@@ -1151,21 +1154,6 @@ function kit({ svelte_config }) {
 				if (id === sveltekit_manifest_data) {
 					return manifest_data_code;
 				}
-			}
-		},
-
-		// TODO this really ought to be unnecessary — an environment-specific `define`
-		// would be preferable. For whatever reason (possibly a Vite bug?) that doesn't
-		// work, since instead we replace stuff ourselves
-		transform: {
-			filter: {
-				code: '__SVELTEKIT_PAYLOAD__'
-			},
-			handler(code) {
-				return {
-					code: code.replace('__SVELTEKIT_PAYLOAD__', kit_global),
-					map: null
-				};
 			}
 		},
 
@@ -1986,8 +1974,11 @@ function kit({ svelte_config }) {
 						log.info('Building service worker');
 
 						// mirror client settings that we couldn't set per environment in the config hook
-						builder.environments.serviceWorker.config.define =
-							builder.environments.client.config.define;
+						builder.environments.serviceWorker.config.define = {
+							...builder.environments.client.config.define,
+							...builder.environments.serviceWorker.config.define
+						};
+
 						builder.environments.serviceWorker.config.resolve.alias = [
 							...get_config_aliases(kit, vite_config.root)
 						];

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -1786,7 +1786,7 @@ function kit({ svelte_config }) {
 						client_chunks.some(
 							(chunk) =>
 								chunk.type === 'chunk' &&
-							chunk.modules[`${out_dir}/generated/build/env/public/client.js`]
+								chunk.modules[`${out_dir}/generated/build/env/public/client.js`]
 						);
 
 					if (kit.output.bundleStrategy === 'split') {

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -1774,7 +1774,9 @@ function kit({ svelte_config }) {
 						client_chunks.some(
 							(chunk) =>
 								chunk.type === 'chunk' &&
-								chunk.modules[`${out_dir}/generated/build/env/public/client.js`]
+								chunk.modules[
+									posixify(fs.realpathSync(`${out_dir}/generated/build/env/public/client.js`))
+								]
 						);
 
 					if (kit.output.bundleStrategy === 'split') {

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -94,7 +94,8 @@ const enforced_config = {
 	resolve: {
 		alias: {
 			$app: true,
-			$env: true
+			$env: true,
+			'<sveltekit:generated>': true
 		}
 	}
 };
@@ -456,6 +457,10 @@ function kit({ svelte_config }) {
 							{ find: '$app', replacement: `${runtime_directory}/app` },
 							{ find: '$env', replacement: `${runtime_directory}/env` },
 							{
+								find: '<sveltekit:generated>',
+								replacement: `${out_dir}/generated/${is_build ? 'build' : 'dev'}`
+							},
+							{
 								find: '__sveltekit/server',
 								replacement: `${runtime_directory}/server/internal.js`
 							},
@@ -504,7 +509,7 @@ function kit({ svelte_config }) {
 							// because they for example use rolldown.build with `platform: 'browser'`
 							'esm-env',
 							// This forces `$app/*` modules to be bundled, since they depend on
-							// virtual modules like `__sveltekit/env` (this isn't a valid bare
+							// generated modules like `<sveltekit:generated>/env/config.js` (this isn't a valid bare
 							// import, but it works with vite-node's externalization logic, which
 							// uses basic concatenation)
 							'@sveltejs/kit/src/runtime'
@@ -1198,7 +1203,7 @@ function kit({ svelte_config }) {
 				// build time, so `env.js` is loaded at runtime. In dev, the
 				// imported module just inlines the current values instead.
 				return {
-					code: `import '__sveltekit/env/service-worker';\n${code}`
+					code: `import '<sveltekit:generated>/env/service-worker.js';\n${code}`
 				};
 			}
 		}
@@ -1231,7 +1236,7 @@ function kit({ svelte_config }) {
 					const server_input = {
 						index: `${runtime_directory}/server/index.js`,
 						internal: `${out_dir}/generated/server/internal.js`,
-						env: '__sveltekit/env',
+						env: '<sveltekit:generated>/env/config.js',
 						['remote-entry']: `${runtime_directory}/app/server/remote/index.js`
 					};
 

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -1770,7 +1770,8 @@ function kit({ svelte_config }) {
 						has_explicit_dynamic_public_env &&
 						client_chunks.some(
 							(chunk) =>
-								chunk.type === 'chunk' && chunk.modules[`${out_dir}/generated/env/public/client.js`]
+								chunk.type === 'chunk' &&
+							chunk.modules[`${out_dir}/generated/build/env/public/client.js`]
 						);
 
 					if (kit.output.bundleStrategy === 'split') {

--- a/packages/kit/src/exports/vite/plugins/env-vars.js
+++ b/packages/kit/src/exports/vite/plugins/env-vars.js
@@ -5,7 +5,6 @@ import path from 'node:path';
 import * as sync from '../../../core/sync/sync.js';
 import {
 	create_sveltekit_env,
-	create_sveltekit_env_dev,
 	create_sveltekit_env_private,
 	create_sveltekit_env_public,
 	create_sveltekit_env_service_worker,
@@ -18,7 +17,6 @@ import { s } from '../../../utils/misc.js';
 import { write_if_changed } from '../../../core/sync/utils.js';
 import { hash } from '../../../utils/hash.js';
 import { posixify } from '../../../utils/os.js';
-import { prefixRegex } from '@rolldown/pluginutils';
 
 /**
  * Generate (and, in dev, maintain) a `${outDir}/generated/env/config.js` module
@@ -29,14 +27,10 @@ import { prefixRegex } from '@rolldown/pluginutils';
  * @returns {Plugin}
  */
 export function plugin_env_vars(config, callback) {
-	// grab these values eagerly because they get mutated (TODO stop mutating them)
-	const dir = config.env.dir;
-	const out = config.outDir;
-
 	const version_hash = hash(config.version.name);
 
 	/** @type {string} */
-	let out_dir;
+	let dir;
 
 	/** @type {Record<string, any>} */
 	let env;
@@ -66,71 +60,71 @@ export function plugin_env_vars(config, callback) {
 		deps = synced.deps;
 
 		const vars = synced.variables;
-		const dir = `${out_dir}/generated/env`;
+		callback(vars);
 
 		write_if_changed(
 			`${dir}/config.js`,
 			create_sveltekit_env(
 				vars,
 				env,
-				resolved_entry && posixify(path.relative(dir, resolved_entry))
-			)
-		);
-
-		write_if_changed(`${dir}/config-dev.js`, create_sveltekit_env_dev(vars, env));
-
-		write_if_changed(
-			`${dir}/public/client.js`,
-			create_sveltekit_env_public(
-				vars,
-				env,
-				`import { payload } from ${s(posixify(path.relative(`${dir}/public`, `${runtime_directory}/client/payload.js`)))};\nconst env = payload.env;`
+				resolved_entry && posixify(path.relative(dir, resolved_entry)),
+				!is_build
 			)
 		);
 
 		write_if_changed(
 			`${dir}/public/server.js`,
-			create_sveltekit_env_public(
-				vars,
-				env,
-				`import { rendered_env as env } from '__sveltekit/env';`
-			)
-		);
-
-		write_if_changed(
-			`${dir}/public/service-worker.js`,
-			create_sveltekit_env_public(
-				vars,
-				env,
-				`const env = globalThis.__sveltekit_${version_hash}.env;`
-			)
+			create_sveltekit_env_public(vars, env, `import { rendered_env as env } from '../config.js';`)
 		);
 
 		write_if_changed(`${dir}/private/server.js`, create_sveltekit_env_private(vars, env));
 
-		write_if_changed(
-			`${dir}/service-worker-prod.js`,
-			create_sveltekit_env_service_worker(
-				vars,
-				env,
-				config.version.name,
-				`globalThis.__sveltekit_${version_hash}`,
-				config.paths.base,
-				config.appDir
-			)
-		);
+		if (is_build) {
+			write_if_changed(
+				`${dir}/public/client.js`,
+				create_sveltekit_env_public(
+					vars,
+					env,
+					`import { payload } from ${s(posixify(path.relative(`${dir}/public`, `${runtime_directory}/client/payload.js`)))};\nconst env = payload.env;`
+				)
+			);
 
-		write_if_changed(
-			`${dir}/service-worker-dev.js`,
-			create_sveltekit_env_service_worker_dev(
-				vars,
-				env,
-				config.version.name,
-				'globalThis.__sveltekit_dev'
-			)
-		);
+			write_if_changed(
+				`${dir}/public/service-worker.js`,
+				create_sveltekit_env_public(
+					vars,
+					env,
+					`const env = globalThis.__sveltekit_${version_hash}.env;`
+				)
+			);
 
-		callback(vars);
+			write_if_changed(
+				`${dir}/service-worker.js`,
+				create_sveltekit_env_service_worker(
+					vars,
+					env,
+					config.version.name,
+					`globalThis.__sveltekit_${version_hash}`,
+					config.paths.base,
+					config.appDir
+				)
+			);
+		} else {
+			write_if_changed(
+				`${dir}/public/client.js`,
+				create_sveltekit_env_public(vars, env, `const { env } = globalThis.__sveltekit_dev;`)
+			);
+
+			write_if_changed(
+				`${dir}/service-worker.js`,
+				create_sveltekit_env_service_worker_dev(
+					vars,
+					env,
+					config.version.name,
+					'globalThis.__sveltekit_dev'
+				)
+			);
+		}
 	}
 
 	return {
@@ -140,11 +134,13 @@ export function plugin_env_vars(config, callback) {
 			resolved_config = c;
 
 			const vite = await import_peer('vite', c.root);
-			env = vite.loadEnv(c.mode, path.resolve(c.root, dir), '');
-
-			out_dir = posixify(path.resolve(c.root, out));
+			env = vite.loadEnv(c.mode, path.resolve(c.root, config.env.dir), '');
 
 			is_build = c.command === 'build';
+
+			dir = posixify(
+				path.resolve(c.root, config.outDir, `generated/${is_build ? 'build' : 'dev'}/env`)
+			);
 		},
 
 		async buildStart() {
@@ -179,37 +175,6 @@ export function plugin_env_vars(config, callback) {
 		async handleHotUpdate(update) {
 			if (!deps.has(update.file)) return;
 			await generate();
-		},
-
-		resolveId: {
-			filter: {
-				id: prefixRegex('__sveltekit/env')
-			},
-			handler(id) {
-				const dir = `${out_dir}/generated/env`;
-
-				if (id === '__sveltekit/env') {
-					return is_build ? `${dir}/config.js` : `${dir}/config-dev.js`;
-				}
-
-				if (id === '__sveltekit/env/private') {
-					return `${dir}/private/server.js`;
-				}
-
-				if (id === '__sveltekit/env/public/server') {
-					return `${dir}/public/server.js`;
-				}
-
-				if (id === '__sveltekit/env/public/client') {
-					return this.environment.name === 'serviceWorker'
-						? `${dir}/public/service-worker.js`
-						: `${dir}/public/client.js`;
-				}
-
-				if (id === '__sveltekit/env/service-worker') {
-					return is_build ? `${dir}/service-worker-prod.js` : `${dir}/service-worker-dev.js`;
-				}
-			}
 		}
 	};
 }

--- a/packages/kit/src/exports/vite/plugins/env-vars.js
+++ b/packages/kit/src/exports/vite/plugins/env-vars.js
@@ -19,7 +19,7 @@ import { hash } from '../../../utils/hash.js';
 import { posixify } from '../../../utils/os.js';
 
 /**
- * Generate (and, in dev, maintain) a `${outDir}/generated/env/config.js` module
+ * Generate (and, in dev, maintain) the `${outDir}/generated/{build,dev}/env` modules
  * derived from `src/env.ts`
  *
  * @param {ValidatedConfig} config
@@ -86,15 +86,6 @@ export function plugin_env_vars(config, callback) {
 					vars,
 					env,
 					`import { payload } from ${s(posixify(path.relative(`${dir}/public`, `${runtime_directory}/client/payload.js`)))};\nconst env = payload.env;`
-				)
-			);
-
-			write_if_changed(
-				`${dir}/public/service-worker.js`,
-				create_sveltekit_env_public(
-					vars,
-					env,
-					`const env = globalThis.__sveltekit_${version_hash}.env;`
 				)
 			);
 

--- a/packages/kit/src/exports/vite/plugins/env-vars.js
+++ b/packages/kit/src/exports/vite/plugins/env-vars.js
@@ -4,6 +4,7 @@
 import path from 'node:path';
 import * as sync from '../../../core/sync/sync.js';
 import {
+	create_dev_public_env_prelude,
 	create_sveltekit_env,
 	create_sveltekit_env_private,
 	create_sveltekit_env_public,
@@ -103,7 +104,7 @@ export function plugin_env_vars(config, callback) {
 		} else {
 			write_if_changed(
 				`${dir}/public/client.js`,
-				create_sveltekit_env_public(vars, env, `const env = globalThis.__sveltekit_dev?.env ?? ${devalue.uneval(dev_env)};`)
+				create_sveltekit_env_public(vars, env, create_dev_public_env_prelude(vars, env))
 			);
 
 			write_if_changed(

--- a/packages/kit/src/exports/vite/plugins/env-vars.js
+++ b/packages/kit/src/exports/vite/plugins/env-vars.js
@@ -103,7 +103,7 @@ export function plugin_env_vars(config, callback) {
 		} else {
 			write_if_changed(
 				`${dir}/public/client.js`,
-				create_sveltekit_env_public(vars, env, `const { env } = globalThis.__sveltekit_dev;`)
+				create_sveltekit_env_public(vars, env, `const env = globalThis.__sveltekit_dev?.env ?? ${devalue.uneval(dev_env)};`)
 			);
 
 			write_if_changed(

--- a/packages/kit/src/exports/vite/plugins/env-vars.js
+++ b/packages/kit/src/exports/vite/plugins/env-vars.js
@@ -4,10 +4,10 @@
 import path from 'node:path';
 import * as sync from '../../../core/sync/sync.js';
 import {
-	create_dev_public_env_prelude,
 	create_sveltekit_env,
 	create_sveltekit_env_private,
 	create_sveltekit_env_public,
+	create_sveltekit_env_public_dev,
 	create_sveltekit_env_service_worker,
 	create_sveltekit_env_service_worker_dev,
 	resolve_env_entry
@@ -102,10 +102,7 @@ export function plugin_env_vars(config, callback) {
 				)
 			);
 		} else {
-			write_if_changed(
-				`${dir}/public/client.js`,
-				create_sveltekit_env_public(vars, env, create_dev_public_env_prelude(vars, env))
-			);
+			write_if_changed(`${dir}/public/client.js`, create_sveltekit_env_public_dev(vars, env));
 
 			write_if_changed(
 				`${dir}/service-worker.js`,

--- a/packages/kit/src/runtime/app/env/private/index.js
+++ b/packages/kit/src/runtime/app/env/private/index.js
@@ -1,1 +1,1 @@
-export * from '__sveltekit/env/private';
+export * from '<sveltekit:generated>/env/private/server.js';

--- a/packages/kit/src/runtime/app/env/public/client.js
+++ b/packages/kit/src/runtime/app/env/public/client.js
@@ -1,1 +1,1 @@
-export * from '__sveltekit/env/public/client';
+export * from '<sveltekit:generated>/env/public/client.js';

--- a/packages/kit/src/runtime/app/env/public/server.js
+++ b/packages/kit/src/runtime/app/env/public/server.js
@@ -1,1 +1,1 @@
-export * from '__sveltekit/env/public/server';
+export * from '<sveltekit:generated>/env/public/server.js';

--- a/packages/kit/src/runtime/server/env_module.js
+++ b/packages/kit/src/runtime/server/env_module.js
@@ -1,5 +1,5 @@
 import * as devalue from 'devalue';
-import { rendered_env } from '__sveltekit/env';
+import { rendered_env } from '<sveltekit:generated>/env/config.js';
 
 /** @type {string} */
 let payload;

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -4,7 +4,7 @@ import { respond } from './respond.js';
 import { create_request_state } from './state.js';
 import { options, get_hooks } from '__SERVER__/internal.js';
 import { set_read_implementation, set_manifest, fix_stack_trace } from './internal.js';
-import { set_env } from '__sveltekit/env';
+import { set_env } from '<sveltekit:generated>/env/config.js';
 import { init_tracing } from '@sveltejs/kit/internal/server';
 import { DEV } from 'esm-env';
 import { init_transport } from '#app/internal/transport';

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -21,7 +21,7 @@ import { try_get_request_store, with_request_store } from '@sveltejs/kit/interna
 import { text_encoder } from '../../utils.js';
 import { count_non_ssi_comments, get_global_name } from '../utils.js';
 import { handle_error_and_jsonify } from '../errors.js';
-import * as env from '__sveltekit/env';
+import * as env from '<sveltekit:generated>/env/config.js';
 import { collect_remote_data } from '../remote-functions.js';
 import Root from '../../components/root.svelte';
 import { render } from 'svelte/server';

--- a/packages/kit/src/types/ambient-private.d.ts
+++ b/packages/kit/src/types/ambient-private.d.ts
@@ -21,7 +21,7 @@ declare module '__sveltekit/server' {
 	export function set_read_implementation(fn: (path: string) => ReadableStream): void;
 }
 
-declare module '__sveltekit/env' {
+declare module '<sveltekit:generated>/env/config.js' {
 	// exported environment variables are defined in env.d.ts
 
 	/** Populate exported environment variables */
@@ -34,15 +34,15 @@ declare module '__sveltekit/env' {
 	export const rendered_env: Record<string, any>;
 }
 
-declare module '__sveltekit/env/private' {
+declare module '<sveltekit:generated>/env/private/server.js' {
 	// exported environment variables are defined in env.d.ts
 }
 
-declare module '__sveltekit/env/public/client' {
+declare module '<sveltekit:generated>/env/public/client.js' {
 	// exported environment variables are defined in env.d.ts
 }
 
-declare module '__sveltekit/env/public/server' {
+declare module '<sveltekit:generated>/env/public/server.js' {
 	// exported environment variables are defined in env.d.ts
 }
 


### PR DESCRIPTION
Follow-up to #16807. Instead of using a `resolveId` hook, we can use an alias for all the generated modules — every module ID like `<sveltekit:generated>/foo.js` corresponds to `.svelte-kit/generated/(build|dev)/foo.js`, making things a little easier to navigate, and reducing the cost of adding more generated modules relative to having to faff about with plugin hooks.

The `<sveltekit:generated>` prefix is bikesheddable, but I figured it's worth being explicit about what this is, and using characters that are invalid in npm package names.

Creating separate directories for dev and build means we don't need to be as careful about what goes where, and can freely use relative imports between generated modules. It means that building while also running a dev server won't result in clobbering.

We can easily extend this to the other virtual modules.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets

- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
