### PR TITLE
chore: read options from one module instead of threading it through the server runtime

### DIFF
--- a/.changeset/soft-jars-repeat.md
+++ b/.changeset/soft-jars-repeat.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+chore: read `options` from a single module instead of passing it through the server runtime

--- a/packages/kit/src/core/sync/write_server.js
+++ b/packages/kit/src/core/sync/write_server.js
@@ -38,7 +38,6 @@ export const options = {
 	csrf_trusted_origins: ${s(config.csrf.trustedOrigins)},
 	embedded: ${config.embedded},
 	hash_routing: ${s(config.router.type === 'hash')},
-	hooks: null, // added lazily, via \`get_hooks\`
 	link_header_preload: ${s(config.output.linkHeaderPreload)},
 	paths_origin: ${s(config.paths.origin)},
 	service_worker: ${has_service_worker},

--- a/packages/kit/src/runtime/app/server/remote/prerender.spec.js
+++ b/packages/kit/src/runtime/app/server/remote/prerender.spec.js
@@ -20,6 +20,7 @@ vi.mock(import('@sveltejs/kit/internal/server'), async (actualPromise) => {
 vi.stubGlobal('__SVELTEKIT_DEV__', false);
 
 const { handle_error_and_jsonify } = await import('../../../server/errors.js');
+const { set_hooks } = await import('../../../server/internal.js');
 
 /**
  * Creates a prerender function whose self-fetch of the prerendered response
@@ -69,10 +70,11 @@ test('propagates an error response instead of running the function', async () =>
 	expect(fn).not.toHaveBeenCalled();
 
 	const handleError = vi.fn();
+	set_hooks(/** @type {any} */ ({ handleError }));
+
 	const transformed = await handle_error_and_jsonify(
 		store.current.event,
 		store.current.state,
-		/** @type {any} */ ({ hooks: { handleError } }),
 		rejection
 	);
 
@@ -84,11 +86,11 @@ test('passes validation errors to handleError without exposing issues by default
 	setup(() => new Response());
 	const issues = [{ message: 'Expected a string' }];
 	const handleError = vi.fn();
+	set_hooks(/** @type {any} */ ({ handleError }));
 
 	const transformed = await handle_error_and_jsonify(
 		store.current.event,
 		store.current.state,
-		/** @type {any} */ ({ hooks: { handleError } }),
 		new ValidationError(issues)
 	);
 

--- a/packages/kit/src/runtime/app/server/remote/query.js
+++ b/packages/kit/src/runtime/app/server/remote/query.js
@@ -330,7 +330,7 @@ function batch(validate_or_fn, maybe_fn) {
 		id: '',
 		name: '',
 		validate,
-		run: async (args, options) => {
+		run: async (args) => {
 			const { event, state } = get_request_store();
 
 			return run_remote_function(
@@ -347,7 +347,7 @@ function batch(validate_or_fn, maybe_fn) {
 								const data = get_result(arg, i);
 								return { type: 'result', data };
 							} catch (error) {
-								const transformed = await handle_error_and_jsonify(event, state, options, error);
+								const transformed = await handle_error_and_jsonify(event, state, error);
 
 								return {
 									type: 'error',

--- a/packages/kit/src/runtime/server/data/index.js
+++ b/packages/kit/src/runtime/server/data/index.js
@@ -13,7 +13,6 @@ import { with_version_header } from '../utils.js';
  * @param {import('@sveltejs/kit').RequestEvent} event
  * @param {import('types').RequestState} state
  * @param {{ page: Pick<import('types').PageNodeIndexes, 'layouts' | 'leaf'> | null }} route
- * @param {import('types').SSROptions} options
  * @param {import('@sveltejs/kit').SSRManifest} manifest
  * @param {boolean[] | undefined} invalidated_data_nodes
  * @param {import('types').TrailingSlash} trailing_slash
@@ -23,7 +22,6 @@ export async function render_data(
 	event,
 	state,
 	route,
-	options,
 	manifest,
 	invalidated_data_nodes,
 	trailing_slash
@@ -92,7 +90,7 @@ export async function render_data(
 			return fn();
 		});
 
-		const data_serializer = server_data_serializer_json(event, state, options);
+		const data_serializer = server_data_serializer_json(event, state);
 		await Promise.all(
 			promises.map(async (p, i) => {
 				const node = await p.catch(async (error) => {
@@ -100,7 +98,7 @@ export async function render_data(
 						throw error;
 					}
 
-					const transformed = await handle_error_and_jsonify(event, state, options, error);
+					const transformed = await handle_error_and_jsonify(event, state, error);
 
 					return /** @type {import('types').ServerErrorNode} */ ({
 						type: 'error',
@@ -135,7 +133,7 @@ export async function render_data(
 		if (error instanceof Redirect) {
 			return redirect_json_response(error);
 		} else {
-			const transformed = await handle_error_and_jsonify(event, state, options, error);
+			const transformed = await handle_error_and_jsonify(event, state, error);
 			return json_response(transformed, transformed.status);
 		}
 	}

--- a/packages/kit/src/runtime/server/errors.js
+++ b/packages/kit/src/runtime/server/errors.js
@@ -8,17 +8,16 @@ import {
 import { with_request_store } from '@sveltejs/kit/internal/server';
 import { add_deprecated_handle_error_properties, coalesce_to_error } from '../../utils/error.js';
 import { negotiate } from '../../utils/http.js';
-import { fix_stack_trace } from './internal.js';
+import { fix_stack_trace, hooks, options } from './internal.js';
 import { escape_html } from '../../utils/escape.js';
 
 /**
  * @param {import('@sveltejs/kit').RequestEvent} event
  * @param {import('types').RequestState} state
- * @param {import('types').SSROptions} options
  * @param {unknown} error
  */
-export async function handle_fatal_error(event, state, options, error) {
-	const body = await handle_error_and_jsonify(event, state, options, error);
+export async function handle_fatal_error(event, state, error) {
+	const body = await handle_error_and_jsonify(event, state, error);
 	const status = body.status;
 
 	// sec-fetch-dest would be nicer, but non-browser clients and plain HTTP hosts don't send it
@@ -33,17 +32,16 @@ export async function handle_fatal_error(event, state, options, error) {
 		});
 	}
 
-	return static_error_page(options, status, body.message);
+	return static_error_page(status, body.message);
 }
 
 /**
  * @param {import('@sveltejs/kit').RequestEvent} event
  * @param {import('types').RequestState} state
- * @param {import('types').SSROptions} options
  * @param {any} error
  * @returns {App.Error | Promise<App.Error>}
  */
-export function handle_error_and_jsonify(event, state, options, error) {
+export function handle_error_and_jsonify(event, state, error) {
 	if (error instanceof HandledHttpError) {
 		return error.body;
 	}
@@ -90,7 +88,7 @@ export function handle_error_and_jsonify(event, state, options, error) {
 		const input = { ...caught, event };
 		if (__SVELTEKIT_DEV__) add_deprecated_handle_error_properties(input, fallback);
 
-		result = with_request_store({ event, state }, () => options.hooks.handleError(input));
+		result = with_request_store({ event, state }, () => hooks.handleError(input));
 	} catch (hook_error) {
 		log_handle_error_hook_failure(error, hook_error);
 		return { status: fallback.status, message: 'Internal Error' };
@@ -141,11 +139,10 @@ function log_handle_error_hook_failure(error, hook_error) {
 /**
  * Return as a response that renders the error.html
  *
- * @param {import('types').SSROptions} options
  * @param {number} status
  * @param {string} message
  */
-export function static_error_page(options, status, message) {
+export function static_error_page(status, message) {
 	let page = options.templates.error({ status, message: escape_html(message) });
 
 	if (__SVELTEKIT_DEV__) {

--- a/packages/kit/src/runtime/server/fetch.js
+++ b/packages/kit/src/runtime/server/fetch.js
@@ -2,14 +2,13 @@ import { parseSetCookie } from 'cookie';
 import { noop } from '../../utils/functions.js';
 import { respond } from './respond.js';
 import * as paths from '#app/paths';
-import { read_implementation } from './internal.js';
+import { hooks, read_implementation } from './internal.js';
 import { has_prerendered_path } from './utils.js';
 import { fork_state_for_subrequest } from './state.js';
 
 /**
  * @param {{
  *   event: import('@sveltejs/kit').RequestEvent;
- *   options: import('types').SSROptions;
  *   manifest: import('@sveltejs/kit').SSRManifest;
  *   state: import('types').RequestState;
  *   get_cookie_header: (url: URL, header: string | null) => string;
@@ -17,7 +16,7 @@ import { fork_state_for_subrequest } from './state.js';
  * }} opts
  * @returns {typeof fetch}
  */
-export function create_fetch({ event, options, manifest, state, get_cookie_header, set_internal }) {
+export function create_fetch({ event, manifest, state, get_cookie_header, set_internal }) {
 	/**
 	 * @type {typeof fetch}
 	 */
@@ -30,7 +29,7 @@ export function create_fetch({ event, options, manifest, state, get_cookie_heade
 		let credentials =
 			(info instanceof Request ? info.credentials : init?.credentials) ?? 'same-origin';
 
-		return options.hooks.handleFetch({
+		return hooks.handleFetch({
 			event,
 			request: original_request,
 			fetch: async (info, init) => {
@@ -148,18 +147,19 @@ export function create_fetch({ event, options, manifest, state, get_cookie_heade
 					request.headers.set('accept-language', accept_language);
 				}
 
-				const response = await internal_fetch(request, options, manifest, state);
+				const response = await internal_fetch(request, manifest, state);
 
 				for (const str of response.headers.getSetCookie()) {
-					const { name, value, ...options } = parseSetCookie(str, { decode: (v) => v });
+					const { name, value, ...cookie_options } = parseSetCookie(str, { decode: (v) => v });
 
-					const path = options.path ?? (url.pathname.split('/').slice(0, -1).join('/') || '/');
+					const path =
+						cookie_options.path ?? (url.pathname.split('/').slice(0, -1).join('/') || '/');
 
-					// options.sameSite is string, something more specific is required - type cast is safe
+					// sameSite is string, something more specific is required - type cast is safe
 					set_internal(name, /** @type {string} */ (value), {
 						path,
 						encode: (value) => value,
-						.../** @type {import('cookie').SerializeOptions} */ (options)
+						.../** @type {import('cookie').SerializeOptions} */ (cookie_options)
 					});
 				}
 
@@ -193,12 +193,11 @@ function normalize_fetch_input(info, init, url) {
 
 /**
  * @param {Request} request
- * @param {import('types').SSROptions} options
  * @param {import('@sveltejs/kit').SSRManifest} manifest
  * @param {import('types').RequestState} state
  * @returns {Promise<Response>}
  */
-async function internal_fetch(request, options, manifest, state) {
+async function internal_fetch(request, manifest, state) {
 	if (request.signal?.aborted) {
 		throw new DOMException('The operation was aborted.', 'AbortError');
 	}
@@ -206,7 +205,7 @@ async function internal_fetch(request, options, manifest, state) {
 	const subrequest_state = fork_state_for_subrequest(state);
 
 	if (!request.signal) {
-		return await respond(request, options, manifest, subrequest_state);
+		return await respond(request, manifest, subrequest_state);
 	}
 
 	let remove_abort_listener = noop;
@@ -219,8 +218,7 @@ async function internal_fetch(request, options, manifest, state) {
 		remove_abort_listener = () => request.signal.removeEventListener('abort', on_abort);
 	});
 
-	return Promise.race([
-		respond(request, options, manifest, subrequest_state),
-		abort_promise
-	]).finally(remove_abort_listener);
+	return Promise.race([respond(request, manifest, subrequest_state), abort_promise]).finally(
+		remove_abort_listener
+	);
 }

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -4,11 +4,20 @@ import { IN_WEBCONTAINER, REROUTED_URL_HEADER } from '../../constants.js';
 import { respond } from './respond.js';
 import { create_request_state } from './state.js';
 import { options, get_hooks } from '<sveltekit:generated>/server.js';
-import { set_read_implementation, set_manifest, fix_stack_trace } from './internal.js';
+import {
+	set_read_implementation,
+	set_manifest,
+	set_options,
+	set_hooks,
+	fix_stack_trace
+} from './internal.js';
 import { set_env } from '<sveltekit:generated>/env/config.js';
 import { init_tracing } from '@sveltejs/kit/internal/server';
 import { DEV } from 'esm-env';
 import { init_transport } from '#app/internal/transport';
+
+// set at module scope because prerendering evaluates user modules before constructing a `Server`
+set_options(options);
 
 /** @type {Promise<any>} */
 let init_promise;
@@ -49,16 +58,11 @@ if (DEV) {
 }
 
 export class Server {
-	/** @type {import('types').SSROptions} */
-	#options;
-
 	/** @type {import('@sveltejs/kit').SSRManifest} */
 	#manifest;
 
 	/** @param {import('@sveltejs/kit').SSRManifest} manifest */
 	constructor(manifest) {
-		/** @type {import('types').SSROptions} */
-		this.#options = options;
 		this.#manifest = manifest;
 
 		// Since AsyncLocalStorage is not working in webcontainers, we don't reset `sync_store`
@@ -123,7 +127,7 @@ export class Server {
 			try {
 				const module = await get_hooks();
 
-				this.#options.hooks = {
+				set_hooks({
 					handle: module.handle || (({ event, resolve }) => resolve(event)),
 					handleError:
 						module.handleError ||
@@ -152,7 +156,7 @@ export class Server {
 						}),
 					handleFetch: module.handleFetch || (({ request, fetch }) => fetch(request)),
 					reroute: module.reroute || noop
-				};
+				});
 
 				init_transport(module.transport ?? {});
 
@@ -161,14 +165,14 @@ export class Server {
 				}
 			} catch (e) {
 				if (__SVELTEKIT_DEV__) {
-					this.#options.hooks = {
+					set_hooks({
 						handle: () => {
 							throw e;
 						},
 						handleError: ({ error }) => console.error(error),
 						handleFetch: ({ request, fetch }) => fetch(request),
 						reroute: noop
-					};
+					});
 				} else {
 					throw e;
 				}
@@ -183,7 +187,7 @@ export class Server {
 	async respond(request, options) {
 		const request_state = create_request_state(options);
 
-		const response = await respond(request, this.#options, this.#manifest, request_state);
+		const response = await respond(request, this.#manifest, request_state);
 
 		if (DEV) {
 			const error = decoded_responses.get(response);

--- a/packages/kit/src/runtime/server/internal.js
+++ b/packages/kit/src/runtime/server/internal.js
@@ -1,4 +1,5 @@
 /** @import { SSRManifest } from '@sveltejs/kit'; */
+/** @import { ServerHooks, SSROptions } from 'types'; */
 import { restore, save } from './dev.js';
 import {
 	has_data_suffix,
@@ -16,6 +17,8 @@ const styleText =
 
 const read_implementation_key = Symbol.for('sveltekit.read_implementation');
 const manifest_key = Symbol.for('sveltekit.manifest');
+const options_key = Symbol.for('sveltekit.options');
+const hooks_key = Symbol.for('sveltekit.hooks');
 
 export let read_implementation = /** @type {((path: string) => ReadableStream<any>) | null} */ (
 	(__SVELTEKIT_DEV__ && restore(read_implementation_key)) ?? null
@@ -24,6 +27,12 @@ export let read_implementation = /** @type {((path: string) => ReadableStream<an
 export let manifest = /** @type {SSRManifest} */ (
 	(__SVELTEKIT_DEV__ && restore(manifest_key)) ?? null
 );
+
+export let options = /** @type {SSROptions} */ (
+	(__SVELTEKIT_DEV__ && restore(options_key)) ?? null
+);
+
+export let hooks = /** @type {ServerHooks} */ ((__SVELTEKIT_DEV__ && restore(hooks_key)) ?? null);
 
 /**
  * @param {(path: string) => ReadableStream<any>} fn
@@ -40,6 +49,22 @@ export function set_read_implementation(fn) {
 export function set_manifest(value) {
 	manifest = value;
 	if (__SVELTEKIT_DEV__) save(manifest_key, value);
+}
+
+/**
+ * @param {SSROptions} value
+ */
+export function set_options(value) {
+	options = value;
+	if (__SVELTEKIT_DEV__) save(options_key, value);
+}
+
+/**
+ * @param {ServerHooks} value
+ */
+export function set_hooks(value) {
+	hooks = value;
+	if (__SVELTEKIT_DEV__) save(hooks_key, value);
 }
 
 /**

--- a/packages/kit/src/runtime/server/page/actions.js
+++ b/packages/kit/src/runtime/server/page/actions.js
@@ -1,6 +1,6 @@
 /** @import { RequestEvent, Actions } from '@sveltejs/kit' */
 /** @import { ActionResult } from '$app/forms' */
-/** @import { SSROptions, SSRNode, ServerNode, ServerActionResult } from 'types' */
+/** @import { SSRNode, ServerNode, ServerActionResult } from 'types' */
 import { DEV } from 'esm-env';
 import { HttpError, Redirect, ActionFailure, SvelteKitError } from '@sveltejs/kit/internal';
 import { with_request_store, merge_tracing, record_span } from '@sveltejs/kit/internal/server';
@@ -23,28 +23,26 @@ export function is_action_json_request(event) {
 /**
  * @param {RequestEvent} event
  * @param {import('types').RequestState} state
- * @param {SSROptions} options
  * @param {SSRNode['server'] | undefined} server
  */
-export async function handle_action_json_request(event, state, options, server) {
+export async function handle_action_json_request(event, state, server) {
 	const result = await handle_action_request(event, state, server);
-	return action_result_json(event, state, options, result);
+	return action_result_json(event, state, result);
 }
 
 /**
  * @param {RequestEvent} event
  * @param {import('types').RequestState} state
- * @param {SSROptions} options
  * @param {ServerActionResult} result
  * @returns {Promise<Response>}
  */
-async function action_result_json(event, state, options, result) {
+async function action_result_json(event, state, result) {
 	if (result.type === 'redirect') {
 		return action_json(result);
 	}
 
 	if (result.type === 'error') {
-		const error = await handle_error_and_jsonify(event, state, options, result.error);
+		const error = await handle_error_and_jsonify(event, state, result.error);
 		return action_json({ ...result, error }, { status: error.status });
 	}
 
@@ -64,7 +62,7 @@ async function action_result_json(event, state, options, result) {
 			{ status: result.status }
 		);
 	} catch (e) {
-		return action_result_json(event, state, options, action_error_result(e, result.location));
+		return action_result_json(event, state, action_error_result(e, result.location));
 	}
 }
 

--- a/packages/kit/src/runtime/server/page/data_serializer.js
+++ b/packages/kit/src/runtime/server/page/data_serializer.js
@@ -10,15 +10,14 @@ import { encoders } from '#app/internal/transport';
  * async iterable containing their resolutions
  * @param {import('@sveltejs/kit').RequestEvent} event
  * @param {import('types').RequestState} state
- * @param {import('types').SSROptions} options
  * @returns {import('./types.js').ServerDataSerializer}
  */
-export function server_data_serializer(event, state, options) {
+export function server_data_serializer(event, state) {
 	let promise_id = 1;
 	let max_nodes = -1;
 
 	const iterator = create_async_iterator();
-	const global = get_global_name(options);
+	const global = get_global_name();
 
 	/** @param {number} index */
 	function get_replacer(index) {
@@ -31,7 +30,7 @@ export function server_data_serializer(event, state, options) {
 					.then(/** @param {any} data */ (data) => ({ data }))
 					.catch(
 						/** @param {any} error */ async (error) => ({
-							error: await handle_error_and_jsonify(event, state, options, error)
+							error: await handle_error_and_jsonify(event, state, error)
 						})
 					)
 					.then(
@@ -46,7 +45,6 @@ export function server_data_serializer(event, state, options) {
 								error = await handle_error_and_jsonify(
 									event,
 									state,
-									options,
 									new Error(`Failed to serialize promise while rendering ${event.route.id}`, {
 										cause: e
 									})
@@ -127,10 +125,9 @@ export function server_data_serializer(event, state, options) {
  * async iterable containing their resolutions
  * @param {import('@sveltejs/kit').RequestEvent} event
  * @param {import('types').RequestState} state
- * @param {import('types').SSROptions} options
  * @returns {import('./types.js').ServerDataSerializerJson}
  */
-export function server_data_serializer_json(event, state, options) {
+export function server_data_serializer_json(event, state) {
 	let promise_id = 1;
 
 	const iterator = create_async_iterator();
@@ -152,7 +149,7 @@ export function server_data_serializer_json(event, state, options) {
 				.catch(
 					/** @param {any} e */ async (e) => {
 						key = 'error';
-						return handle_error_and_jsonify(event, state, options, /** @type {any} */ (e));
+						return handle_error_and_jsonify(event, state, /** @type {any} */ (e));
 					}
 				)
 				.then(
@@ -165,7 +162,6 @@ export function server_data_serializer_json(event, state, options) {
 							const error = await handle_error_and_jsonify(
 								event,
 								state,
-								options,
 								new Error(`Failed to serialize promise while rendering ${event.route.id}`, {
 									cause: e
 								})

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -1,5 +1,5 @@
 /** @import { RequestEvent, SSRManifest } from '@sveltejs/kit' */
-/** @import { PageNodeIndexes, RequestState, RequiredResolveOptions, ServerDataNode, SSRNode, SSROptions } from 'types' */
+/** @import { PageNodeIndexes, RequestState, RequiredResolveOptions, ServerDataNode, SSRNode } from 'types' */
 import { text } from '@sveltejs/kit';
 import { Redirect } from '@sveltejs/kit/internal';
 import { compact } from '../../../utils/array.js';
@@ -32,13 +32,12 @@ const MAX_DEPTH = 10;
  * @param {RequestEvent} event
  * @param {RequestState} state
  * @param {PageNodeIndexes} page
- * @param {SSROptions} options
  * @param {SSRManifest} manifest
  * @param {import('../../../utils/page_nodes.js').PageNodes} nodes
  * @param {RequiredResolveOptions} resolve_opts
  * @returns {Promise<Response>}
  */
-export async function render_page(event, state, page, options, manifest, nodes, resolve_opts) {
+export async function render_page(event, state, page, manifest, nodes, resolve_opts) {
 	if (state.depth > MAX_DEPTH) {
 		// infinite request cycle detected
 		return text(`Not found: ${event.url.pathname}`, {
@@ -48,7 +47,7 @@ export async function render_page(event, state, page, options, manifest, nodes, 
 
 	if (is_action_json_request(event)) {
 		const node = await manifest._.nodes[page.leaf]();
-		return handle_action_json_request(event, state, options, node?.server);
+		return handle_action_json_request(event, state, node?.server);
 	}
 
 	try {
@@ -150,10 +149,9 @@ export async function render_page(event, state, page, options, manifest, nodes, 
 				error: null,
 				event,
 				state,
-				options,
 				manifest,
 				resolve_opts,
-				data_serializer: server_data_serializer(event, state, options)
+				data_serializer: server_data_serializer(event, state)
 			});
 		}
 
@@ -163,10 +161,10 @@ export async function render_page(event, state, page, options, manifest, nodes, 
 		/** @type {Error | null} */
 		let load_error = null;
 
-		const data_serializer = server_data_serializer(event, state, options);
+		const data_serializer = server_data_serializer(event, state);
 		const data_serializer_json =
 			(state.prerendering || state.prerender_default === true) && should_prerender_data
-				? server_data_serializer_json(event, state, options)
+				? server_data_serializer_json(event, state)
 				: null;
 
 		/** @type {Array<Promise<ServerDataNode | null>>} */
@@ -274,7 +272,7 @@ export async function render_page(event, state, page, options, manifest, nodes, 
 						return redirect_response(err.status, err.location);
 					}
 
-					const error = await handle_error_and_jsonify(event, state, options, err);
+					const error = await handle_error_and_jsonify(event, state, err);
 					const status = error.status;
 
 					for (const { error: index, idx } of nearest_error_pages(i, branch, page.errors)) {
@@ -293,7 +291,6 @@ export async function render_page(event, state, page, options, manifest, nodes, 
 						return await render_response({
 							event,
 							state,
-							options,
 							manifest,
 							resolve_opts,
 							page_config: {
@@ -311,7 +308,7 @@ export async function render_page(event, state, page, options, manifest, nodes, 
 
 					// if we're still here, it means the error happened in the root layout,
 					// which means we have to fall back to error.html
-					return static_error_page(options, status, error.message);
+					return static_error_page(status, error.message);
 				}
 			} else {
 				// push an empty slot so we can rewind past gaps to the
@@ -339,7 +336,6 @@ export async function render_page(event, state, page, options, manifest, nodes, 
 		return await render_response({
 			event,
 			state,
-			options,
 			manifest,
 			resolve_opts,
 			page_config: {
@@ -351,7 +347,7 @@ export async function render_page(event, state, page, options, manifest, nodes, 
 			branch: compact(branch),
 			action_result,
 			fetched,
-			data_serializer: !ssr ? server_data_serializer(event, state, options) : data_serializer,
+			data_serializer: !ssr ? server_data_serializer(event, state) : data_serializer,
 			error_components: await load_error_components(ssr, branch, page, manifest)
 		});
 	} catch (e) {
@@ -365,7 +361,6 @@ export async function render_page(event, state, page, options, manifest, nodes, 
 		return await respond_with_error({
 			event,
 			state,
-			options,
 			manifest,
 			error: e,
 			resolve_opts

--- a/packages/kit/src/runtime/server/page/load_data.spec.js
+++ b/packages/kit/src/runtime/server/page/load_data.spec.js
@@ -1,5 +1,8 @@
-import { assert, expect, test } from 'vitest';
-import { create_universal_fetch } from './load_data.js';
+import { assert, expect, test, vi } from 'vitest';
+
+vi.stubGlobal('__SVELTEKIT_DEV__', undefined);
+
+const { create_universal_fetch } = await import('./load_data.js');
 
 /**
  * @param {Partial<Pick<import('@sveltejs/kit').RequestEvent, 'fetch' | 'url' | 'request' | 'route'>>} event

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -27,6 +27,7 @@ import Root from '../../components/root.svelte';
 import { render } from 'svelte/server';
 import { Props, RenderNode } from '../../props.svelte.js';
 import { has_custom_transporters, uneval } from '#app/internal/transport';
+import { options } from '../internal.js';
 
 // TODO rename this function/module
 
@@ -35,7 +36,6 @@ import { has_custom_transporters, uneval } from '#app/internal/transport';
  * @param {{
  *   branch: Array<import('./types.js').Loaded>;
  *   fetched: Array<import('./types.js').Fetched>;
- *   options: import('types').SSROptions;
  *   manifest: import('@sveltejs/kit').SSRManifest;
  *   page_config: { ssr: boolean; csr: boolean };
  *   status: number;
@@ -51,7 +51,6 @@ import { has_custom_transporters, uneval } from '#app/internal/transport';
 export async function render_response({
 	branch,
 	fetched,
-	options,
 	manifest,
 	page_config,
 	status,
@@ -203,7 +202,7 @@ export async function render_response({
 							throw e;
 						}
 
-						const handled = handle_error_and_jsonify(event, render_state, options, e);
+						const handled = handle_error_and_jsonify(event, render_state, e);
 
 						// TODO 4.0 make this an async function and await `handled`
 						if (handled instanceof Promise) {
@@ -347,7 +346,7 @@ export async function render_response({
 		}
 	}
 
-	const global = get_global_name(options);
+	const global = get_global_name();
 	const { data, chunks } = data_serializer.get_data(csp);
 
 	if (page_config.ssr && page_config.csr) {
@@ -517,7 +516,7 @@ export async function render_response({
 			args.push(`{\n${indent}\t${hydrate.join(`,\n${indent}\t`)}\n${indent}}`);
 		}
 
-		const remote_data = await collect_remote_data({}, event, state, options);
+		const remote_data = await collect_remote_data({}, event, state);
 
 		const serialized_data =
 			Object.keys(remote_data).length > 0

--- a/packages/kit/src/runtime/server/page/respond_with_error.js
+++ b/packages/kit/src/runtime/server/page/respond_with_error.js
@@ -14,17 +14,16 @@ import { server_data_serializer } from './data_serializer.js';
  * @param {{
  *   event: import('@sveltejs/kit').RequestEvent;
  *   state: import('types').RequestState;
- *   options: import('types').SSROptions;
  *   manifest: import('@sveltejs/kit').SSRManifest;
  *   error: unknown;
  *   resolve_opts: import('types').RequiredResolveOptions;
  * }} opts
  */
-export async function respond_with_error({ event, state, options, manifest, error, resolve_opts }) {
+export async function respond_with_error({ event, state, manifest, error, resolve_opts }) {
 	// reroute to the fallback page to prevent an infinite chain of requests.
 	if (event.request.headers.get('x-sveltekit-error')) {
-		const transformed = await handle_error_and_jsonify(event, state, options, error);
-		return static_error_page(options, transformed.status, transformed.message);
+		const transformed = await handle_error_and_jsonify(event, state, error);
+		return static_error_page(transformed.status, transformed.message);
 	}
 
 	/** @type {import('./types.js').Fetched[]} */
@@ -35,9 +34,9 @@ export async function respond_with_error({ event, state, options, manifest, erro
 		const nodes = new PageNodes([default_layout]);
 		const ssr = nodes.ssr();
 		const csr = nodes.csr();
-		const data_serializer = server_data_serializer(event, state, options);
+		const data_serializer = server_data_serializer(event, state);
 		// Do this here first in case the awaits below before rendering themselves error
-		const transformed = await handle_error_and_jsonify(event, state, options, error);
+		const transformed = await handle_error_and_jsonify(event, state, error);
 
 		if (ssr) {
 			state.error = true;
@@ -80,7 +79,6 @@ export async function respond_with_error({ event, state, options, manifest, erro
 		}
 
 		return await render_response({
-			options,
 			manifest,
 			page_config: {
 				ssr,
@@ -103,8 +101,8 @@ export async function respond_with_error({ event, state, options, manifest, erro
 			return redirect_response(e.status, e.location);
 		}
 
-		const transformed = await handle_error_and_jsonify(event, state, options, e);
+		const transformed = await handle_error_and_jsonify(event, state, e);
 
-		return static_error_page(options, transformed.status, transformed.message);
+		return static_error_page(transformed.status, transformed.message);
 	}
 }

--- a/packages/kit/src/runtime/server/remote-functions.js
+++ b/packages/kit/src/runtime/server/remote-functions.js
@@ -1,6 +1,6 @@
 /** @import { RequestEvent, SSRManifest } from '@sveltejs/kit' */
 /** @import { RemoteForm } from '$app/server' */
-/** @import { RemoteFormInternals, RemoteFunctionData, RemoteFunctionResponse, RemoteInternals, RequestState, ServerActionResult, SSROptions } from 'types' */
+/** @import { RemoteFormInternals, RemoteFunctionData, RemoteFunctionResponse, RemoteInternals, RequestState, ServerActionResult } from 'types' */
 
 import { error } from '@sveltejs/kit';
 import { Redirect, SvelteKitError } from '@sveltejs/kit/internal';
@@ -26,7 +26,7 @@ import { with_version_header } from './utils.js';
 const KEEP_ALIVE_INTERVAL = 30_000;
 
 /** @type {typeof handle_remote_call_internal} */
-export async function handle_remote_call(event, state, options, manifest, id) {
+export async function handle_remote_call(event, state, manifest, id) {
 	return record_span({
 		name: 'sveltekit.remote.call',
 		attributes: {
@@ -35,7 +35,7 @@ export async function handle_remote_call(event, state, options, manifest, id) {
 		fn: async (current) => {
 			const traced_event = merge_tracing(event, current);
 			const response = await with_request_store({ event: traced_event, state }, () =>
-				handle_remote_call_internal(traced_event, state, options, manifest, id)
+				handle_remote_call_internal(traced_event, state, manifest, id)
 			);
 			return with_version_header(response);
 		}
@@ -45,11 +45,10 @@ export async function handle_remote_call(event, state, options, manifest, id) {
 /**
  * @param {RequestEvent} event
  * @param {RequestState} state
- * @param {SSROptions} options
  * @param {SSRManifest} manifest
  * @param {string} id
  */
-async function handle_remote_call_internal(event, state, options, manifest, id) {
+async function handle_remote_call_internal(event, state, manifest, id) {
 	const [hash, name, additional_args] = id.split('/');
 	const remotes = manifest._.remotes;
 
@@ -175,12 +174,7 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
 											location: error.location
 										});
 									} else {
-										const transformed = await handle_error_and_jsonify(
-											event,
-											state,
-											options,
-											error
-										);
+										const transformed = await handle_error_and_jsonify(event, state, error);
 
 										send(controller, {
 											type: 'error',
@@ -218,7 +212,7 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
 
 				const args = await Promise.all(payloads.map((payload) => parse_remote_arg(payload)));
 
-				data._ = await with_request_store({ event, state }, () => internals.run(args, options));
+				data._ = await with_request_store({ event, state }, () => internals.run(args));
 
 				break;
 			}
@@ -309,7 +303,7 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
 			}
 		}
 
-		await collect_remote_data(data, event, state, options);
+		await collect_remote_data(data, event, state);
 
 		return Response.json(
 			/** @type {RemoteFunctionResponse} */ ({
@@ -320,7 +314,7 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
 		);
 	} catch (error) {
 		if (error instanceof Redirect) {
-			const data = await collect_remote_data({ redirect: error.location }, event, state, options);
+			const data = await collect_remote_data({ redirect: error.location }, event, state);
 
 			return Response.json(
 				/** @type {RemoteFunctionResponse} */ ({
@@ -331,7 +325,7 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
 			);
 		}
 
-		const transformed = await handle_error_and_jsonify(event, state, options, error);
+		const transformed = await handle_error_and_jsonify(event, state, error);
 
 		return Response.json(
 			/** @type {RemoteFunctionResponse} */ ({
@@ -356,9 +350,8 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
  * @param {RemoteFunctionData} data
  * @param {RequestEvent} event
  * @param {RequestState} state
- * @param {SSROptions} options
  */
-export async function collect_remote_data(data, event, state, options) {
+export async function collect_remote_data(data, event, state) {
 	/**
 	 *
 	 * @param {unknown} error
@@ -366,7 +359,7 @@ export async function collect_remote_data(data, event, state, options) {
 	 */
 	function convert_error(error) {
 		// TODO 4.0 remove the `Promise.resolve(...)`
-		return Promise.resolve(handle_error_and_jsonify(event, state, options, error));
+		return Promise.resolve(handle_error_and_jsonify(event, state, error));
 	}
 
 	/** @type {Promise<any>[]} */

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -45,6 +45,7 @@ import {
 } from '../pathname.js';
 import { server_data_serializer } from './page/data_serializer.js';
 import { get_remote_id, handle_remote_call } from './remote-functions.js';
+import { hooks, options } from './internal.js';
 
 /** @type {import('types').RequiredResolveOptions['transformPageChunk']} */
 const default_transform = ({ html }) => html;
@@ -85,12 +86,11 @@ export const respond = propagate_context(internal_respond);
 
 /**
  * @param {Request} request
- * @param {import('types').SSROptions} options
  * @param {import('@sveltejs/kit').SSRManifest} manifest
  * @param {import('types').RequestState} state
  * @returns {Promise<Response>}
  */
-export async function internal_respond(request, options, manifest, state) {
+export async function internal_respond(request, manifest, state) {
 	/** URL but stripped from the potential `/__data.json` suffix and its search param  */
 	const url = new URL(request.url);
 
@@ -243,7 +243,6 @@ export async function internal_respond(request, options, manifest, state) {
 	// @ts-expect-error this has to be assigned lazily
 	event.fetch = create_fetch({
 		event,
-		options,
 		manifest,
 		state,
 		get_cookie_header,
@@ -263,7 +262,7 @@ export async function internal_respond(request, options, manifest, state) {
 
 			// reroute could alter the given URL, so we pass a copy
 			resolved_path =
-				(await options.hooks.reroute({ url: new URL(url), fetch: event.fetch })) ?? url.pathname;
+				(await hooks.reroute({ url: new URL(url), fetch: event.fetch })) ?? url.pathname;
 
 			if (!manifest._.routes.length && resolved_path !== url.pathname) {
 				state.rerouted_url = denormalise_url({
@@ -332,7 +331,7 @@ export async function internal_respond(request, options, manifest, state) {
 				statusText: response.statusText
 			});
 		} catch (error) {
-			return await handle_fatal_error(event, state, options, error);
+			return await handle_fatal_error(event, state, error);
 		}
 	}
 
@@ -378,7 +377,7 @@ export async function internal_respond(request, options, manifest, state) {
 				event.params = result.params;
 			}
 		} catch (e) {
-			return await handle_fatal_error(event, state, options, e);
+			return await handle_fatal_error(event, state, e);
 		}
 	}
 
@@ -461,10 +460,10 @@ export async function internal_respond(request, options, manifest, state) {
 				add_cookies_to_headers(response.headers, new_cookies.values());
 				return response;
 			} catch (err) {
-				return await handle_fatal_error(event, state, options, err);
+				return await handle_fatal_error(event, state, err);
 			}
 		}
-		return await handle_fatal_error(event, state, options, e);
+		return await handle_fatal_error(event, state, e);
 	}
 
 	async function handle() {
@@ -494,7 +493,7 @@ export async function internal_respond(request, options, manifest, state) {
 				};
 
 				return await with_request_store({ event: traced_event, state }, () =>
-					options.hooks.handle({
+					hooks.handle({
 						event: traced_event,
 						resolve: (event, opts) => {
 							return record_span({
@@ -601,7 +600,6 @@ export async function internal_respond(request, options, manifest, state) {
 				return await respond_with_error({
 					event,
 					state,
-					options,
 					manifest,
 					error: new SvelteKitError(
 						400,
@@ -616,7 +614,6 @@ export async function internal_respond(request, options, manifest, state) {
 				return await render_response({
 					event,
 					state,
-					options,
 					manifest,
 					page_config: { ssr: false, csr: true },
 					status: 200,
@@ -631,12 +628,12 @@ export async function internal_respond(request, options, manifest, state) {
 					],
 					fetched: [],
 					resolve_opts,
-					data_serializer: server_data_serializer(event, state, options)
+					data_serializer: server_data_serializer(event, state)
 				});
 			}
 
 			if (remote_id) {
-				return await handle_remote_call(event, state, options, manifest, remote_id);
+				return await handle_remote_call(event, state, manifest, remote_id);
 			}
 
 			if (route) {
@@ -650,7 +647,6 @@ export async function internal_respond(request, options, manifest, state) {
 						event,
 						state,
 						route,
-						options,
 						manifest,
 						invalidated_data_nodes,
 						trailing_slash
@@ -685,7 +681,6 @@ export async function internal_respond(request, options, manifest, state) {
 								event,
 								state,
 								route.page,
-								options,
 								manifest,
 								page_nodes,
 								resolve_opts
@@ -774,7 +769,6 @@ export async function internal_respond(request, options, manifest, state) {
 						event,
 						state,
 						{ page: { layouts: [], leaf: 0 } },
-						options,
 						manifest,
 						invalidated_data_nodes,
 						// there is no route to take a trailing slash option from, and the
@@ -793,7 +787,6 @@ export async function internal_respond(request, options, manifest, state) {
 				return await respond_with_error({
 					event,
 					state,
-					options,
 					manifest,
 					error: new SvelteKitError(404, 'Not Found', `Not found: ${event.url.pathname}`),
 					resolve_opts
@@ -815,7 +808,7 @@ export async function internal_respond(request, options, manifest, state) {
 			// and I don't even know how to describe it. need to investigate at some point
 
 			// HttpError from endpoint can end up here - TODO should it be handled there instead?
-			return await handle_fatal_error(event, state, options, e);
+			return await handle_fatal_error(event, state, e);
 		} finally {
 			event.cookies.set = () => {
 				throw new Error('Cannot use `cookies.set(...)` after the response has been generated');

--- a/packages/kit/src/runtime/server/utils.js
+++ b/packages/kit/src/runtime/server/utils.js
@@ -1,5 +1,6 @@
 import { text } from '@sveltejs/kit';
 import { ENDPOINT_METHODS } from '../../constants.js';
+import { options } from './internal.js';
 
 /**
  * @param {Partial<Record<import('types').HttpMethod, any>>} mod
@@ -30,9 +31,8 @@ export function allowed_methods(mod) {
 }
 
 /**
- * @param {import('types').SSROptions} options
  */
-export function get_global_name(options) {
+export function get_global_name() {
 	return __SVELTEKIT_DEV__ ? '__sveltekit_dev' : `__sveltekit_${options.version_hash}`;
 }
 

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -497,7 +497,6 @@ export interface SSROptions {
 	csrf_trusted_origins: string[];
 	embedded: boolean;
 	hash_routing: boolean;
-	hooks: ServerHooks;
 	link_header_preload: ValidatedConfig['output']['linkHeaderPreload'];
 	paths_origin: string | undefined;
 	service_worker: boolean;
@@ -606,7 +605,7 @@ export interface RemoteQueryLiveInternals extends BaseRemoteInternals {
 export interface RemoteQueryBatchInternals extends BaseRemoteInternals {
 	type: 'query_batch';
 	validate: (arg?: any) => MaybePromise<any>;
-	run: (args: any[], options: SSROptions) => Promise<any[]>;
+	run: (args: any[]) => Promise<any[]>;
 	/**
 	 * Creates a `RemoteQuery` bound directly to a specific client payload (the
 	 * stringified raw argument) and a pre-validated argument, skipping the query


### PR DESCRIPTION
`options` is already a single module-level object: `runtime/server/index.js` imports it from `<sveltekit:generated>/server.js` and `Server.init` writes `hooks` onto it, so every `Server` in a process shares it. It was also passed through 17 parameter positions, from `internal_respond` down to `static_error_page`, plus the `RemoteInternals.run` callback.

It now sits in `runtime/server/internal.js` next to `manifest` and `read_implementation`, and `hooks` gets its own `set_hooks()` there, so `options` is immutable build data once `set_options` has run. `set_options` is called at module scope rather than in the constructor, so it lands before prerendering evaluates the user's remote modules, which happens before any `Server` is constructed.

`fetch.js` renames its destructured set-cookie `options` to `cookie_options`, which would otherwise shadow the import.

Follow-up to https://github.com/sveltejs/kit/pull/16605#discussion_r3731480016. Part of #16519.
