### PR TITLE
fix: don't re-suspend consumers awaiting a remote query when its value arrives

### DIFF
--- a/.changeset/eighty-moons-repeat.md
+++ b/.changeset/eighty-moons-repeat.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: don't re-suspend consumers awaiting a query when its value arrives

--- a/packages/kit/src/runtime/client/remote-functions/query/instance.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query/instance.svelte.js
@@ -102,9 +102,14 @@ export class Query {
 			.catch(noop);
 	}
 
+	/** @returns {boolean} whether there was an in-flight request to resolve */
 	#clear_pending() {
+		const had_pending = this.#latest.length > 0;
+
 		this.#latest.forEach((r) => r(undefined));
 		this.#latest.length = 0;
+
+		return had_pending;
 	}
 
 	#run() {
@@ -242,12 +247,34 @@ export class Query {
 		// SSR record can never shadow the newly-set value
 		delete query_responses[this.#key];
 
-		this.#clear_pending();
+		// a rejected promise must be replaced, or consumers awaiting the query would keep
+		// throwing the old error. read untracked so that calling `set` from inside an
+		// effect doesn't subscribe that effect to the error
+		const rejected = untrack(() => this.#error !== undefined);
+		const resolved_in_flight = this.#clear_pending();
+
 		this.#ready = true;
 		this.#loading = false;
 		this.#error = undefined;
 		this.#raw = value;
-		this.#promise = Promise.resolve();
+
+		// A fresh promise is how consumers awaiting this query learn that a new value is
+		// available, so it is required whenever they are not already suspended on one —
+		// a server-initiated single-flight update, `.set(...)`, or SSR hydration.
+		//
+		// When there *was* an in-flight request we have just resolved it, and `#then`
+		// reads `#current` after the promise settles rather than closing over the value,
+		// so those consumers already see the new value. Replacing the promise as well
+		// would invalidate `#then` a second time and re-suspend a consumer that is
+		// already awaiting this query — in a second batch, while the first is still
+		// pending. That puts Svelte into 'time travelling' mode, where deriveds are never
+		// marked clean, so everything downstream of the query recomputes on every read.
+		// The cost is exponential in the depth of the derived graph, which is enough to
+		// lock up a page that renders a chart.
+		// See https://github.com/sveltejs/kit/issues/16854
+		if (!resolved_in_flight || rejected) {
+			this.#promise = Promise.resolve();
+		}
 	}
 
 	/** @param {HttpError} error */

--- a/packages/kit/test/apps/async/src/routes/remote/query-derived-memoization/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/query-derived-memoization/+page.svelte
@@ -1,0 +1,43 @@
+<script>
+	import Graph from './Graph.svelte';
+	import { get_rows } from './data.remote.js';
+
+	/**
+	 * Both modes render the same graph, from the same data, updated the same number of
+	 * times. Only the source of the data differs:
+	 *
+	 * - `promise` feeds it from a plain awaited promise
+	 * - `query` feeds it from an awaited remote query
+	 *
+	 * `promise` is the control. It only counts as one if the graph really re-renders,
+	 * which is what `#result` is for — note that `rows` is read synchronously below,
+	 * because reading it inside the `setTimeout` callback would leave `plain_promise`
+	 * with no reactive dependency and the control would quietly stop testing anything.
+	 */
+	let mode = $state('query');
+	let bucket = $state(0);
+
+	const rows = $derived(Array.from({ length: 10 + bucket }, (_, i) => i));
+
+	const plain_promise = $derived.by(() => {
+		const current = rows;
+		return new Promise((resolve) => setTimeout(() => resolve(current), 20));
+	});
+</script>
+
+<label><input type="radio" value="promise" bind:group={mode} /> promise</label>
+<label><input type="radio" value="query" bind:group={mode} /> query</label>
+
+<button id="bump" onclick={() => (bucket += 1)}>bump</button>
+
+{#if mode === 'promise'}
+	<svelte:boundary>
+		{#snippet pending()}<p id="pending">loading</p>{/snippet}
+		<Graph rows={await plain_promise} />
+	</svelte:boundary>
+{:else}
+	<svelte:boundary>
+		{#snippet pending()}<p id="pending">loading</p>{/snippet}
+		<Graph rows={await get_rows({ bucket })} />
+	</svelte:boundary>
+{/if}

--- a/packages/kit/test/apps/async/src/routes/remote/query-derived-memoization/Graph.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/query-derived-memoization/Graph.svelte
@@ -1,0 +1,50 @@
+<script>
+	/**
+	 * A deep graph of deriveds, in the shape that makes lost memoization expensive.
+	 *
+	 * Each level has two nodes:
+	 *
+	 * - `object_n` returns a fresh object, so `equals` always fails and its write version
+	 *   increases on every recomputation
+	 * - `constant_n` always returns the same value, so `equals` always holds and its write
+	 *   version never increases, which leaves it permanently dirtier than the `object_n`
+	 *   it reads
+	 *
+	 * When deriveds are memoized this costs one recomputation per node. When they are not,
+	 * every read of a level re-walks the level below it several times over, so the cost is
+	 * exponential in the depth. That is the shape a charting library's chart context has, and
+	 * why a chart is where this bug surfaces as a frozen tab rather than a slow render.
+	 */
+	let { rows } = $props();
+
+	/**
+	 * @template T
+	 * @param {T} value
+	 * @returns {T}
+	 */
+	function counted(value) {
+		if (typeof window !== 'undefined') {
+			const w = /** @type {Record<string, number>} */ (/** @type {unknown} */ (window));
+			w.__recomputations = (w.__recomputations ?? 0) + 1;
+		}
+
+		return value;
+	}
+
+	const object_0 = $derived(counted({ n: rows.length }));
+	const constant_0 = $derived(counted(object_0.n >= 0 ? null : 1));
+	const object_1 = $derived(counted({ n: object_0.n + (constant_0 ?? 0) }));
+	const constant_1 = $derived(counted(object_1.n >= 0 ? null : 1));
+	const object_2 = $derived(counted({ n: object_1.n + (constant_1 ?? 0) }));
+	const constant_2 = $derived(counted(object_2.n >= 0 ? null : 1));
+	const object_3 = $derived(counted({ n: object_2.n + (constant_2 ?? 0) }));
+	const constant_3 = $derived(counted(object_3.n >= 0 ? null : 1));
+	const object_4 = $derived(counted({ n: object_3.n + (constant_3 ?? 0) }));
+	const constant_4 = $derived(counted(object_4.n >= 0 ? null : 1));
+	const object_5 = $derived(counted({ n: object_4.n + (constant_4 ?? 0) }));
+	const constant_5 = $derived(counted(object_5.n >= 0 ? null : 1));
+	const object_6 = $derived(counted({ n: object_5.n + (constant_5 ?? 0) }));
+	const constant_6 = $derived(counted(object_6.n >= 0 ? null : 1));
+</script>
+
+<p id="result">{object_6.n}{constant_6 ?? ''}</p>

--- a/packages/kit/test/apps/async/src/routes/remote/query-derived-memoization/data.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/query-derived-memoization/data.remote.js
@@ -1,0 +1,7 @@
+import { query } from '$app/server';
+import * as v from 'valibot';
+
+// the argument changes on every bump, so each bump is a distinct query instance
+export const get_rows = query(v.object({ bucket: v.number() }), ({ bucket }) => {
+	return Array.from({ length: 10 + bucket }, (_, i) => i);
+});

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -57,6 +57,52 @@ test.describe('remote functions', () => {
 		await page.goto('/plain-lib');
 		await expect(page.locator('p')).toHaveText('key set for https://example.com/jwks');
 	});
+
+	// https://github.com/sveltejs/kit/issues/16854
+	//
+	// Deriveds downstream of an awaited query lost their memoization and were recomputed
+	// on every read, which is exponential in the depth of the graph. The fixture's graph
+	// is seven levels deep and costs fourteen recomputations when memoization holds, and
+	// tens of thousands when it doesn't; a real charting library's graph is deep enough
+	// that the tab never recovers.
+	//
+	// The bound is deliberately counted rather than timed, so a regression fails in
+	// milliseconds instead of hanging until the test times out.
+	const RECOMPUTATION_LIMIT = 1000;
+
+	/** @param {import('@playwright/test').Page} page */
+	const recomputations = (page) =>
+		page.evaluate(
+			() => /** @type {Record<string, number>} */ (/** @type {unknown} */ (window)).__recomputations
+		);
+
+	test('deriveds fed by an awaited promise are memoized', async ({ page }) => {
+		await page.goto('/remote/query-derived-memoization');
+		await page.getByRole('radio', { name: 'promise' }).check();
+		await expect(page.locator('#result')).toHaveText('10');
+
+		await page.evaluate(() => {
+			/** @type {Record<string, number>} */ (/** @type {unknown} */ (window)).__recomputations = 0;
+		});
+		await page.locator('#bump').click();
+
+		// the graph must actually re-render, or the control tests nothing
+		await expect(page.locator('#result')).toHaveText('11');
+		expect(await recomputations(page)).toBeLessThan(RECOMPUTATION_LIMIT);
+	});
+
+	test('deriveds fed by an awaited query are memoized', async ({ page }) => {
+		await page.goto('/remote/query-derived-memoization');
+		await expect(page.locator('#result')).toHaveText('10');
+
+		await page.evaluate(() => {
+			/** @type {Record<string, number>} */ (/** @type {unknown} */ (window)).__recomputations = 0;
+		});
+		await page.locator('#bump').click();
+
+		await expect(page.locator('#result')).toHaveText('11');
+		expect(await recomputations(page)).toBeLessThan(RECOMPUTATION_LIMIT);
+	});
 });
 
 // have to run in serial because commands mutate in-memory data on the server (should fix this at some point)


### PR DESCRIPTION
closes #16854

Deriveds downstream of a remote query that the page also `await`s stop being memoized, so every read re-walks the dependency graph. The cost is exponential in the depth of that graph — enough to lock the main thread on a page that renders a chart, with no error, no failed boundary and no recovery short of a reload.

## Cause

`Query.set()` unconditionally replaced `#promise` with a fresh resolved promise. That identity change is how a consumer awaiting the query learns a new value is available, and it is needed for a server-initiated single-flight update, an explicit `.set(...)` and SSR hydration — but not when a request was already in flight.

In that case `#clear_pending()` has just resolved the promise those consumers are suspended on, and `#then` reads `#current` after the promise settles rather than closing over the value, so they already see the new value. Replacing the promise as well invalidated `#then` a second time and re-suspended an already-awaiting consumer, in a second batch, while the first was still pending.

Two live batches put Svelte into 'time travelling' mode, where `update_derived` and `is_dirty` deliberately never mark a derived `CLEAN`. Everything downstream of the query then recomputes on every read instead of once.

This is a 3.x regression rather than a Svelte one because the response path moved. In 2.64.0 the fetch callback returned the value and `#run()`'s own `.then` wrote it, so `set()` was never involved in a response. In 3.x the callback returns nothing and `remote_request` injects the value through `set()`, putting it on the hot path for every query response.

## Fix

Replace the promise only when consumers are not already suspended on one, or when the existing promise is a rejection that would otherwise keep being thrown.

## Test

`test/apps/async/src/routes/remote/query-derived-memoization` renders the same seven-level derived graph twice: once fed by a plain awaited promise (the control) and once by an awaited remote query. The graph alternates nodes returning a fresh object with nodes returning a constant, which is the shape that makes lost memoization expensive.

The test counts recomputations rather than timing the interaction, so a regression fails in milliseconds with a number instead of hanging until the test times out, and it asserts the graph actually re-rendered so the control cannot pass while doing nothing.

Measured over one interaction, with `svelte@5.56.8` and `vite@8.2.1` held constant so the Kit version is the only variable:

| | recomputations while time travelling | total |
| --- | --- | --- |
| `@sveltejs/kit` 2.64.0 | 0 | 14 |
| 3.0.0-next.23, before this PR | 27,307 | 27,309 |
| 3.0.0-next.23, with this PR | 0 | 14 |

The two commits are separated so the test can be checked out on its own and observed to fail.

Verified separately against the original `layerchart` reproduction from #16854: `FROZEN` on the first press before, `25ms/11bars / 25ms/12bars / 18ms/13bars / 27ms/14bars` after.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

`pnpm lint`, `pnpm check` and `pnpm -F @sveltejs/kit test:unit` (737 passed) are clean. The full `test/apps/async` suite passes in both dev and build modes apart from four `query.live` tests that fail identically on an unmodified checkout of `main`.

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
