### PR TITLE
feat: move `basePath` and `prerenderedRoutes` to the public SSRManifest api

### DIFF
--- a/.changeset/early-eggs-crash.md
+++ b/.changeset/early-eggs-crash.md
@@ -1,0 +1,9 @@
+---
+"@sveltejs/kit": minor
+"@sveltejs/adapter-vercel": minor
+"@sveltejs/adapter-node": minor
+"@sveltejs/adapter-cloudflare": minor
+---
+
+feat: move `basePath` and `prerenderedRoutes` to the public SSRManifest api
+  

--- a/packages/adapter-cloudflare/files/internal.d.ts
+++ b/packages/adapter-cloudflare/files/internal.d.ts
@@ -6,7 +6,4 @@ declare module 'MANIFEST' {
 	import { SSRManifest } from '@sveltejs/kit';
 
 	export const manifest: SSRManifest;
-	export const prerendered: Set<string>;
-	export const app_path: string;
-	export const base_path: string;
 }

--- a/packages/adapter-cloudflare/files/worker.js
+++ b/packages/adapter-cloudflare/files/worker.js
@@ -1,5 +1,5 @@
 import { Server } from 'SERVER';
-import { manifest, prerendered, base_path } from 'MANIFEST';
+import { manifest } from 'MANIFEST';
 import { env } from 'cloudflare:workers';
 
 const server = new Server(manifest);
