### PR TITLE
fix: preserve paths.base when vite preview redirects a prerendered page to the correct trailing slash

### DIFF
--- a/.changeset/preview-base-trailing-slash-redirect.md
+++ b/.changeset/preview-base-trailing-slash-redirect.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: preserve `paths.base` when `vite preview` redirects a prerendered page to the correct trailing slash

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -9,6 +9,7 @@ import sirv from 'sirv';
 import { loadEnv, normalizePath } from 'vite';
 import { createReadableStream, getRequest, setResponse } from '../../../exports/node/index.js';
 import { SVELTE_KIT_ASSETS } from '../../../constants.js';
+import { relative_pathname } from '../../../utils/url.js';
 import { is_chrome_devtools_request, not_found } from '../utils.js';
 import { stackless } from '../../../utils/error.js';
 
@@ -176,9 +177,11 @@ export async function preview(vite, vite_config, svelte_config) {
 					}
 
 					if (redirect) {
-						if (search) redirect += search;
-						res.writeHead(307, {
-							location: redirect
+						// relative so (possibly invisible) path prefixes are preserved
+						let location = relative_pathname(pathname, redirect);
+						if (search) location += search;
+						res.writeHead(308, {
+							location
 						});
 
 						res.end();

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -177,11 +177,9 @@ export async function preview(vite, vite_config, svelte_config) {
 					}
 
 					if (redirect) {
-						// relative so (possibly invisible) path prefixes are preserved
-						let location = relative_pathname(pathname, redirect);
-						if (search) location += search;
 						res.writeHead(308, {
-							location
+							// relative so (possibly invisible) path prefixes are preserved
+							location: relative_pathname(pathname, redirect) + search
 						});
 
 						res.end();

--- a/packages/kit/test/apps/options-2/test/test.js
+++ b/packages/kit/test/apps/options-2/test/test.js
@@ -129,6 +129,19 @@ test.describe('trailing slash', () => {
 		await clicknav('a[href="/basepath/trailing-slash-server/prerender"]');
 		await expect(page.locator('h2')).toHaveText('/basepath/trailing-slash-server/prerender/');
 	});
+
+	test('normalizes the trailing slash of a prerendered page without dropping the base', async ({
+		request
+	}) => {
+		const response = await request.get('/basepath/trailing-slash-server/prerender');
+		expect(new URL(response.url()).pathname).toBe('/basepath/trailing-slash-server/prerender/');
+		expect(response.status()).toBe(200);
+
+		const redirect = await request.get('/basepath/trailing-slash-server/prerender', {
+			maxRedirects: 0
+		});
+		expect(redirect.status()).toBe(308);
+	});
 });
 
 test.describe('Service worker', () => {


### PR DESCRIPTION
The trailing-slash redirect for prerendered pages in `exports/vite/preview/index.js` writes an absolute `location` from the pathname the middleware sees, but that middleware runs inside `scoped(base, ...)`, which has already stripped `paths.base`. With a base path the browser lands on `/nested/` instead of `/base/nested/`. Production (#9351) and adapter-node (#16431) send a relative location for this reason and use 308; preview now does the same via `relative_pathname`.
