### PR TITLE
fix: discard invalidation results made stale by a completed navigation

### DIFF
--- a/.changeset/invalidate-during-resolution.md
+++ b/.changeset/invalidate-during-resolution.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: discard invalidation results when a navigation completes while they load

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -615,7 +615,7 @@ async function _invalidate(reset_page_state = true) {
 
 	const token = (invalidation_token = {});
 	const nav_token = navigation_token;
-	const navigating = is_navigating;
+	const prev_current = current;
 	const intent = await get_navigation_intent(current.url, true);
 
 	// Clear preload, it might be affected by the invalidation.
@@ -655,9 +655,9 @@ async function _invalidate(reset_page_state = true) {
 		);
 	}
 
-	// A navigation started before the invalidation and ended before it finished. The invalidation did not redirect,
-	// hence it likely contains outdated data now, so we ignore it.
-	if (navigating && !is_navigating) {
+	// a navigation applied its result while the invalidation was loading,
+	// so the invalidation contains outdated data for a page we are no longer on
+	if (current !== prev_current) {
 		return;
 	}
 

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -889,6 +889,13 @@ test.describe('Invalidation', () => {
 		page,
 		clicknav
 	}) => {
+		// with server-side route resolution, delay resolution so that refreshAll
+		// reliably starts while the navigation is still resolving its route
+		await page.route('**/__route.js', async (route) => {
+			await new Promise((resolve) => setTimeout(resolve, 150));
+			await route.continue();
+		});
+
 		await page.goto('/load/invalidation/during-navigation/a');
 		await expect(page.locator('[data-testid="scores"]')).toHaveText('1 - 1');
 


### PR DESCRIPTION
`_invalidate` in `packages/kit/src/runtime/client/client.js` detects a racing navigation by capturing `is_navigating` and bailing if it flipped back to false. But `navigate` sets `is_navigating` only after `await get_navigation_intent(url, false)`, which is a network round trip when route resolution happens on the server. An `invalidate()` or `refreshAll()` starting during that round trip sees `is_navigating === false`, reruns the load functions of the page being left, and applies their result over the page the navigation just rendered.

A navigation makes an in-flight invalidation stale exactly when it applies its result, which is also when it reassigns `current`, so `_invalidate` now captures `current` and bails if its identity changed.

The existing test only hits the race when route resolution outlasts its 50ms `refreshAll` timer, so it passes locally and fails on loaded CI runners. It now delays `__route.js` responses by 150ms, and fails without the fix.

This is what turns the `test:server-side-route-resolution` legs red on #16842.
