### PR TITLE
chore: resolve service worker entry once

### DIFF
--- a/.changeset/quiet-owls-resolve.md
+++ b/.changeset/quiet-owls-resolve.md
@@ -1,5 +1,0 @@
----
-'@sveltejs/kit': patch
----
-
-chore: resolve the service worker entry once and share it between the service worker plugins

--- a/.changeset/quiet-owls-resolve.md
+++ b/.changeset/quiet-owls-resolve.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+chore: resolve the service worker entry once and share it between the service worker plugins

--- a/packages/kit/src/exports/vite/build/service-worker.js
+++ b/packages/kit/src/exports/vite/build/service-worker.js
@@ -1,7 +1,6 @@
 /** @import { ValidatedConfig } from 'types' */
 /** @import { Plugin, UserConfig } from 'vite' */
 import { runtime_directory } from '../../../core/utils.js';
-import { posixify } from '../../../utils/os.js';
 import { warn_overridden_config } from '../utils.js';
 
 /**
@@ -37,7 +36,7 @@ export function plugin_service_worker_build(kit, get_config) {
 							rolldownOptions: {
 								external: [`${kit.paths.base}/${kit.appDir}/env.js`],
 								input: {
-									'service-worker': posixify(service_worker_entry_file)
+									'service-worker': service_worker_entry_file
 								},
 								output: {
 									format: 'es',

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -1897,7 +1897,7 @@ function kit({ svelte_config }) {
 				initial_config,
 				out
 			})),
-			plugin_service_worker_env_vars(svelte_config),
+			plugin_service_worker_env_vars(() => service_worker_entry_file),
 			plugin_compile,
 			plugin_adapter,
 			svelte_config.adapter?.vite?.plugins?.post

--- a/packages/kit/src/exports/vite/plugins/env-vars.js
+++ b/packages/kit/src/exports/vite/plugins/env-vars.js
@@ -8,7 +8,6 @@ import { create_env_modules, resolve_env_entry } from '../../../core/env.js';
 import { import_peer } from '../../../utils/import.js';
 import { write_if_changed } from '../../../core/sync/utils.js';
 import { posixify } from '../../../utils/os.js';
-import { resolve_entry } from '../../../utils/filesystem.js';
 
 /**
  * Generate (and, in dev, maintain) the `${outDir}/generated/{build,dev}/env` modules
@@ -119,10 +118,10 @@ export function plugin_env_vars(config, callback) {
 }
 
 /**
- * @param {ValidatedConfig} kit
+ * @param {() => string | null} get_service_worker_entry_file
  * @returns {Plugin}
  */
-export function plugin_service_worker_env_vars(kit) {
+export function plugin_service_worker_env_vars(get_service_worker_entry_file) {
 	/** @type {string | null} */
 	let service_worker_entry_file;
 
@@ -130,8 +129,7 @@ export function plugin_service_worker_env_vars(kit) {
 	const plugin = {
 		name: 'vite-plugin-sveltekit-service-worker-env',
 		configResolved() {
-			service_worker_entry_file = resolve_entry(kit.files.serviceWorker);
-			service_worker_entry_file &&= posixify(service_worker_entry_file);
+			service_worker_entry_file = get_service_worker_entry_file();
 
 			if (service_worker_entry_file) {
 				plugin.transform.filter = {


### PR DESCRIPTION
After #16859, `plugin_service_worker_env_vars` re-resolves the service worker entry that `plugin_setup` already resolved and hands to `plugin_service_worker_build`. Pass it the same value via a getter and drop the redundant `posixify` in `build/service-worker.js`.

---

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
