### PR TITLE
docs: parent load only reruns for server load `parent()` calls

### DIFF
--- a/documentation/docs/20-core-concepts/20-load.md
+++ b/documentation/docs/20-core-concepts/20-load.md
@@ -691,7 +691,7 @@ To summarize, a `load` function will rerun in the following situations:
 - It references a property of `url` (such as `url.pathname` or `url.search`) whose value has changed. Properties in `request.url` are _not_ tracked
 - It calls `url.searchParams.get(...)`, `url.searchParams.getAll(...)` or `url.searchParams.has(...)` and the parameter in question changes. Accessing other properties of `url.searchParams` will have the same effect as accessing `url.search`.
 - It calls `await parent()` and a parent `load` function reran
-- A child `load` function calls `await parent()` and is rerunning, and the parent is a server load function
+- A child server `load` function calls `await parent()` and is rerunning, and the parent is also a server `load` function. A universal `load` function that calls `await parent()` reuses the parent's existing data instead
 - It declared a dependency on a specific URL via [`fetch`](#Making-fetch-requests) (universal load only) or [`depends`](@sveltejs-kit#LoadEvent), and that URL was marked invalid with [`invalidate(url)`]($app-navigation#invalidate)
 - All active `load` functions were forcibly rerun with [`invalidateAll()`]($app-navigation#invalidateAll)
 


### PR DESCRIPTION
Fixes #14356. Only the server-side `parent()` reruns the parent load (to reconstruct its data, since the server is stateless); a universal load's `parent()` reuses the already-loaded data on the client, so the bullet as written promised a rerun that never happens for `+layout.js`/`+page.js` children.