### PR TITLE
fix: route dev-server response logging through Vite's logger

### DIFF
--- a/.changeset/neat-otters-pause.md
+++ b/.changeset/neat-otters-pause.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: route dev-server response logging through Vite's logger so it respects `logLevel` and `customLogger`

--- a/packages/kit/src/core/postbuild/prerender.js
+++ b/packages/kit/src/core/postbuild/prerender.js
@@ -52,7 +52,7 @@ async function prerender({
 	const manifest = (await import(pathToFileURL(manifest_path).href)).manifest;
 
 	/** @type {import('types').ServerInternalModule} */
-	const { set_building, set_prerendering, set_manifest, set_read_implementation, log_response } =
+	const { set_building, set_prerendering, set_manifest, set_read_implementation, format_response } =
 		await import(pathToFileURL(`${out}/server/internal.js`).href);
 
 	// configure `import { building } from `$app/env` —
@@ -424,7 +424,7 @@ async function prerender({
 		}
 
 		if (response.status >= 400) {
-			log_response(response.status, request);
+			console.log(format_response(response.status, request));
 		}
 
 		const body = Buffer.from(await response.arrayBuffer());

--- a/packages/kit/src/core/sync/write_server.js
+++ b/packages/kit/src/core/sync/write_server.js
@@ -28,7 +28,7 @@ const server_template = ({
 }) => `
 import { set_building, set_prerendering } from '$app/env/server';
 import { set_assets } from '$app/paths/internal/server';
-import { set_fix_stack_trace, set_manifest, set_read_implementation, log_response } from '${runtime_directory}/server/internal.js';
+import { set_fix_stack_trace, set_manifest, set_read_implementation, format_response } from '${runtime_directory}/server/internal.js';
 import error from './shared/error-template.js';
 
 export const options = {
@@ -81,7 +81,7 @@ export async function get_hooks() {
 	};
 }
 
-export { set_assets, set_building, set_fix_stack_trace, set_manifest, set_prerendering, set_read_implementation, log_response };
+export { set_assets, set_building, set_fix_stack_trace, set_manifest, set_prerendering, set_read_implementation, format_response };
 `;
 
 /**

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -90,6 +90,20 @@ export async function dev(
 	const runner = get_runner(vite, vite_dev_server);
 
 	/**
+	 * Log a response to the console, routed through Vite's logger so that it
+	 * respects the configured `logLevel` and any `customLogger`
+	 * @param {number} status
+	 * @param {string} log
+	 */
+	function log_dev_response(status, log) {
+		if (status < 400) {
+			vite_dev_server.config.logger.info(log);
+		} else {
+			vite_dev_server.config.logger.error(log);
+		}
+	}
+
+	/**
 	 * @param {string} url
 	 * @returns {Promise<Record<string, any>>}
 	 */
@@ -580,7 +594,7 @@ export async function dev(
 					await runner.import(`${get_runtime_base(root)}/server/index.js`)
 				);
 
-				const { set_fix_stack_trace, log_response } = await runner.import(
+				const { set_fix_stack_trace, format_response } = await runner.import(
 					`${get_runtime_base(root)}/server/internal.js`
 				);
 				set_fix_stack_trace(fix_stack_trace);
@@ -647,11 +661,11 @@ export async function dev(
 				if (rendered.status === 404) {
 					// @ts-expect-error
 					serve_static_middleware.handle(req, res, () => {
-						log_response(rendered.status, request);
+						log_dev_response(rendered.status, format_response(rendered.status, request));
 						setResponse(res, rendered);
 					});
 				} else {
-					log_response(rendered.status, request);
+					log_dev_response(rendered.status, format_response(rendered.status, request));
 					setResponse(res, rendered);
 				}
 			} catch (e) {

--- a/packages/kit/src/runtime/server/internal.js
+++ b/packages/kit/src/runtime/server/internal.js
@@ -45,8 +45,9 @@ export function set_manifest(value) {
 /**
  * @param {number} status
  * @param {Request} request
+ * @returns {string}
  */
-export function log_response(status, request) {
+export function format_response(status, request) {
 	const url = new URL(request.url);
 	const requested = url.href.replace(url.origin, '');
 
@@ -65,7 +66,7 @@ export function log_response(status, request) {
 		log += requested;
 	}
 
-	console.log(log);
+	return log;
 }
 
 export { fix_stack_trace, set_fix_stack_trace } from './sourcemaps.js';

--- a/packages/kit/src/runtime/server/internal.spec.js
+++ b/packages/kit/src/runtime/server/internal.spec.js
@@ -1,0 +1,58 @@
+import { expect, test, vi } from 'vitest';
+import { stripVTControlCharacters } from 'node:util';
+
+// `__SVELTEKIT_DEV__` is a compile-time flag that is normally replaced by the
+// Vite plugin at build time; provide it here so the module can be loaded
+/** @type {any} */ (globalThis).__SVELTEKIT_DEV__ = false;
+
+const { format_response } = await import('./internal.js');
+
+test('formats a plain page request', () => {
+	expect(
+		stripVTControlCharacters(format_response(200, new Request('http://localhost:5173/')))
+	).toBe('200 GET /');
+});
+
+test('formats a request with a path', () => {
+	expect(
+		stripVTControlCharacters(format_response(200, new Request('http://localhost:5173/blog/hello')))
+	).toBe('200 GET /blog/hello');
+});
+
+test('formats a data request', () => {
+	expect(
+		stripVTControlCharacters(
+			format_response(200, new Request('http://localhost:5173/blog/hello/__data.json?sveltekit=1'))
+		)
+	).toBe('200 GET /blog/hello/__data.json?sveltekit=1');
+});
+
+test('formats a route resolution request', () => {
+	expect(
+		stripVTControlCharacters(
+			format_response(200, new Request('http://localhost:5173/blog/hello/__route.js'))
+		)
+	).toBe('200 GET /blog/hello/__route.js');
+});
+
+test('formats a remote function request', () => {
+	expect(
+		stripVTControlCharacters(
+			format_response(200, new Request('http://localhost:5173/_app/remote/abc123?x=1'))
+		)
+	).toBe('200 GET /_app/remote/abc123?x=1');
+});
+
+test('formats an error response', () => {
+	expect(
+		stripVTControlCharacters(format_response(500, new Request('http://localhost:5173/')))
+	).toBe('500 GET /');
+});
+
+test('returns a string and does not log to the console', () => {
+	const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+	const result = format_response(200, new Request('http://localhost:5173/'));
+	expect(typeof result).toBe('string');
+	expect(spy).not.toHaveBeenCalled();
+	spy.mockRestore();
+});

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -48,7 +48,7 @@ export interface ServerInternalModule {
 	set_version(version: string): void;
 	set_fix_stack_trace(fix_stack_trace: (error: Error) => void): void;
 	get_hooks: () => Promise<Record<string, any>>;
-	log_response: (status: number, request: Request) => void;
+	format_response: (status: number, request: Request) => string;
 }
 
 export interface Asset {


### PR DESCRIPTION
Fixes #16825

## Summary

In the dev server, every SSR response is logged to the console (e.g. `200 GET /`) via a raw `console.log` from `log_response` in the runtime `server/internal.js`. Because it bypasses Vite's logger, `logLevel` and `customLogger` have no effect on it.

This change routes dev-server response logging through Vite's resolved logger:

- `format_response(status, request)` in `packages/kit/src/runtime/server/internal.js` is now a pure function that returns the formatted line instead of printing it, so the caller decides how to emit it.
- The dev middleware (`packages/kit/src/exports/vite/dev/index.js`) emits the line via `vite_dev_server.config.logger` — `logger.info` for statuses < 400 and `logger.error` for >= 400. This means:
  - `logLevel: "warn"` (or `"error"`/`"silent"`) now suppresses successful-request lines, while errors remain visible
  - a user-supplied `customLogger` receives the lines
- Prerender logging (`packages/kit/src/core/postbuild/prerender.js`) is unchanged in behaviour — it still prints only >= 400 responses via `console.log`.
- Renamed `log_response` -> `format_response` in the generated server module (`core/sync/write_server.js`) and the internal type declaration to match the new contract.

## Testing

- Added unit tests for `format_response` covering plain pages, data requests, route-resolution requests, remote-function requests, and error responses (all pass).
- `pnpm tsc-native` and `oxfmt --check` pass on the changed files.

### Changesets

`patch` for `@sveltejs/kit`.