### PR TITLE
chore: build streamed responses from async generators

### DIFF
--- a/.changeset/brave-streams-yield.md
+++ b/.changeset/brave-streams-yield.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+chore: build streamed responses from async generators

--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -3,7 +3,7 @@
 
 import { DEV } from 'esm-env';
 import * as devalue from 'devalue';
-import { text_decoder, text_encoder } from './utils.js';
+import { stream_from_iterable, text_decoder, text_encoder } from './utils.js';
 import { noop } from '../utils/functions.js';
 import { SvelteKitError } from '@sveltejs/kit/internal';
 
@@ -442,8 +442,7 @@ class LazyFile {
 	stream() {
 		const range = read_range(this.#get_chunk, this.#offset, this.size);
 		const size = this.size;
-		// TODO remove the cast once TypeScript's lib includes `ReadableStream.from`
-		return /** @type {any} */ (ReadableStream).from(
+		return stream_from_iterable(
 			(async function* () {
 				let cursor = 0;
 				for await (const chunk of range) {

--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -441,25 +441,18 @@ class LazyFile {
 	}
 	stream() {
 		const range = read_range(this.#get_chunk, this.#offset, this.size);
-		let cursor = 0;
-		return new ReadableStream({
-			pull: async (controller) => {
-				const { value, done } = await range.next();
-				if (done) {
-					if (cursor < this.size) {
-						controller.error('incomplete file data');
-					} else {
-						controller.close();
-					}
-					return;
+		const size = this.size;
+		// TODO remove the cast once TypeScript's lib includes `ReadableStream.from`
+		return /** @type {any} */ (ReadableStream).from(
+			(async function* () {
+				let cursor = 0;
+				for await (const chunk of range) {
+					cursor += chunk.byteLength;
+					yield chunk;
 				}
-				cursor += value.byteLength;
-				controller.enqueue(value);
-				if (cursor >= this.size) {
-					controller.close();
-				}
-			}
-		});
+				if (cursor < size) throw new Error('incomplete file data');
+			})()
+		);
 	}
 	async text() {
 		return text_decoder.decode(await this.arrayBuffer());

--- a/packages/kit/src/runtime/server/data/index.js
+++ b/packages/kit/src/runtime/server/data/index.js
@@ -121,11 +121,11 @@ export async function render_data(
 
 		return with_version_header(
 			new Response(stream_text(data, chunks), {
-					headers: {
-						// we use a proprietary content type to prevent buffering.
-						// the `text` prefix makes it inspectable
-						'content-type': 'text/sveltekit-data',
-						'cache-control': 'private, no-store'
+				headers: {
+					// we use a proprietary content type to prevent buffering.
+					// the `text` prefix makes it inspectable
+					'content-type': 'text/sveltekit-data',
+					'cache-control': 'private, no-store'
 				}
 			})
 		);

--- a/packages/kit/src/runtime/server/data/index.js
+++ b/packages/kit/src/runtime/server/data/index.js
@@ -6,7 +6,7 @@ import { server_data_serializer_json } from '../page/data_serializer.js';
 import { load_server_data } from '../page/load_data.js';
 import { handle_error_and_jsonify } from '../errors.js';
 import { normalize_path } from '../../../utils/url.js';
-import { text_encoder } from '../../utils.js';
+import { stream_text } from '../../utils.js';
 import { with_version_header } from '../utils.js';
 
 /**
@@ -120,27 +120,14 @@ export async function render_data(
 		}
 
 		return with_version_header(
-			new Response(
-				new ReadableStream({
-					async start(controller) {
-						controller.enqueue(text_encoder.encode(data));
-						for await (const chunk of chunks) {
-							controller.enqueue(text_encoder.encode(chunk));
-						}
-						controller.close();
-					},
-
-					type: 'bytes'
-				}),
-				{
+			new Response(stream_text(data, chunks), {
 					headers: {
 						// we use a proprietary content type to prevent buffering.
 						// the `text` prefix makes it inspectable
 						'content-type': 'text/sveltekit-data',
 						'cache-control': 'private, no-store'
-					}
 				}
-			)
+			})
 		);
 	} catch (e) {
 		const error = normalize_error(e);

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -1,4 +1,5 @@
 import { noop } from '../../utils/functions.js';
+import { stream_from_iterable } from '../utils.js';
 import { IN_WEBCONTAINER } from '../../constants.js';
 import { respond } from './respond.js';
 import { create_request_state } from './state.js';
@@ -105,14 +106,11 @@ export class Server {
 					return result;
 				}
 
-				// TODO remove the cast once TypeScript's lib includes `ReadableStream.from`
-				return /** @type {ReadableStream} */ (
-					/** @type {any} */ (ReadableStream).from(
-						(async function* () {
-							const stream = await result;
-							if (stream) yield* stream;
-						})()
-					)
+				return stream_from_iterable(
+					(async function* () {
+						const stream = await result;
+						if (stream) yield* stream;
+					})()
 				);
 			};
 

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -18,7 +18,7 @@ import {
 	route_id_resolution_pathname
 } from '../../pathname.js';
 import { try_get_request_store, with_request_store } from '@sveltejs/kit/internal/server';
-import { text_encoder } from '../../utils.js';
+import { stream_text } from '../../utils.js';
 import { count_non_ssi_comments, get_global_name } from '../utils.js';
 import { handle_error_and_jsonify } from '../errors.js';
 import * as env from '<sveltekit:generated>/env/config.js';
@@ -657,22 +657,7 @@ export async function render_response({
 				status,
 				headers
 			})
-		: new Response(
-				new ReadableStream({
-					async start(controller) {
-						controller.enqueue(text_encoder.encode(transformed + '\n'));
-						for await (const chunk of chunks) {
-							if (chunk.length) controller.enqueue(text_encoder.encode(chunk));
-						}
-						controller.close();
-					},
-
-					type: 'bytes'
-				}),
-				{
-					headers
-				}
-			);
+		: new Response(stream_text(transformed + '\n', chunks), { headers });
 }
 
 class Head {

--- a/packages/kit/src/runtime/utils.js
+++ b/packages/kit/src/runtime/utils.js
@@ -1,6 +1,23 @@
 import { BROWSER } from 'esm-env';
 
 export const text_encoder = new TextEncoder();
+
+/**
+ * @param {string} head
+ * @param {AsyncIterable<string>} chunks
+ * @returns {ReadableStream<Uint8Array>} `head` followed by each non-empty chunk, encoded
+ */
+export function stream_text(head, chunks) {
+	// TODO remove the cast once TypeScript's lib includes `ReadableStream.from`
+	return /** @type {any} */ (ReadableStream).from(
+		(async function* () {
+			yield text_encoder.encode(head);
+			for await (const chunk of chunks) {
+				if (chunk) yield text_encoder.encode(chunk);
+			}
+		})()
+	);
+}
 export const text_decoder = new TextDecoder();
 
 /**

--- a/packages/kit/src/runtime/utils.js
+++ b/packages/kit/src/runtime/utils.js
@@ -3,13 +3,37 @@ import { BROWSER } from 'esm-env';
 export const text_encoder = new TextEncoder();
 
 /**
+ * `ReadableStream.from`, for runtimes that don't support it (as of writing, every Bun release)
+ * @template T
+ * @param {AsyncIterable<T>} iterable
+ * @returns {ReadableStream<T>}
+ */
+export function stream_from_iterable(iterable) {
+	// TODO remove the casts once TypeScript's lib includes `ReadableStream.from`
+	if (/** @type {any} */ (ReadableStream).from) {
+		return /** @type {any} */ (ReadableStream).from(iterable);
+	}
+
+	const iterator = iterable[Symbol.asyncIterator]();
+	return new ReadableStream({
+		async pull(controller) {
+			const { value, done } = await iterator.next();
+			if (done) controller.close();
+			else controller.enqueue(value);
+		},
+		async cancel(reason) {
+			await iterator.return?.(reason);
+		}
+	});
+}
+
+/**
  * @param {string} head
  * @param {AsyncIterable<string>} chunks
  * @returns {ReadableStream<Uint8Array>} `head` followed by each non-empty chunk, encoded
  */
 export function stream_text(head, chunks) {
-	// TODO remove the cast once TypeScript's lib includes `ReadableStream.from`
-	return /** @type {any} */ (ReadableStream).from(
+	return stream_from_iterable(
 		(async function* () {
 			yield text_encoder.encode(head);
 			for await (const chunk of chunks) {

--- a/packages/kit/src/runtime/utils.spec.js
+++ b/packages/kit/src/runtime/utils.spec.js
@@ -1,5 +1,5 @@
 import { afterEach, assert, beforeEach, describe, expect, test } from 'vitest';
-import { base64_decode, base64_encode, text_encoder } from './utils.js';
+import { base64_decode, base64_encode, stream_from_iterable, text_encoder } from './utils.js';
 
 const inputs = [
 	'hello world',
@@ -44,5 +44,48 @@ describe('base64_decode', () => {
 
 		const actual = base64_decode(encoded);
 		expect(actual).toEqual(text_encoder.encode(input));
+	});
+});
+
+describe('stream_from_iterable without ReadableStream.from', () => {
+	const from = /** @type {any} */ (ReadableStream).from;
+
+	beforeEach(() => {
+		delete (/** @type {any} */ (ReadableStream).from);
+	});
+
+	afterEach(() => {
+		/** @type {any} */ (ReadableStream).from = from;
+	});
+
+	test('streams the iterable', async () => {
+		const stream = stream_from_iterable(
+			(async function* () {
+				yield await Promise.resolve(1);
+				yield 2;
+			})()
+		);
+
+		assert.deepEqual(await Array.fromAsync(stream), [1, 2]);
+	});
+
+	test('cancelling the stream ends the iterable', async () => {
+		let finished = false;
+
+		const stream = stream_from_iterable(
+			(async function* () {
+				try {
+					yield await Promise.resolve(1);
+					yield 2;
+				} finally {
+					finished = true;
+				}
+			})()
+		);
+
+		const reader = stream.getReader();
+		assert.equal((await reader.read()).value, 1);
+		await reader.cancel();
+		assert.equal(finished, true);
 	});
 });

--- a/packages/kit/src/utils/streaming.js
+++ b/packages/kit/src/utils/streaming.js
@@ -15,7 +15,7 @@ export function create_async_iterator() {
 	const deferred = [];
 
 	return {
-		iterate: async function* (transform = (x) => x) {
+		async *iterate(transform = (x) => x) {
 			// `deferred` can grow while we iterate, as resolved values may add further promises
 			for (let i = 0; i < deferred.length; i += 1) {
 				yield transform(await deferred[i].promise);

--- a/packages/kit/src/utils/streaming.js
+++ b/packages/kit/src/utils/streaming.js
@@ -10,26 +10,16 @@ import { noop } from './functions.js';
  */
 export function create_async_iterator() {
 	let resolved = -1;
-	let returned = -1;
 
 	/** @type {PromiseWithResolvers<T>[]} */
 	const deferred = [];
 
 	return {
-		iterate: (transform = (x) => x) => {
-			return {
-				[Symbol.asyncIterator]() {
-					return {
-						next: async () => {
-							const next = deferred[++returned];
-							if (!next) return { value: null, done: true };
-
-							const value = await next.promise;
-							return { value: transform(value), done: false };
-						}
-					};
-				}
-			};
+		iterate: async function* (transform = (x) => x) {
+			// `deferred` can grow while we iterate, as resolved values may add further promises
+			for (let i = 0; i < deferred.length; i += 1) {
+				yield transform(await deferred[i].promise);
+			}
 		},
 		add: (promise) => {
 			const next = Promise.withResolvers();


### PR DESCRIPTION
Four places hand-write the producer side of a stream. `server/page/render.js` and `server/data/index.js` each construct a `ReadableStream` whose `start` enqueues an encoded head, loops an async iterable of chunks and closes; `form-utils.js` `LazyFile.stream()` drives `read_range` through a `pull` adapter that re-tracks a cursor the generator already knows; and `utils/streaming.js` `create_async_iterator` implements `[Symbol.asyncIterator]`/`next` by hand with two index cursors.

This replaces them with async generators and `ReadableStream.from`, which `server/index.js` already relies on for promised `read` results. The two response pumps share a `stream_text(head, chunks)` helper, `LazyFile.stream()` becomes a `for await` over `read_range`, and `iterate` becomes an `async function*` over the deferred list.

Two deliberate deltas: the response streams lose `type: 'bytes'` (added alongside the encoding fix in #9136; `Response` only requires `Uint8Array` chunks, which `.from` over encoded strings provides), and an incomplete `LazyFile` now errors with an `Error` instead of a bare string.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
