### PR TITLE
fix: only require svelte-trusted-html trusted-types policy when client code ships

### DIFF
--- a/.changeset/lazy-queens-refuse.md
+++ b/.changeset/lazy-queens-refuse.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: only require the `svelte-trusted-html` trusted-types policy when client-side code is shipped, allowing builds where all pages have `csr: false`

--- a/packages/kit/src/core/config/index.js
+++ b/packages/kit/src/core/config/index.js
@@ -277,11 +277,8 @@ export function validate_config(config, cwd = process.cwd()) {
 	}
 
 	if (validated.kit.csp?.directives?.['require-trusted-types-for']?.includes('script')) {
-		if (!validated.kit.csp?.directives?.['trusted-types']?.includes('svelte-trusted-html')) {
-			throw new Error(
-				"The `csp.directives['trusted-types']` option must include 'svelte-trusted-html'"
-			);
-		}
+		// the 'svelte-trusted-html' policy is only required when client-side code ships,
+		// which is checked at build time once page options are known
 		if (
 			validated.kit.serviceWorker?.register &&
 			resolve_entry(path.resolve(cwd, validated.kit.files.serviceWorker)) &&

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -1335,6 +1335,16 @@ async function kit({ svelte_config }) {
 					(node) => node.page_options?.csr === false
 				);
 
+				if (
+					!skip_client_build &&
+					kit.csp.directives['require-trusted-types-for']?.includes('script') &&
+					!kit.csp.directives['trusted-types']?.includes('svelte-trusted-html')
+				) {
+					throw new Error(
+						"The `csp.directives['trusted-types']` option must include 'svelte-trusted-html' unless all pages have `csr: false`"
+					);
+				}
+
 				/** @type {Manifest | null} */
 				let client_manifest = null;
 


### PR DESCRIPTION
Previously, setting csp.directives['require-trusted-types-for']: ['script'] without including 'svelte-trusted-html' in trusted-types threw during config validation. This blocked builds of apps where every page has csr: false — those apps ship no client-side code, so the policy is never used.

The check now runs at build time instead, reusing the same statically-analysed page options that decide skip_client_build. If any page ships client code (or its csr option can't be statically analysed), the original error still throws; if all pages have csr: false, the build proceeds.

Note: since the analysis only runs during build, vite dev no longer surfaces the missing policy at startup.

- packages/kit/src/core/config/index.js — removed the check from validate_config
- packages/kit/src/exports/vite/index.js — added the check after skip_client_build is computed

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
