### PR TITLE
chore: generate the env modules in a single pass

### DIFF
--- a/.changeset/env-exports-generator.md
+++ b/.changeset/env-exports-generator.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+chore: generate the env modules in a single pass

--- a/packages/kit/src/core/env.js
+++ b/packages/kit/src/core/env.js
@@ -10,6 +10,8 @@ import { handle_issues, validate } from '../exports/internal/env.js';
 import { get_config_aliases } from '../exports/vite/utils.js';
 import { get_runner } from '../runner.js';
 import { import_peer } from '../utils/import.js';
+import { hash } from '../utils/hash.js';
+import { posixify } from '../utils/os.js';
 
 /**
  * @typedef {'public' | 'private'} EnvType
@@ -112,40 +114,64 @@ export async function load_explicit_env(kit, file, root, mode) {
 }
 
 /**
- * Creates the `<sveltekit:generated>/env/config.js` module
- * @param {Record<string, EnvVarConfig<any> | undefined> | null} variables
+ * Creates the `<sveltekit:generated>/env/*` modules, keyed by path relative to `dir`. Every module
+ * derives from one pass over `variables`, so an inlined value is validated once per build.
+ * @param {ValidatedConfig} config
+ * @param {Record<string, EnvVarConfig<any>> | null} variables
  * @param {Record<string, string>} env
+ * @param {string} dir
  * @param {string | null} entry
  * @param {boolean} is_dev
+ * @returns {Record<string, string>}
  */
