### PR TITLE
chore: dedupe the form action request handlers

### DIFF
--- a/.changeset/action-error-result.md
+++ b/.changeset/action-error-result.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+chore: share the action error result between form actions and remote forms

--- a/packages/kit/src/runtime/app/server/remote/form.js
+++ b/packages/kit/src/runtime/app/server/remote/form.js
@@ -15,7 +15,7 @@ import { ActionFailure, ValidationError } from '@sveltejs/kit/internal';
 import { DEV } from 'esm-env';
 
 const incorrect_fail_message =
-	'`fail()` is for form actions. A remote `form` handler should return a value or throw `invalid()`';
+	'`fail(...)` is for form actions. A remote `form` handler should call `invalid(...)` instead. See https://svelte.dev/docs/kit/remote-functions#form-Programmatic-validation';
 
 /**
  * Creates a form object that can be spread onto a `<form>` element.

--- a/packages/kit/src/runtime/app/server/remote/form.js
+++ b/packages/kit/src/runtime/app/server/remote/form.js
@@ -11,7 +11,11 @@ import {
 	parse_form_key
 } from '../../../form-utils.js';
 import { get_cache, get_implicit_lookup, run_remote_function } from './shared.js';
-import { ValidationError } from '@sveltejs/kit/internal';
+import { ActionFailure, ValidationError } from '@sveltejs/kit/internal';
+import { DEV } from 'esm-env';
+
+const incorrect_fail_message =
+	'`fail()` is for form actions. A remote `form` handler should return a value or throw `invalid()`';
 
 /**
  * Creates a form object that can be spread onto a `<form>` element.
@@ -118,9 +122,15 @@ export function form(validate_or_fn, maybe_fn) {
 							() => data,
 							(data) => (!maybe_fn ? fn() : fn(data, issue))
 						);
+
+						if (DEV && output.result instanceof ActionFailure) {
+							throw new Error(incorrect_fail_message);
+						}
 					} catch (e) {
 						if (e instanceof ValidationError) {
 							handle_issues(output, e.issues, form_data, __.id);
+						} else if (DEV && e instanceof ActionFailure) {
+							throw new Error(incorrect_fail_message);
 						} else {
 							throw e;
 						}

--- a/packages/kit/src/runtime/app/server/remote/form.js
+++ b/packages/kit/src/runtime/app/server/remote/form.js
@@ -130,7 +130,7 @@ export function form(validate_or_fn, maybe_fn) {
 						if (e instanceof ValidationError) {
 							handle_issues(output, e.issues, form_data, __.id);
 						} else if (DEV && e instanceof ActionFailure) {
-							throw new Error(incorrect_fail_message);
+							throw new Error(incorrect_fail_message, { cause: e });
 						} else {
 							throw e;
 						}

--- a/packages/kit/src/runtime/server/page/actions.js
+++ b/packages/kit/src/runtime/server/page/actions.js
@@ -1,6 +1,6 @@
 /** @import { RequestEvent, Actions } from '@sveltejs/kit' */
 /** @import { ActionResult } from '$app/forms' */
-/** @import { SSROptions, SSRNode, ServerNode } from 'types' */
+/** @import { SSROptions, SSRNode, ServerNode, ServerActionResult } from 'types' */
 import { DEV } from 'esm-env';
 import { HttpError, Redirect, ActionFailure, SvelteKitError } from '@sveltejs/kit/internal';
 import { with_request_store, merge_tracing, record_span } from '@sveltejs/kit/internal/server';
@@ -35,7 +35,7 @@ export async function handle_action_json_request(event, state, options, server) 
  * @param {RequestEvent} event
  * @param {import('types').RequestState} state
  * @param {SSROptions} options
