### PR TITLE
feat: output workers to client assets

### DIFF
--- a/.changeset/wise-pandas-cheat.md
+++ b/.changeset/wise-pandas-cheat.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: copy worker files emitted by the server build to the client output directory

--- a/packages/kit/src/exports/vite/build/index.js
+++ b/packages/kit/src/exports/vite/build/index.js
@@ -521,17 +521,15 @@ export function plugin_compile(
 				/** @type {Array<{ path: string }> | null} */
 				let immutable = null;
 
-				const server_assets = `${out}/server/${assets_path}`;
-				const client_assets = `${out}/client/${assets_path}`;
-				const workers_path = `${kit.appDir}/immutable/workers`;
+				const server_immutable = `${out}/server/${kit.appDir}/immutable`;
+				const client_immutable = `${out}/client/${kit.appDir}/immutable`;
 
 				const skip_client_build = manifest_data.nodes.every(
 					(node) => node.page_options?.csr === false
 				);
 
 				if (skip_client_build) {
-					copy(server_assets, client_assets);
-					copy(`${out}/server/${workers_path}`, `${out}/client/${workers_path}`);
+					copy(server_immutable, client_immutable);
 					copy(kit.files.assets, `${out}/client`);
 				} else {
 					// ...and build the client
@@ -575,22 +573,9 @@ export function plugin_compile(
 							.flat()
 					);
 
-					if (fs.existsSync(server_assets)) {
-						for (const file of fs.readdirSync(server_assets)) {
-							const src = `${server_assets}/${file}`;
-							const dest = `${client_assets}/${file}`;
-
-							if (fs.existsSync(dest) || ssr_stylesheets.has(`${assets_path}/${file}`)) {
-								continue;
-							}
-
-							copy(src, dest);
-						}
-					}
-
-					// worker files emitted by the server build (e.g. `?worker&url` imports
-					// in server-only modules) must be served to the client, too
-					copy(`${out}/server/${workers_path}`, `${out}/client/${workers_path}`);
+					copy(server_immutable, client_immutable, {
+						filter: (file) => !ssr_stylesheets.has(`${assets_path}/${file}`)
+					});
 
 					vite_client_manifest = /** @type {Manifest} */ (
 						JSON.parse(read(`${out}/client/.vite/manifest.json`))

--- a/packages/kit/src/exports/vite/build/index.js
+++ b/packages/kit/src/exports/vite/build/index.js
@@ -523,6 +523,7 @@ export function plugin_compile(
 
 				const server_assets = `${out}/server/${assets_path}`;
 				const client_assets = `${out}/client/${assets_path}`;
+				const workers_path = `${kit.appDir}/immutable/workers`;
 
 				const skip_client_build = manifest_data.nodes.every(
 					(node) => node.page_options?.csr === false
@@ -530,6 +531,7 @@ export function plugin_compile(
 
 				if (skip_client_build) {
 					copy(server_assets, client_assets);
+					copy(`${out}/server/${workers_path}`, `${out}/client/${workers_path}`);
 					copy(kit.files.assets, `${out}/client`);
 				} else {
 					// ...and build the client
@@ -585,6 +587,10 @@ export function plugin_compile(
 							copy(src, dest);
 						}
 					}
+
+					// worker files emitted by the server build (e.g. `?worker&url` imports
+					// in server-only modules) must be served to the client, too
+					copy(`${out}/server/${workers_path}`, `${out}/client/${workers_path}`);
 
 					vite_client_manifest = /** @type {Manifest} */ (
 						JSON.parse(read(`${out}/client/.vite/manifest.json`))

--- a/packages/kit/test/apps/basics/src/routes/worker-import/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/worker-import/+page.server.js
@@ -1,0 +1,5 @@
+import worker_url from './worker.js?worker&url';
+
+export function load() {
+	return { worker_url };
+}

--- a/packages/kit/test/apps/basics/src/routes/worker-import/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/worker-import/+page.svelte
@@ -1,0 +1,6 @@
+<script>
+	/** @type {import('./$types').PageData} */
+	export let data;
+</script>
+
+<a href={data.worker_url}>worker</a>

--- a/packages/kit/test/apps/basics/src/routes/worker-import/worker.js
+++ b/packages/kit/test/apps/basics/src/routes/worker-import/worker.js
@@ -1,0 +1,1 @@
+postMessage('hello from worker');

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -1163,6 +1163,15 @@ test.describe('$app/env', () => {
 	});
 });
 
+test.describe('web workers', () => {
+	test('worker files emitted by the server build are copied to the client output', () => {
+		test.skip(!!process.env.DEV, 'skip when in dev mode');
+
+		const workers = path.join(root, '.svelte-kit/output/client/_app/immutable/workers');
+		expect(fs.readdirSync(workers).some((file) => file.startsWith('worker-'))).toBe(true);
+	});
+});
+
 test.describe('tracing', () => {
 	// Helper function to find the resolve.root span deep in the handle.child chain
 	/**

--- a/packages/kit/test/apps/no-csr/src/routes/assets/+page.svelte
+++ b/packages/kit/test/apps/no-csr/src/routes/assets/+page.svelte
@@ -1,8 +1,12 @@
 <script>
 	import image from './favicon.png?no-inline';
+	import worker_url from './worker.js?worker&url';
 </script>
 
 <img src={image} alt="svelte logo" />
 
 <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
 <a href="/asset.json">includes public assets</a>
+
+<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+<a data-testid="worker" href={worker_url}>includes worker files</a>

--- a/packages/kit/test/apps/no-csr/src/routes/assets/worker.js
+++ b/packages/kit/test/apps/no-csr/src/routes/assets/worker.js
@@ -1,0 +1,1 @@
+postMessage('hello from worker');

--- a/packages/kit/test/apps/no-csr/test/test.js
+++ b/packages/kit/test/apps/no-csr/test/test.js
@@ -22,4 +22,10 @@ test('skips client build if every node has CSR disabled', async ({ page, request
 
 	const public_asset_response = await request.get('/asset.json');
 	expect(public_asset_response.status()).toBe(200);
+
+	const worker_url = await page.getByTestId('worker').getAttribute('href');
+	if (!worker_url) throw new Error('Worker href not found on /assets page');
+
+	const worker_response = await request.get(worker_url);
+	expect(worker_response.status()).toBe(200);
 });


### PR DESCRIPTION
Worker chunks from `?worker` and `?worker&url` imports are emitted to `{appDir}/immutable/workers/`. In two cases, only the SSR build emits them: when every page has `csr: false` (the client build is skipped entirely), and when the import lives in a server-only module such as `+page.server.js`. The files then exist only in `output/server/`, which adapters never publish, so the worker URL returns a 404 in production.

The build already handles this problem for `immutable/assets/` by copying server-emitted files into `output/client/`. This PR applies the same copy to `immutable/workers/` in both build branches. Filenames are content-hashed, so copying over an identical file is harmless, and apps without workers are unaffected.

Tests: the `basics` app covers the server-only import case by checking that the worker file lands in the client output. The `amp` app covers the skipped client build case by fetching the worker URL and expecting a 200. Both tests fail without the fix.

Related: #12438. That issue also stems from worker files being overlooked, but it concerns the `$service-worker` `build` list and is not resolved here.
  
---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
