### PR TITLE
fix: keep the server-only import guard's manifest current

### DIFF
--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -1710,12 +1710,17 @@ function kit({ svelte_config }) {
 				explicit_env_config = vars;
 			}),
 			process.env.TEST !== 'true'
-				? plugin_guard(svelte_config, () => ({
-						vite,
-						root,
-						normalized_aliases,
-						service_worker_entry_file
-					}))
+				? plugin_guard(
+						svelte_config,
+						() => ({
+							vite,
+							root,
+							normalized_aliases,
+							service_worker_entry_file
+						}),
+						// in dev, this doesn't exist yet, so we need to create it
+						() => (manifest_data ??= create_manifest_data(svelte_config, root))
+					)
 				: undefined,
 			plugin_service_worker_build(svelte_config, () => ({
 				service_worker_entry_file,

--- a/packages/kit/src/exports/vite/plugins/guard.js
+++ b/packages/kit/src/exports/vite/plugins/guard.js
@@ -13,16 +13,16 @@ import {
 } from '../utils.js';
 import { stackless } from '../../../utils/error.js';
 import { posixify } from '../../../utils/os.js';
-import create_manifest_data from '../../../core/sync/create_manifest_data/index.js';
 
 /**
  * Ensures that client-side code can't accidentally import server-side code,
  * whether in `*.server.js` files, `$app/server`, any `/server/` directory, or `$app/env/private`
  * @param {ValidatedConfig} kit
  * @param {() => { vite: typeof import('vite'); root: string; normalized_aliases: Array<{ alias: string, path: string }>; service_worker_entry_file: string | null; }} get_config
+ * @param {() => ManifestData} get_manifest_data
  * @returns {Plugin}
  */
-export function plugin_guard(kit, get_config) {
+export function plugin_guard(kit, get_config, get_manifest_data) {
 	/** @type {string} */
 	let root;
 
@@ -36,9 +36,6 @@ export function plugin_guard(kit, get_config) {
 	let normalized_routes;
 	/** @type {string} */
 	let normalized_assets;
-
-	/** @type {ManifestData} */
-	let manifest_data;
 
 	/** @type {string | null} */
 	let service_worker_entry_file;
@@ -127,8 +124,7 @@ export function plugin_guard(kit, get_config) {
 
 				if (!is_server_only) return;
 
-				// in dev, this doesn't exist, so we need to create it
-				manifest_data ??= create_manifest_data(kit, root);
+				const manifest_data = get_manifest_data();
 
 				/** @type {Set<string>} */
 				const entrypoints = new Set();


### PR DESCRIPTION
#16863 gave the guard plugin its own `manifest_data`, created on the first server-only import and never updated. Before, it read the one in `index.js`, which the dev server reassigns on route changes (`index.js:1090`), so a route added mid-session could now import server code without an error. In build it also repeated the `create_manifest_data` walk `index.js:507` already did.

This passes a thunk over the shared variable instead, with the lazy create moved alongside it.