-export function create_sveltekit_env(variables, env, entry, is_dev) {
-	const imports = entry
-		? [
-				`import { variables } from ${JSON.stringify(entry)};`,
-				`import { validate, handle_issues } from '@sveltejs/kit/internal/env';`
-			]
-		: [`const variables = {};`, `const handle_issues = () => {};`];
-
-	const declarations = [];
-	const setters = [];
-
+export function create_env_modules(config, variables, env, dir, entry, is_dev) {
 	/** @type {Record<string, StandardSchemaV1.Issue[]>} */
 	const issues = {};
 
-	for (const [name, config] of Object.entries(variables ?? {})) {
-		if (config?.static) {
-			if (config.public) {
-				const value = validate(variables ?? {}, env[name], name, issues);
-				declarations.push(`explicit_public_env.${name} = ${devalue.uneval(value)};`);
+	/** @type {Record<string, string>} */
+	const dev_env = {};
+
+	/** @type {string[]} */
+	const declarations = [];
+	/** @type {string[]} */
+	const setters = [];
+	/** @type {string[]} */
+	const public_exports = [];
+	/** @type {string[]} */
+	const private_exports = [];
+	/** @type {string[]} */
+	const sw_properties = [];
+
+	let sw_dynamic = false;
+
+	for (const [name, { public: is_public, static: is_static }] of Object.entries(variables ?? {})) {
+		if (is_dev && name in env) dev_env[name] = env[name];
+
+		const exports = is_public ? public_exports : private_exports;
+
+		if (is_static) {
+			const value = devalue.uneval(validate(variables ?? {}, env[name], name, issues));
+			exports.push(`export const ${name} = ${value};\n`);
+
+			if (is_public) {
+				declarations.push(`explicit_public_env.${name} = ${value};`);
+				sw_properties.push(`${name}: ${value}`);
 			}
 		} else {
+			exports.push(`export const ${name} = env.${name};\n`);
 			setters.push(
 				`const ${name} = validate(variables, env.${name}, ${JSON.stringify(name)}, issues);`
 			);
 
-			if (config?.public) {
+			if (is_public) {
 				setters.push(`explicit_public_env.${name} = ${name};`);
 				setters.push(`rendered_env.${name} = ${name};`);
+				sw_dynamic = true;
+				// in dev there is no prerendered env module, so the service worker inlines the value
+				if (is_dev) {
+					const value = devalue.uneval(validate(variables ?? {}, env[name], name, issues));
+					sw_properties.push(`${name}: ${value}`);
+				}
 			} else {
 				setters.push(`dynamic_private_env.${name} = ${name};`);
 			}
@@ -154,8 +180,13 @@ export function create_sveltekit_env(variables, env, entry, is_dev) {
 
 	handle_issues(issues);
 
-	const blocks = [
-		imports.join('\n'),
+	const config_blocks = [
+		entry
+			? [
+					`import { variables } from ${JSON.stringify(entry)};`,
+					`import { validate, handle_issues } from '@sveltejs/kit/internal/env';`
+				].join('\n')
+			: [`const variables = {};`, `const handle_issues = () => {};`].join('\n'),
 		`const issues = {};`,
 		'export { variables }',
 		'export const dynamic_private_env = {};',
@@ -176,94 +207,62 @@ export function create_sveltekit_env(variables, env, entry, is_dev) {
 		// through the Vite config but don't run the SvelteKit dev server, which is what
 		// normally calls `set_env`. Without this, dynamic env vars imported from
 		// `$app/env/public` and `$app/env/private` would be `undefined` in such contexts.
-		/** @type {Record<string, string>} */
-		const dev_env = {};
-		for (const name of Object.keys(variables ?? {})) {
-			if (name in env) dev_env[name] = env[name];
-		}
-
-		blocks.push(`set_env(${devalue.uneval(dev_env)});`);
+		config_blocks.push(`set_env(${devalue.uneval(dev_env)});`);
 	}
 
-	return blocks.join('\n\n');
-}
+	/**
+	 * @param {string} prelude
+	 * @param {string[]} exports
+	 */
+	const module = (prelude, exports) => (variables ? `${prelude}\n\n${exports.join('')}` : '');
 
-/**
- * Creates the `<sveltekit:generated>/env/private/server.js` and `<sveltekit:generated>/env/public/*` modules
- * @param {Record<string, EnvVarConfig<any>> | null} variables
- * @param {Record<string, string>} env
- * @param {boolean} is_public
- * @param {string} prelude
- */
-export function create_sveltekit_env_exports(variables, env, is_public, prelude) {
-	if (!variables) {
-		return '';
-	}
+	const global = is_dev
+		? 'globalThis.__sveltekit_dev'
+		: `globalThis.__sveltekit_${hash(config.version.name)}`;
 
-	/** @type {Record<string, StandardSchemaV1.Issue[]>} */
-	const issues = {};
+	const version = JSON.stringify(config.version.name);
 
-	/** @type {string[]} */
-	const exports = [];
+	// a production build with dynamic public env vars loads them at runtime via an import of
+	// the prerendered `env.js`; otherwise the values are inlined
+	const service_worker =
+		!is_dev && sw_dynamic
+			? dedent`
+				import { env } from '${config.paths.base}/${config.appDir}/env.js';
 
-	for (const [name, config] of Object.entries(variables)) {
-		if (!!config.public !== is_public) continue;
+				${global} = {
+					base: location.pathname.split('/').slice(0, -1).join('/'),
+					env,
+					version: ${version}
+				};
+			`
+			: dedent`
+				${global} = {
+					base: location.pathname.split('/').slice(0, -1).join('/'),
+					env: {
+						${sw_properties.join(',\n\t\t') || '// empty'}
+					},
+					version: ${version}
+				};
+			`;
 
-		const value = config.static
-			? devalue.uneval(validate(variables, env[name], name, issues))
-			: `env.${name}`;
-
-		exports.push(`export const ${name} = ${value};\n`);
-	}
-
-	handle_issues(issues);
-
-	return `${prelude}\n\n${exports.join('')}`;
-}
-
-/**
- * Creates the `<sveltekit:generated>/env/service-worker.js` module. When a production build uses
- * dynamic public env vars, they're loaded at runtime via an import of the prerendered `env.js`.
- * Otherwise, values are inlined.
- * @param {Record<string, EnvVarConfig<any>> | null} variables
- * @param {Record<string, string>} env
- * @param {string} version
- * @param {string} global
- * @param {{ base: string, app_dir: string } | null} prerendered `null` in dev
- */
-export function create_sveltekit_env_service_worker(variables, env, version, global, prerendered) {
-	const entries = Object.entries(variables ?? {}).filter(([, config]) => config.public);
-
-	if (prerendered && entries.some(([, config]) => !config.static)) {
-		return dedent`
-			import { env } from '${prerendered.base}/${prerendered.app_dir}/env.js';
-
-			${global} = {
-				base: location.pathname.split('/').slice(0, -1).join('/'),
-				env,
-				version: ${JSON.stringify(version)}
-			};
-		`;
-	}
-
-	/** @type {Record<string, StandardSchemaV1.Issue[]>} */
-	const issues = {};
-
-	const properties = entries.map(
-		([name]) => `${name}: ${devalue.uneval(validate(variables ?? {}, env[name], name, issues))}`
-	);
-
-	handle_issues(issues);
-
-	return dedent`
-		${global} = {
-			base: location.pathname.split('/').slice(0, -1).join('/'),
-			env: {
-				${properties.join(',\n\t\t') || '// empty'}
-			},
-			version: ${JSON.stringify(version)}
-		};
-	`;
+	return {
+		'config.js': config_blocks.join('\n\n'),
+		'public/server.js': module(
+			`import { rendered_env as env } from '../config.js';`,
+			public_exports
+		),
+		'private/server.js': module(
+			`import { dynamic_private_env as env } from '../config.js';`,
+			private_exports
+		),
+		'public/client.js': module(
+			is_dev
+				? `const { env } = globalThis.__sveltekit_dev;`
+				: `import { payload } from ${JSON.stringify(posixify(path.relative(`${dir}/public`, `${runtime_directory}/client/payload.js`)))};\nconst env = payload.env;`,
+			public_exports
+		),
+		'service-worker.js': service_worker
+	};
 }
 
 /** @param {string} description */

--- a/packages/kit/src/core/env.js
+++ b/packages/kit/src/core/env.js
@@ -189,43 +189,13 @@ export function create_sveltekit_env(variables, env, entry, is_dev) {
 }
 
 /**
- * Creates the `<sveltekit:generated>/env/private/server.js` module
+ * Creates the `<sveltekit:generated>/env/private/server.js` and `<sveltekit:generated>/env/public/*` modules
  * @param {Record<string, EnvVarConfig<any>> | null} variables
  * @param {Record<string, string>} env
- */
-export function create_sveltekit_env_private(variables, env) {
-	if (!variables) {
-		return '';
-	}
-
-	/** @type {Record<string, StandardSchemaV1.Issue[]>} */
-	const issues = {};
-
-	/** @type {string[]} */
-	const exports = [];
-
-	for (const [name, config] of Object.entries(variables)) {
-		if (config.public) continue;
-
-		const value = config.static
-			? devalue.uneval(validate(variables, env[name], name, issues))
-			: `env.${name}`;
-
-		exports.push(`export const ${name} = ${value};\n`);
-	}
-
-	handle_issues(issues);
-
-	return `import { dynamic_private_env as env } from '../config.js';\n\n${exports.join('')}`;
-}
-
-/**
- * Creates the `<sveltekit:generated>/env/public/*` modules
- * @param {Record<string, EnvVarConfig<any>> | null} variables
- * @param {Record<string, string>} env
+ * @param {boolean} is_public
  * @param {string} prelude
  */
-export function create_sveltekit_env_public(variables, env, prelude) {
+export function create_sveltekit_env_exports(variables, env, is_public, prelude) {
 	if (!variables) {
 		return '';
 	}
@@ -237,7 +207,7 @@ export function create_sveltekit_env_public(variables, env, prelude) {
 	const exports = [];
 
 	for (const [name, config] of Object.entries(variables)) {
-		if (!config.public) continue;
+		if (!!config.public !== is_public) continue;
 
 		const value = config.static
 			? devalue.uneval(validate(variables, env[name], name, issues))
@@ -252,78 +222,38 @@ export function create_sveltekit_env_public(variables, env, prelude) {
 }
 
 /**
+ * Creates the `<sveltekit:generated>/env/service-worker.js` module. When a production build uses
+ * dynamic public env vars, they're loaded at runtime via an import of the prerendered `env.js`.
+ * Otherwise, values are inlined.
  * @param {Record<string, EnvVarConfig<any>> | null} variables
  * @param {Record<string, string>} env
- * @param {boolean} include_static
- * @returns {Record<string, any>}
+ * @param {string} version
+ * @param {string} global
+ * @param {{ base: string, app_dir: string } | null} prerendered `null` in dev
  */
-function validate_public_env(variables, env, include_static) {
+export function create_sveltekit_env_service_worker(variables, env, version, global, prerendered) {
+	const entries = Object.entries(variables ?? {}).filter(([, config]) => config.public);
+
+	if (prerendered && entries.some(([, config]) => !config.static)) {
+		return dedent`
+			import { env } from '${prerendered.base}/${prerendered.app_dir}/env.js';
+
+			${global} = {
+				base: location.pathname.split('/').slice(0, -1).join('/'),
+				env,
+				version: ${JSON.stringify(version)}
+			};
+		`;
+	}
+
 	/** @type {Record<string, StandardSchemaV1.Issue[]>} */
 	const issues = {};
 
-	/** @type {Record<string, any>} */
-	const values = {};
-
-	for (const [name, config] of Object.entries(variables ?? {})) {
-		if (!config.public || (config.static && !include_static)) continue;
-
-		values[name] = validate(variables ?? {}, env[name], name, issues);
-	}
+	const properties = entries.map(
+		([name]) => `${name}: ${devalue.uneval(validate(variables ?? {}, env[name], name, issues))}`
+	);
 
 	handle_issues(issues);
-
-	return values;
-}
-
-/**
- * Creates the `<sveltekit:generated>/env/service-worker.js` module used in production. When an app uses
- * dynamic public env vars, they're loaded at runtime via an import of the prerendered
- * `env.js`. If there are none, values are inlined.
- * @param {Record<string, EnvVarConfig<any>> | null} variables
- * @param {Record<string, string>} env
- * @param {string} version
- * @param {string} global
- * @param {string} base
- * @param {string} app_dir
- */
-export function create_sveltekit_env_service_worker(
-	variables,
-	env,
-	version,
-	global,
-	base,
-	app_dir
-) {
-	const has_dynamic_public_env = Object.values(variables ?? {}).some(
-		(config) => config.public && !config.static
-	);
-
-	if (!has_dynamic_public_env) {
-		return create_sveltekit_env_service_worker_dev(variables, env, version, global);
-	}
-
-	return dedent`
-		import { env } from '${base}/${app_dir}/env.js';
-
-		${global} = {
-			base: location.pathname.split('/').slice(0, -1).join('/'),
-			env,
-			version: ${JSON.stringify(version)}
-		};
-	`;
-}
-
-/**
- * Creates the `<sveltekit:generated>/env/service-worker.js` module used in development
- * @param {Record<string, EnvVarConfig<any>> | null} variables
- * @param {Record<string, string>} env
- * @param {string} version
- * @param {string} global
- */
-export function create_sveltekit_env_service_worker_dev(variables, env, version, global) {
-	const properties = Object.entries(validate_public_env(variables, env, true)).map(
-		([name, value]) => `${name}: ${devalue.uneval(value)}`
-	);
 
 	return dedent`
 		${global} = {

--- a/packages/kit/src/exports/vite/plugins/env-vars.js
+++ b/packages/kit/src/exports/vite/plugins/env-vars.js
@@ -5,10 +5,8 @@ import path from 'node:path';
 import * as sync from '../../../core/sync/sync.js';
 import {
 	create_sveltekit_env,
-	create_sveltekit_env_private,
-	create_sveltekit_env_public,
+	create_sveltekit_env_exports,
 	create_sveltekit_env_service_worker,
-	create_sveltekit_env_service_worker_dev,
 	resolve_env_entry
 } from '../../../core/env.js';
 import { import_peer } from '../../../utils/import.js';
@@ -74,17 +72,31 @@ export function plugin_env_vars(config, callback) {
 
 		write_if_changed(
 			`${dir}/public/server.js`,
-			create_sveltekit_env_public(vars, env, `import { rendered_env as env } from '../config.js';`)
+			create_sveltekit_env_exports(
+				vars,
+				env,
+				true,
+				`import { rendered_env as env } from '../config.js';`
+			)
 		);
 
-		write_if_changed(`${dir}/private/server.js`, create_sveltekit_env_private(vars, env));
+		write_if_changed(
+			`${dir}/private/server.js`,
+			create_sveltekit_env_exports(
+				vars,
+				env,
+				false,
+				`import { dynamic_private_env as env } from '../config.js';`
+			)
+		);
 
 		if (is_build) {
 			write_if_changed(
 				`${dir}/public/client.js`,
-				create_sveltekit_env_public(
+				create_sveltekit_env_exports(
 					vars,
 					env,
+					true,
 					`import { payload } from ${s(posixify(path.relative(`${dir}/public`, `${runtime_directory}/client/payload.js`)))};\nconst env = payload.env;`
 				)
 			);
@@ -96,23 +108,23 @@ export function plugin_env_vars(config, callback) {
 					env,
 					config.version.name,
 					`globalThis.__sveltekit_${version_hash}`,
-					config.paths.base,
-					config.appDir
+					{ base: config.paths.base, app_dir: config.appDir }
 				)
 			);
 		} else {
 			write_if_changed(
 				`${dir}/public/client.js`,
-				create_sveltekit_env_public(vars, env, `const { env } = globalThis.__sveltekit_dev;`)
+				create_sveltekit_env_exports(vars, env, true, `const { env } = globalThis.__sveltekit_dev;`)
 			);
 
 			write_if_changed(
 				`${dir}/service-worker.js`,
-				create_sveltekit_env_service_worker_dev(
+				create_sveltekit_env_service_worker(
 					vars,
 					env,
 					config.version.name,
-					'globalThis.__sveltekit_dev'
+					'globalThis.__sveltekit_dev',
+					null
 				)
 			);
 		}

--- a/packages/kit/src/exports/vite/plugins/env-vars.js
+++ b/packages/kit/src/exports/vite/plugins/env-vars.js
@@ -3,17 +3,9 @@
 /** @import { ValidatedConfig } from 'types' */
 import path from 'node:path';
 import * as sync from '../../../core/sync/sync.js';
-import {
-	create_sveltekit_env,
-	create_sveltekit_env_exports,
-	create_sveltekit_env_service_worker,
-	resolve_env_entry
-} from '../../../core/env.js';
+import { create_env_modules, resolve_env_entry } from '../../../core/env.js';
 import { import_peer } from '../../../utils/import.js';
-import { runtime_directory } from '../../../core/utils.js';
-import { s } from '../../../utils/misc.js';
 import { write_if_changed } from '../../../core/sync/utils.js';
-import { hash } from '../../../utils/hash.js';
 import { posixify } from '../../../utils/os.js';
 
 /**
@@ -25,8 +17,6 @@ import { posixify } from '../../../utils/os.js';
  * @returns {Plugin}
  */
 export function plugin_env_vars(config, callback) {
-	const version_hash = hash(config.version.name);
-
 	/** @type {string} */
 	let dir;
 
@@ -60,73 +50,17 @@ export function plugin_env_vars(config, callback) {
 		const vars = synced.variables;
 		callback(vars);
 
-		write_if_changed(
-			`${dir}/config.js`,
-			create_sveltekit_env(
-				vars,
-				env,
-				resolved_entry && posixify(path.relative(dir, resolved_entry)),
-				!is_build
-			)
+		const modules = create_env_modules(
+			config,
+			vars,
+			env,
+			dir,
+			resolved_entry && posixify(path.relative(dir, resolved_entry)),
+			!is_build
 		);
 
-		write_if_changed(
-			`${dir}/public/server.js`,
-			create_sveltekit_env_exports(
-				vars,
-				env,
-				true,
-				`import { rendered_env as env } from '../config.js';`
-			)
-		);
-
-		write_if_changed(
-			`${dir}/private/server.js`,
-			create_sveltekit_env_exports(
-				vars,
-				env,
-				false,
-				`import { dynamic_private_env as env } from '../config.js';`
-			)
-		);
-
-		if (is_build) {
-			write_if_changed(
-				`${dir}/public/client.js`,
-				create_sveltekit_env_exports(
-					vars,
-					env,
-					true,
-					`import { payload } from ${s(posixify(path.relative(`${dir}/public`, `${runtime_directory}/client/payload.js`)))};\nconst env = payload.env;`
-				)
-			);
-
-			write_if_changed(
-				`${dir}/service-worker.js`,
-				create_sveltekit_env_service_worker(
-					vars,
-					env,
-					config.version.name,
-					`globalThis.__sveltekit_${version_hash}`,
-					{ base: config.paths.base, app_dir: config.appDir }
-				)
-			);
-		} else {
-			write_if_changed(
-				`${dir}/public/client.js`,
-				create_sveltekit_env_exports(vars, env, true, `const { env } = globalThis.__sveltekit_dev;`)
-			);
-
-			write_if_changed(
-				`${dir}/service-worker.js`,
-				create_sveltekit_env_service_worker(
-					vars,
-					env,
-					config.version.name,
-					'globalThis.__sveltekit_dev',
-					null
-				)
-			);
+		for (const [file, code] of Object.entries(modules)) {
+			write_if_changed(`${dir}/${file}`, code);
 		}
 	}
 


### PR DESCRIPTION
`core/env.js` had one generator per `<sveltekit:generated>/env/*` module, each iterating the same variables and calling `validate()` on the same static values, so a user's schema ran three to four times per build (and per hot update in dev), and a validator that isn't a pure function of its input baked different values into `config.js`, `public/server.js` and `public/client.js`.

`create_env_modules` replaces them with a single pass over the variables that returns every module keyed by path, so the plugin only writes files. Dynamic variables are untouched; they were already validated once by `set_env`.

One visible change: invalid variables that previously surfaced one module at a time are now reported in a single error.