@@ -59,7 +59,7 @@ export default {
 
 		// files in /static, the service worker, and Vite imported server assets
 		let is_static_asset = false;
-		const filename = stripped_pathname.slice(base_path.length + 1);
+		const filename = stripped_pathname.slice(manifest.basePath.length + 1);
 		if (filename) {
 			is_static_asset =
 				manifest.assets.has(filename) || manifest.assets.has(filename + '/index.html');
@@ -69,7 +69,7 @@ export default {
 
 		if (
 			is_static_asset ||
-			prerendered.has(pathname) ||
+			manifest.prerenderedRoutes.has(pathname) ||
 			pathname === version_file ||
 			pathname.startsWith(immutable)
 		) {
@@ -84,7 +84,7 @@ export default {
 		}
 
 		// trailing slash redirect for prerendered pages
-		if (location && prerendered.has(location)) {
+		if (location && manifest.prerenderedRoutes.has(location)) {
 			if (search) location += search;
 			return new Response('', {
 				status: 308,

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -105,9 +105,7 @@ export default function (options = {}) {
 			const worker_dest_dir = path.dirname(worker_dest);
 			writeFileSync(
 				`${tmp}/manifest.js`,
-				`export const manifest = ${builder.generateManifest({ relativePath: path.posix.relative(tmp, builder.getServerDirectory()) })};\n\n` +
-					`export const prerendered = new Set(${JSON.stringify(builder.prerendered.paths)});\n\n` +
-					`export const base_path = ${JSON.stringify(builder.config.paths.base)};\n`
+				`export const manifest = ${builder.generateManifest({ relativePath: path.posix.relative(tmp, builder.getServerDirectory()) })};`
 			);
 			builder.copy(`${files}/worker.js`, worker_dest, {
 				replace: {

--- a/packages/adapter-node/internal.d.ts
+++ b/packages/adapter-node/internal.d.ts
@@ -1,10 +1,8 @@
 declare module 'MANIFEST' {
 	import { SSRManifest } from '@sveltejs/kit';
 
-	export const base: string;
-	export const uncompressed_extensions: Set<string>;
 	export const manifest: SSRManifest;
-	export const prerendered: Set<string>;
+	export const uncompressed_extensions: Set<string>;
 }
 
 declare module 'SERVER' {

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -5,7 +5,7 @@ import sirv from 'sirv';
 import { parse as polka_url_parser } from '@polka/url';
 import { getRequest, setResponse, createReadableStream } from '@sveltejs/kit/node';
 import { Server } from 'SERVER';
-import { manifest, prerendered, base, uncompressed_extensions } from 'MANIFEST';
+import { manifest, uncompressed_extensions } from 'MANIFEST';
 import { dir } from './dir.js';
 import { env, env_prefix } from './env.js';
 import { parse_as_bytes } from './utils.js';
@@ -28,7 +28,7 @@ if (isNaN(body_size_limit)) {
 	);
 }
 
-const asset_dir = `${dir}/client${base}`;
+const asset_dir = `${dir}/client${manifest.basePath}`;
 
 await server.init({
 	env: process.env,
@@ -96,13 +96,13 @@ function serve_prerendered() {
 			// ignore invalid URI
 		}
 
-		if (prerendered.has(pathname)) {
+		if (manifest.prerenderedRoutes.has(pathname)) {
 			return handler?.(req, res, next);
 		}
 
 		// remove or add trailing slash as appropriate
 		const inverted = pathname.at(-1) === '/' ? pathname.slice(0, -1) : pathname + '/';
-		if (prerendered.has(inverted)) {
+		if (manifest.prerenderedRoutes.has(inverted)) {
 			const location = relative_pathname(pathname, inverted) + (query ? search : '');
 			res.writeHead(308, { location }).end();
 		} else {

--- a/packages/adapter-vercel/internal.d.ts
+++ b/packages/adapter-vercel/internal.d.ts
@@ -4,5 +4,6 @@ declare module 'SERVER' {
 
 declare module 'MANIFEST' {
 	import { SSRManifest } from '@sveltejs/kit';
+
 	export const manifest: SSRManifest;
 }

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -190,6 +190,7 @@ export function create_builder({
 				build_data,
 				prerendered: prerendered.paths,
 				relative_path: relativePath,
+				base_path: config.paths.base,
 				routes: subset
 					? subset.map((route) => /** @type {import('types').RouteData} */ (lookup.get(route)))
 					: route_data.filter((route) => prerender_map.get(route.id) !== true),

--- a/packages/kit/src/core/generate_manifest/index.js
+++ b/packages/kit/src/core/generate_manifest/index.js
@@ -18,6 +18,7 @@ import { uneval } from 'devalue';
  *   build_data: import('types').BuildData;
  *   prerendered: string[];
  *   relative_path: string;
+ *   base_path: string;
  *   routes: import('types').RouteData[];
  *   remotes: RemoteChunk[];
  *   root: string;
@@ -27,6 +28,7 @@ export function generate_manifest({
 	build_data,
 	prerendered,
 	relative_path,
+	base_path,
 	routes,
 	remotes,
 	root
@@ -109,6 +111,8 @@ export function generate_manifest({
 			appPath: ${s(build_data.app_path)},
 			assets: new Set(${s(assets)}),
 			mimeTypes: ${s(mime_types)},
+			prerenderedRoutes: new Set(${s(prerendered)}),
+			basePath: ${s(base_path)},
 			_: {
 				client: ${uneval(build_data.client)},
 				nodes: [
@@ -132,7 +136,6 @@ export function generate_manifest({
 						`;
 					}).filter(Boolean).join(',\n')}
 				],
-				prerendered_routes: new Set(${s(prerendered)}),
 				matchers: async () => {
 					${
 						uses_matchers && build_data.manifest_data.params

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -680,6 +680,8 @@ export interface SSRManifest {
 	/** Static files from `config.files.assets` and the service worker (if any). */
 	assets: Set<string>;
 	mimeTypes: Record<string, string>;
+	prerenderedRoutes: Set<string>;
+	basePath: string;
 
 	/** @internal private fields */
 	_: {
@@ -688,7 +690,6 @@ export interface SSRManifest {
 		/** hashed filename -> import to that file */
 		remotes: Record<string, () => Promise<{ default: Record<string, any> }>>;
 		routes: SSRRoute[];
-		prerendered_routes: Set<string>;
 		matchers: () => Promise<Record<string, ParamMatcher>>;
 		/** A `[file]: size` map of all assets imported by server code. */
 		server_assets: Record<string, number>;

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -169,6 +169,8 @@ export async function dev(
 			appPath: svelte_config.appDir,
 			assets: new Set(manifest_data.assets.map((asset) => asset.file)),
 			mimeTypes: get_mime_lookup(manifest_data),
+			prerenderedRoutes: new Set(),
+			basePath: svelte_config.paths.base,
 			_: {
 				client: {
 					start: `${get_runtime_base(root)}/client/entry.js`,
@@ -291,7 +293,6 @@ export async function dev(
 						return result;
 					};
 				}),
-				prerendered_routes: new Set(),
 				get remotes() {
 					return Object.fromEntries(
 						get_remotes().map((remote) => [

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -1603,6 +1603,7 @@ function kit({ svelte_config }) {
 						build_data,
 						prerendered: [],
 						relative_path: '.',
+						base_path: svelte_config.paths.base,
 						routes: manifest_data.routes,
 						remotes,
 						root
@@ -1865,6 +1866,7 @@ function kit({ svelte_config }) {
 							build_data,
 							prerendered: [],
 							relative_path: '.',
+							base_path: kit.paths.base,
 							routes: manifest_data.routes,
 							remotes,
 							root
@@ -1938,6 +1940,7 @@ function kit({ svelte_config }) {
 						build_data,
 						prerendered: prerendered.paths,
 						relative_path: '.',
+						base_path: kit.paths.base,
 						routes: manifest_data.routes.filter(
 							(route) => prerender_results.prerender_map.get(route.id) !== true
 						),

--- a/packages/kit/src/runtime/server/utils.js
+++ b/packages/kit/src/runtime/server/utils.js
@@ -110,8 +110,8 @@ export function serialize_uses(node) {
  */
 export function has_prerendered_path(manifest, pathname) {
 	return (
-		manifest._.prerendered_routes.has(pathname) ||
-		(pathname.at(-1) === '/' && manifest._.prerendered_routes.has(pathname.slice(0, -1)))
+		manifest.prerenderedRoutes.has(pathname) ||
+		(pathname.at(-1) === '/' && manifest.prerenderedRoutes.has(pathname.slice(0, -1)))
 	);
 }
 

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -664,6 +664,8 @@ declare module '@sveltejs/kit' {
 		/** Static files from `config.files.assets` and the service worker (if any). */
 		assets: Set<string>;
 		mimeTypes: Record<string, string>;
+		prerenderedRoutes: Set<string>;
+		basePath: string;
 	}
 
 	/**


### PR DESCRIPTION
Cleans up some private API access for adapter-node and adapter-cloudflare. This also will allow adapter-cloudflare to import the manifest only, instead of having to add additional exports to it, helpful for @cloudflare/vite-plugin stuff.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