- * @param {ActionResult} result
+ * @param {ServerActionResult} result
  * @returns {Promise<Response>}
  */
 async function action_result_json(event, state, options, result) {
@@ -87,7 +87,7 @@ export function get_action_location(url) {
 /**
  * @param {RequestEvent} event
  * @param {string} location
- * @returns {Extract<ActionResult, { type: 'error' }>}
+ * @returns {Extract<ServerActionResult, { type: 'error' }>}
  */
 export function no_actions_result(event, location) {
 	event.setHeaders({
@@ -98,7 +98,6 @@ export function no_actions_result(event, location) {
 	return {
 		type: 'error',
 		location,
-		// We're lying a bit with the types here; this will be transformed into a proper App.Error object later
 		error: new SvelteKitError(
 			405,
 			'Method Not Allowed',
@@ -110,7 +109,7 @@ export function no_actions_result(event, location) {
 /**
  * @param {unknown} e
  * @param {string} location
- * @returns {Extract<ActionResult, { type: 'redirect' | 'error' }>}
+ * @returns {Extract<ServerActionResult, { type: 'redirect' | 'error' }>}
  */
 export function action_error_result(e, location) {
 	const err = normalize_error(e);
@@ -126,7 +125,6 @@ export function action_error_result(e, location) {
 	return {
 		type: 'error',
 		location,
-		// @ts-expect-error We're lying a bit with the types here; this will be transformed into a proper App.Error object later
 		error: err
 	};
 }
@@ -161,7 +159,7 @@ export function is_action_request(event) {
  * @param {RequestEvent} event
  * @param {import('types').RequestState} state
  * @param {SSRNode['server'] | undefined} server
- * @returns {Promise<ActionResult>}
+ * @returns {Promise<ServerActionResult>}
  */
 export async function handle_action_request(event, state, server) {
 	const actions = server?.actions;

--- a/packages/kit/src/runtime/server/page/actions.js
+++ b/packages/kit/src/runtime/server/page/actions.js
@@ -89,7 +89,7 @@ export function get_action_location(url) {
  * @param {string} location
  * @returns {Extract<ServerActionResult, { type: 'error' }>}
  */
-export function no_actions_result(event, location) {
+export function method_not_allowed_result(event, location) {
 	event.setHeaders({
 		// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/405
 		// "The server must generate an Allow header field in a 405 status code response"
@@ -167,7 +167,7 @@ export async function handle_action_request(event, state, server) {
 
 	if (!actions) {
 		// TODO should this be a different error altogether?
-		return no_actions_result(event, location);
+		return method_not_allowed_result(event, location);
 	}
 
 	check_named_default_separate(actions);

--- a/packages/kit/src/runtime/server/page/actions.js
+++ b/packages/kit/src/runtime/server/page/actions.js
@@ -96,7 +96,7 @@ export async function handle_action_json_request(event, state, options, server) 
 			});
 		}
 	} catch (e) {
-		const result = action_error_result(e, location);
+		const result = action_error_result(check_incorrect_fail_use(e), location);
 
 		if (result.type === 'redirect') {
 			return action_json(result);
@@ -125,7 +125,7 @@ export function get_action_location(url) {
 }
 
 /**
- * @param {HttpError | Error} error
+ * @param {unknown} error
  */
 function check_incorrect_fail_use(error) {
 	return error instanceof ActionFailure
@@ -153,7 +153,7 @@ export function action_error_result(e, location) {
 		type: 'error',
 		location,
 		// @ts-expect-error We're lying a bit with the types here; this will be transformed into a proper App.Error object later
-		error: check_incorrect_fail_use(err)
+		error: err
 	};
 }
 
@@ -238,7 +238,7 @@ export async function handle_action_request(event, state, server) {
 			};
 		}
 	} catch (e) {
-		return action_error_result(e, location);
+		return action_error_result(check_incorrect_fail_use(e), location);
 	}
 }
 

--- a/packages/kit/src/runtime/server/page/actions.js
+++ b/packages/kit/src/runtime/server/page/actions.js
@@ -141,10 +141,34 @@ export function get_action_location(url) {
 /**
  * @param {HttpError | Error} error
  */
-export function check_incorrect_fail_use(error) {
+function check_incorrect_fail_use(error) {
 	return error instanceof ActionFailure
 		? new Error('Cannot "throw fail()". Use "return fail()"')
 		: error;
+}
+
+/**
+ * @param {unknown} e
+ * @param {string} location
+ * @returns {ActionResult}
+ */
+export function action_error_result(e, location) {
+	const err = normalize_error(e);
+
+	if (err instanceof Redirect) {
+		return {
+			type: 'redirect',
+			status: err.status,
+			location: err.location
+		};
+	}
+
+	return {
+		type: 'error',
+		location,
+		// @ts-expect-error We're lying a bit with the types here; this will be transformed into a proper App.Error object later
+		error: check_incorrect_fail_use(err)
+	};
 }
 
 /**
@@ -228,22 +252,7 @@ export async function handle_action_request(event, state, server) {
 			};
 		}
 	} catch (e) {
-		const err = normalize_error(e);
-
-		if (err instanceof Redirect) {
-			return {
-				type: 'redirect',
-				status: err.status,
-				location: err.location
-			};
-		}
-
-		return {
-			type: 'error',
-			location,
-			// @ts-expect-error We're lying a bit with the types here; this will be transformed into a proper App.Error object later
-			error: check_incorrect_fail_use(err)
-		};
+		return action_error_result(e, location);
 	}
 }
 

--- a/packages/kit/src/runtime/server/page/actions.js
+++ b/packages/kit/src/runtime/server/page/actions.js
@@ -96,29 +96,15 @@ export async function handle_action_json_request(event, state, options, server) 
 			});
 		}
 	} catch (e) {
-		const err = normalize_error(e);
+		const result = action_error_result(e, location);
 
-		if (err instanceof Redirect) {
-			return action_json_redirect(err);
+		if (result.type === 'redirect') {
+			return action_json(result);
 		}
 
-		const transformed = await handle_error_and_jsonify(
-			event,
-			state,
-			options,
-			check_incorrect_fail_use(err)
-		);
+		const error = await handle_error_and_jsonify(event, state, options, result.error);
 
-		return action_json(
-			{
-				type: 'error',
-				error: transformed,
-				location
-			},
-			{
-				status: transformed.status
-			}
-		);
+		return action_json({ type: 'error', error, location }, { status: error.status });
 	}
 }
 
@@ -150,7 +136,7 @@ function check_incorrect_fail_use(error) {
 /**
  * @param {unknown} e
  * @param {string} location
- * @returns {ActionResult}
+ * @returns {Extract<ActionResult, { type: 'redirect' | 'error' }>}
  */
 export function action_error_result(e, location) {
 	const err = normalize_error(e);

--- a/packages/kit/src/runtime/server/page/actions.js
+++ b/packages/kit/src/runtime/server/page/actions.js
@@ -27,84 +27,44 @@ export function is_action_json_request(event) {
  * @param {SSRNode['server'] | undefined} server
  */
 export async function handle_action_json_request(event, state, options, server) {
-	const actions = server?.actions;
-	const location = get_action_location(event.url);
+	const result = await handle_action_request(event, state, server);
+	return action_result_json(event, state, options, result);
+}
 
-	if (!actions) {
-		const no_actions_error = new SvelteKitError(
-			405,
-			'Method Not Allowed',
-			`POST method not allowed. No form actions exist for ${DEV ? `the page at ${event.route.id}` : 'this page'}`
-		);
-
-		const error = await handle_error_and_jsonify(event, state, options, no_actions_error);
-
-		return action_json(
-			{
-				type: 'error',
-				error,
-				location
-			},
-			{
-				status: error.status,
-				headers: {
-					// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/405
-					// "The server must generate an Allow header field in a 405 status code response"
-					allow: 'GET'
-				}
-			}
-		);
+/**
+ * @param {RequestEvent} event
+ * @param {import('types').RequestState} state
+ * @param {SSROptions} options
+ * @param {ActionResult} result
+ * @returns {Promise<Response>}
+ */
+async function action_result_json(event, state, options, result) {
+	if (result.type === 'redirect') {
+		return action_json(result);
 	}
 
-	check_named_default_separate(actions);
+	if (result.type === 'error') {
+		const error = await handle_error_and_jsonify(event, state, options, result.error);
+		return action_json({ ...result, error }, { status: error.status });
+	}
+
+	if (result.type === 'success' && !result.data) {
+		return action_json({ ...result, status: 204, data: undefined });
+	}
 
 	try {
-		const data = await call_action(event, state, actions);
-
-		if (DEV) {
-			validate_action_return(data);
-		}
-
-		if (data instanceof ActionFailure) {
-			return action_json(
-				{
-					type: 'failure',
-					status: data.status,
-					location,
-					// @ts-expect-error we assign a string to what is supposed to be an object. That's ok
-					// because we don't use the object outside, and this way we have better code navigation
-					// through knowing where the related interface is used.
-					data: try_serialize(data.data, stringify, /** @type {string} */ (event.route.id))
-				},
-				{
-					status: data.status
-				}
-			);
-		} else if (data) {
-			return action_json({
-				type: 'success',
-				status: 200,
-				location,
-				// @ts-expect-error see comment above
-				data: try_serialize(data, stringify, /** @type {string} */ (event.route.id))
-			});
-		} else {
-			return action_json({
-				type: 'success',
-				status: 204,
-				location
-			});
-		}
+		return action_json(
+			{
+				...result,
+				// @ts-expect-error we assign a string to what is supposed to be an object. That's ok
+				// because we don't use the object outside, and this way we have better code navigation
+				// through knowing where the related interface is used.
+				data: try_serialize(result.data, stringify, /** @type {string} */ (event.route.id))
+			},
+			{ status: result.status }
+		);
 	} catch (e) {
-		const result = action_error_result(check_incorrect_fail_use(e), location);
-
-		if (result.type === 'redirect') {
-			return action_json(result);
-		}
-
-		const error = await handle_error_and_jsonify(event, state, options, result.error);
-
-		return action_json({ type: 'error', error, location }, { status: error.status });
+		return action_result_json(event, state, options, action_error_result(e, result.location));
 	}
 }
 
@@ -125,12 +85,26 @@ export function get_action_location(url) {
 }
 
 /**
- * @param {unknown} error
+ * @param {RequestEvent} event
+ * @param {string} location
+ * @returns {Extract<ActionResult, { type: 'error' }>}
  */
-function check_incorrect_fail_use(error) {
-	return error instanceof ActionFailure
-		? new Error('Cannot "throw fail()". Use "return fail()"')
-		: error;
+export function no_actions_result(event, location) {
+	event.setHeaders({
+		// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/405
+		// "The server must generate an Allow header field in a 405 status code response"
+		allow: 'GET'
+	});
+	return {
+		type: 'error',
+		location,
+		// We're lying a bit with the types here; this will be transformed into a proper App.Error object later
+		error: new SvelteKitError(
+			405,
+			'Method Not Allowed',
+			`POST method not allowed. No form actions exist for ${DEV ? `the page at ${event.route.id}` : 'this page'}`
+		)
+	};
 }
 
 /**
@@ -195,21 +169,7 @@ export async function handle_action_request(event, state, server) {
 
 	if (!actions) {
 		// TODO should this be a different error altogether?
-		event.setHeaders({
-			// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/405
-			// "The server must generate an Allow header field in a 405 status code response"
-			allow: 'GET'
-		});
-		return {
-			type: 'error',
-			location,
-			// We're lying a bit with the types here; this will be transformed into a proper App.Error object later
-			error: new SvelteKitError(
-				405,
-				'Method Not Allowed',
-				`POST method not allowed. No form actions exist for ${DEV ? `the page at ${event.route.id}` : 'this page'}`
-			)
-		};
+		return no_actions_result(event, location);
 	}
 
 	check_named_default_separate(actions);
@@ -238,7 +198,10 @@ export async function handle_action_request(event, state, server) {
 			};
 		}
 	} catch (e) {
-		return action_error_result(check_incorrect_fail_use(e), location);
+		return action_error_result(
+			e instanceof ActionFailure ? new Error('Cannot "throw fail()". Use "return fail()"') : e,
+			location
+		);
 	}
 }
 

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -1,5 +1,4 @@
 /** @import { RequestEvent, SSRManifest } from '@sveltejs/kit' */
-/** @import { ActionResult } from '$app/forms' */
 /** @import { PageNodeIndexes, RequestState, RequiredResolveOptions, ServerDataNode, SSRNode, SSROptions } from 'types' */
 import { text } from '@sveltejs/kit';
 import { Redirect } from '@sveltejs/kit/internal';
@@ -57,7 +56,7 @@ export async function render_page(event, state, page, options, manifest, nodes, 
 
 		let status = 200;
 
-		/** @type {ActionResult | undefined} */
+		/** @type {import('types').ServerActionResult | undefined} */
 		let action_result = undefined;
 
 		if (is_action_request(event)) {

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -43,7 +43,7 @@ import { has_custom_transporters, uneval } from '#app/internal/transport';
  *   event: import('@sveltejs/kit').RequestEvent;
  *   state: import('types').RequestState;
  *   resolve_opts: import('types').RequiredResolveOptions;
- *   action_result?: import('$app/forms').ActionResult;
+ *   action_result?: import('types').ServerActionResult;
  *   data_serializer: import('./types.js').ServerDataSerializer;
  *   error_components?: Array<import('svelte').Component | undefined>
  * }} opts

--- a/packages/kit/src/runtime/server/remote-functions.js
+++ b/packages/kit/src/runtime/server/remote-functions.js
@@ -11,8 +11,7 @@ import { is_form_content_type } from '../../utils/http.js';
 import { create_remote_key, parse_remote_arg, split_remote_key } from '../shared.js';
 import { stringify } from '#app/internal/transport';
 import { handle_error_and_jsonify } from './errors.js';
-import { normalize_error } from '../../utils/error.js';
-import { check_incorrect_fail_use, get_action_location } from './page/actions.js';
+import { action_error_result, get_action_location } from './page/actions.js';
 import { DEV } from 'esm-env';
 import { deserialize_binary_form } from '../form-utils.js';
 import { with_version_header } from './utils.js';
@@ -591,22 +590,7 @@ async function handle_remote_form_post_internal(event, state, manifest, id) {
 			location
 		};
 	} catch (e) {
-		const err = normalize_error(e);
-
-		if (err instanceof Redirect) {
-			return {
-				type: 'redirect',
-				status: err.status,
-				location: err.location
-			};
-		}
-
-		return {
-			type: 'error',
-			location,
-			// @ts-expect-error We're lying a bit with the types here; this will be transformed into a proper App.Error object later
-			error: check_incorrect_fail_use(err)
-		};
+		return action_error_result(e, location);
 	}
 }
 

--- a/packages/kit/src/runtime/server/remote-functions.js
+++ b/packages/kit/src/runtime/server/remote-functions.js
@@ -10,7 +10,11 @@ import { is_form_content_type } from '../../utils/http.js';
 import { create_remote_key, parse_remote_arg, split_remote_key } from '../shared.js';
 import { stringify } from '#app/internal/transport';
 import { handle_error_and_jsonify } from './errors.js';
-import { action_error_result, get_action_location, no_actions_result } from './page/actions.js';
+import {
+	action_error_result,
+	get_action_location,
+	method_not_allowed_result
+} from './page/actions.js';
 import { deserialize_binary_form } from '../form-utils.js';
 import { with_version_header } from './utils.js';
 
@@ -544,7 +548,7 @@ async function handle_remote_form_post_internal(event, state, manifest, id) {
 	);
 
 	if (!form) {
-		return no_actions_result(event, location);
+		return method_not_allowed_result(event, location);
 	}
 
 	if (action_id) {

--- a/packages/kit/src/runtime/server/remote-functions.js
+++ b/packages/kit/src/runtime/server/remote-functions.js
@@ -1,7 +1,6 @@
 /** @import { RequestEvent, SSRManifest } from '@sveltejs/kit' */
 /** @import { RemoteForm } from '$app/server' */
-/** @import { ActionResult } from '$app/forms' */
-/** @import { RemoteFormInternals, RemoteFunctionData, RemoteFunctionResponse, RemoteInternals, RequestState, SSROptions } from 'types' */
+/** @import { RemoteFormInternals, RemoteFunctionData, RemoteFunctionResponse, RemoteInternals, RequestState, ServerActionResult, SSROptions } from 'types' */
 
 import { error } from '@sveltejs/kit';
 import { Redirect, SvelteKitError } from '@sveltejs/kit/internal';
@@ -529,7 +528,7 @@ export async function handle_remote_form_post(event, state, manifest, id) {
  * @param {RequestState} state
  * @param {SSRManifest} manifest
  * @param {string} id
- * @returns {Promise<ActionResult>}
+ * @returns {Promise<ServerActionResult>}
  */
 async function handle_remote_form_post_internal(event, state, manifest, id) {
 	const location = get_action_location(event.url);

--- a/packages/kit/src/runtime/server/remote-functions.js
+++ b/packages/kit/src/runtime/server/remote-functions.js
@@ -11,8 +11,7 @@ import { is_form_content_type } from '../../utils/http.js';
 import { create_remote_key, parse_remote_arg, split_remote_key } from '../shared.js';
 import { stringify } from '#app/internal/transport';
 import { handle_error_and_jsonify } from './errors.js';
-import { action_error_result, get_action_location } from './page/actions.js';
-import { DEV } from 'esm-env';
+import { action_error_result, get_action_location, no_actions_result } from './page/actions.js';
 import { deserialize_binary_form } from '../form-utils.js';
 import { with_version_header } from './utils.js';
 
@@ -546,21 +545,7 @@ async function handle_remote_form_post_internal(event, state, manifest, id) {
 	);
 
 	if (!form) {
-		event.setHeaders({
-			// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/405
-			// "The server must generate an Allow header field in a 405 status code response"
-			allow: 'GET'
-		});
-		return {
-			type: 'error',
-			location,
-			// We're lying a bit with the types here; this will be transformed into a proper App.Error object later
-			error: new SvelteKitError(
-				405,
-				'Method Not Allowed',
-				`POST method not allowed. No form actions exist for ${DEV ? `the page at ${event.route.id}` : 'this page'}`
-			)
-		};
+		return no_actions_result(event, location);
 	}
 
 	if (action_id) {

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -8,7 +8,8 @@ import {
 	Actions,
 	RequestEvent,
 	SSRManifest,
-	Emulator
+	Emulator,
+	HttpError
 } from '@sveltejs/kit';
 import { RemoteFormIssue, RemoteQuery, RemoteLiveQuery } from '$app/server';
 import { Config } from '@sveltejs/kit/vite';
@@ -291,6 +292,14 @@ export interface RouteData {
 		page_options: PageOptions | null;
 	} | null;
 }
+
+/**
+ * The server-side form of `ActionResult`, before the error is passed
+ * through `handleError` and the data is serialized
+ */
+export type ServerActionResult =
+	| Exclude<import('$app/forms').ActionResult, { type: 'error' }>
+	| { type: 'error'; location: string; error: Error | HttpError };
 
 export type ServerRedirectNode = {
 	type: 'redirect';


### PR DESCRIPTION
`handle_action_json_request` in `runtime/server/page/actions.js` was a copy of `handle_action_request` that differed only in how each branch was encoded, and the 405 result was written out a third time in `handle_remote_form_post_internal` (`runtime/server/remote-functions.js`). #16684 had to add `location` to every copy. `handle_action_request` now runs once and `action_result_json` encodes the result for the JSON transport; `method_not_allowed_result` and `action_error_result` are shared with the remote form POST handler.

The `fail()` misuse check is no longer in the shared catch, since `fail()` is form-action only. Remote `form` handlers get a dev-time error for a thrown or returned `fail()` in `app/server/remote/form.js`, covering both the enhanced and no-JS transports.

`ServerActionResult` (`types/internal.d.ts`) types the pre-`handleError` result, so we're no longer lying about the types.
