### PR TITLE
chore: read build-time config from defines instead of SSROptions

### DIFF
--- a/.changeset/olive-hoops-shave.md
+++ b/.changeset/olive-hoops-shave.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+chore: read build-time config from defines on the server instead of carrying it in `options`

--- a/packages/kit/src/core/env.js
+++ b/packages/kit/src/core/env.js
@@ -4,13 +4,12 @@
 import path from 'node:path';
 import * as devalue from 'devalue';
 import { dedent } from './sync/utils.js';
-import { runtime_directory } from './utils.js';
+import { get_global_name, runtime_directory } from './utils.js';
 import { resolve_entry } from '../utils/filesystem.js';
 import { handle_issues, validate } from '../exports/internal/env.js';
 import { get_config_aliases } from '../exports/vite/utils.js';
 import { get_runner } from '../runner.js';
 import { import_peer } from '../utils/import.js';
-import { hash } from '../utils/hash.js';
 import { posixify } from '../utils/os.js';
 
 /**
@@ -216,9 +215,7 @@ export function create_env_modules(config, variables, env, dir, entry, is_dev) {
 	 */
 	const module = (prelude, exports) => (variables ? `${prelude}\n\n${exports.join('')}` : '');
 
-	const global = is_dev
-		? 'globalThis.__sveltekit_dev'
-		: `globalThis.__sveltekit_${hash(config.version.name)}`;
+	const global = `globalThis.${get_global_name(config.version.name, is_dev)}`;
 
 	const version = JSON.stringify(config.version.name);
 
@@ -257,7 +254,7 @@ export function create_env_modules(config, variables, env, dir, entry, is_dev) {
 		),
 		'public/client.js': module(
 			is_dev
-				? `const { env } = globalThis.__sveltekit_dev;`
+				? `const { env } = ${global};`
 				: `import { payload } from ${JSON.stringify(posixify(path.relative(`${dir}/public`, `${runtime_directory}/client/payload.js`)))};\nconst env = payload.env;`,
 			public_exports
 		),

--- a/packages/kit/src/core/sync/write_server.js
+++ b/packages/kit/src/core/sync/write_server.js
@@ -1,5 +1,4 @@
 import path from 'node:path';
-import { hash } from '../../utils/hash.js';
 import { resolve_entry } from '../../utils/filesystem.js';
 import { posixify } from '../../utils/os.js';
 import { s } from '../../utils/misc.js';
@@ -13,7 +12,6 @@ import { runtime_directory } from '../utils.js';
  *   server_hooks: string | null;
  *   universal_hooks: string | null;
  *   config: import('types').ValidatedConfig;
- *   has_service_worker: boolean;
  *   template: string;
  *   runtime_directory: string;
  * }} opts
@@ -22,7 +20,6 @@ const server_template = ({
 	config,
 	server_hooks,
 	universal_hooks,
-	has_service_worker,
 	template,
 	runtime_directory
 }) => `
@@ -34,13 +31,7 @@ import error from './shared/error-template.js';
 export const options = {
 	app_template_contains_nonce: ${template.includes('%sveltekit.nonce%')},
 	csp: ${s(config.csp)},
-	csrf_check_origin: ${s(!config.csrf.trustedOrigins.includes('*'))},
 	csrf_trusted_origins: ${s(config.csrf.trustedOrigins)},
-	embedded: ${config.embedded},
-	hash_routing: ${s(config.router.type === 'hash')},
-	link_header_preload: ${s(config.output.linkHeaderPreload)},
-	paths_origin: ${s(config.paths.origin)},
-	service_worker: ${has_service_worker},
 	service_worker_options: ${config.serviceWorker.register ? s(config.serviceWorker.options) : 'null'},
 	templates: {
 		app: ({ head, body, assets, nonce, env }) => ${s(template)
@@ -54,9 +45,7 @@ export const options = {
 				(_match, capture) => `" + (env[${s(capture)}] ?? "") + "`
 			)},
 		error
-	},
-	version: ${s(config.version.name)},
-	version_hash: ${s(hash(config.version.name))}
+	}
 };
 
 export async function get_hooks() {
@@ -124,8 +113,6 @@ export function write_server(config, output, root) {
 			runtime_directory: relative(runtime_directory),
 			server_hooks: server_hooks_file ? relative(server_hooks_file) : null,
 			universal_hooks: universal_hooks_file ? relative(universal_hooks_file) : null,
-			has_service_worker:
-				config.serviceWorker.register && !!resolve_entry(config.files.serviceWorker),
 			template: load_template(root, config)
 		})
 	);

--- a/packages/kit/src/core/utils.js
+++ b/packages/kit/src/core/utils.js
@@ -4,6 +4,7 @@ import { styleText } from 'node:util';
 import { to_fs } from '../utils/vite.js';
 import { noop } from '../utils/functions.js';
 import { posixify } from '../utils/os.js';
+import { hash } from '../utils/hash.js';
 
 /**
  * Resolved path of the `runtime` directory posix-ified
@@ -14,6 +15,15 @@ import { posixify } from '../utils/os.js';
  * If we do this conversion in other cases it has the opposite effect though and fails.
  */
 export const runtime_directory = posixify(fileURLToPath(new URL('../runtime', import.meta.url)));
+
+/**
+ * The name of the `globalThis.__sveltekit_xxx` object the app's payload is attached to
+ * @param {string} version_name
+ * @param {boolean} dev
+ */
+export function get_global_name(version_name, dev) {
+	return dev ? '__sveltekit_dev' : `__sveltekit_${hash(version_name)}`;
+}
 
 /**
  * This allows us to import SvelteKit internals that aren't exposed via `pkg.exports` in a

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -18,7 +18,7 @@ import { to_fs } from '../../utils/vite.js';
 import { create_exported_declarations } from '../../core/env.js';
 import * as sync from '../../core/sync/sync.js';
 import { load_and_validate_params } from '../../utils/params.js';
-import { runtime_directory, logger } from '../../core/utils.js';
+import { runtime_directory, logger, get_global_name } from '../../core/utils.js';
 import { generate_manifest } from '../../core/generate_manifest/index.js';
 import { build_server_nodes } from './build/build_server.js';
 import { find_deps, resolve_symlinks } from './build/utils.js';
@@ -232,9 +232,6 @@ function kit({ svelte_config }) {
 	/** @type {string} The base directory for the Vite builds */
 	let out;
 
-	/** @type {string} */
-	let version_hash;
-
 	/** @type {ResolvedConfig} */
 	let vite_config;
 
@@ -266,6 +263,9 @@ function kit({ svelte_config }) {
 
 	const sourcemapIgnoreList = /** @param {string} relative_path */ (relative_path) =>
 		relative_path.includes('node_modules') || relative_path.includes(kit.outDir);
+
+	/** @type {string} the `__sveltekit_xxx` name, without `globalThis.` */
+	let global_name;
 
 	/** @type {string} name for `globalThis.__sveltekit_xxx` */
 	let kit_global;
@@ -332,11 +332,8 @@ function kit({ svelte_config }) {
 				out_dir = posixify(kit.outDir);
 				out = `${out_dir}/output`;
 
-				version_hash = hash(kit.version.name);
-
-				kit_global = is_build
-					? `globalThis.__sveltekit_${version_hash}`
-					: 'globalThis.__sveltekit_dev';
+				global_name = get_global_name(kit.version.name, !is_build);
+				kit_global = `globalThis.${global_name}`;
 
 				service_worker_entry_file = resolve_entry(kit.files.serviceWorker);
 				service_worker_entry_file &&= posixify(service_worker_entry_file);
@@ -493,7 +490,12 @@ function kit({ svelte_config }) {
 					__SVELTEKIT_SUPPORTS_ASYNC__: s(
 						svelte_config.compilerOptions?.experimental?.async ?? false
 					),
-					__SVELTEKIT_DEV__: s(!is_build)
+					__SVELTEKIT_DEV__: s(!is_build),
+					__SVELTEKIT_GLOBAL_NAME__: s(global_name),
+					__SVELTEKIT_CSRF_CHECK_ORIGIN__: s(!kit.csrf.trustedOrigins.includes('*')),
+					__SVELTEKIT_LINK_HEADER_PRELOAD__: s(kit.output.linkHeaderPreload),
+					__SVELTEKIT_PATHS_ORIGIN__: s(kit.paths.origin) ?? 'undefined',
+					__SVELTEKIT_SERVICE_WORKER__: s(kit.serviceWorker.register && !!service_worker_entry_file)
 				};
 
 				if (is_build) {
@@ -920,7 +922,7 @@ function kit({ svelte_config }) {
 							manifest: true,
 							rolldownOptions: {
 								output: {
-									name: `__sveltekit_${version_hash}.app`,
+									name: `${global_name}.app`,
 									assetFileNames: `${app_immutable}/assets/[name].[hash][extname]`,
 									hoistTransitiveImports: false,
 									sourcemapIgnoreList

--- a/packages/kit/src/runtime/server/page/data_serializer.js
+++ b/packages/kit/src/runtime/server/page/data_serializer.js
@@ -1,7 +1,7 @@
 import * as devalue from 'devalue';
 import { compact } from '../../../utils/array.js';
 import { create_async_iterator } from '../../../utils/streaming.js';
-import { clarify_devalue_error, get_global_name, serialize_uses } from '../utils.js';
+import { clarify_devalue_error, serialize_uses } from '../utils.js';
 import { handle_error_and_jsonify } from '../errors.js';
 import { encoders } from '#app/internal/transport';
 
@@ -17,7 +17,7 @@ export function server_data_serializer(event, state) {
 	let max_nodes = -1;
 
 	const iterator = create_async_iterator();
-	const global = get_global_name();
+	const global = __SVELTEKIT_GLOBAL_NAME__;
 
 	/** @param {number} index */
 	function get_replacer(index) {

--- a/packages/kit/src/runtime/server/page/load_data.spec.js
+++ b/packages/kit/src/runtime/server/page/load_data.spec.js
@@ -1,8 +1,5 @@
-import { assert, expect, test, vi } from 'vitest';
-
-vi.stubGlobal('__SVELTEKIT_DEV__', undefined);
-
-const { create_universal_fetch } = await import('./load_data.js');
+import { assert, expect, test } from 'vitest';
+import { create_universal_fetch } from './load_data.js';
 
 /**
  * @param {Partial<Pick<import('@sveltejs/kit').RequestEvent, 'fetch' | 'url' | 'request' | 'route'>>} event

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -19,7 +19,7 @@ import {
 } from '../../pathname.js';
 import { try_get_request_store, with_request_store } from '@sveltejs/kit/internal/server';
 import { stream_text } from '../../utils.js';
-import { count_non_ssi_comments, get_global_name } from '../utils.js';
+import { count_non_ssi_comments } from '../utils.js';
 import { handle_error_and_jsonify } from '../errors.js';
 import * as env from '<sveltekit:generated>/env/config.js';
 import { collect_remote_data } from '../remote-functions.js';
@@ -133,7 +133,7 @@ export async function render_response({
 			if (!paths.assets || (paths.assets[0] === '/' && paths.assets !== SVELTE_KIT_ASSETS)) {
 				assets = base;
 			}
-		} else if (options.hash_routing) {
+		} else if (__SVELTEKIT_HASH_ROUTING__) {
 			// we have to assume that we're in the right place
 			base_expression = "new URL('.', location).pathname.slice(0, -1)";
 		}
@@ -311,7 +311,10 @@ export async function render_response({
 	 * @param {string[]} attributes
 	 */
 	const add_preload = (path, attributes) => {
-		if (options.link_header_preload && !(state.prerendering || state.prerender_default === true)) {
+		if (
+			__SVELTEKIT_LINK_HEADER_PRELOAD__ &&
+			!(state.prerendering || state.prerender_default === true)
+		) {
 			link_headers.add(`<${encodeURI(path)}>; ${attributes.join('; ')}; nopush`);
 		} else {
 			head.add_link_tag(path, attributes);
@@ -328,7 +331,7 @@ export async function render_response({
 			// include them in disabled state so that Vite can detect them and doesn't try to add them
 			attributes.push('disabled', 'media="(max-width: 0)"');
 		} else {
-			if (options.link_header_preload && resolve_opts.preload({ type: 'css', path })) {
+			if (__SVELTEKIT_LINK_HEADER_PRELOAD__ && resolve_opts.preload({ type: 'css', path })) {
 				link_headers.add(`<${encodeURI(path)}>; rel="preload"; as="style"; nopush`);
 			}
 		}
@@ -346,7 +349,7 @@ export async function render_response({
 		}
 	}
 
-	const global = get_global_name();
+	const global = __SVELTEKIT_GLOBAL_NAME__;
 	const { data, chunks } = data_serializer.get_data(csp);
 
 	if (page_config.ssr && page_config.csr) {
@@ -508,7 +511,7 @@ export async function render_response({
 					); // make output after it's put together with the rest more readable
 					hydrate.push(`params: ${devalue.uneval(event.params)}`, `server_route: ${stringified}`);
 				}
-			} else if (options.embedded) {
+			} else if (__SVELTEKIT_EMBEDDED__) {
 				hydrate.push(`params: ${devalue.uneval(event.params)}`, `route: ${s(event.route)}`);
 			}
 
@@ -548,7 +551,7 @@ export async function render_response({
 			blocks.push(boot);
 		}
 
-		if (options.service_worker) {
+		if (__SVELTEKIT_SERVICE_WORKER__) {
 			let opts = ", { type: 'module' }";
 			if (options.service_worker_options != null) {
 				const service_worker_options = { ...options.service_worker_options, type: 'module' };
@@ -609,7 +612,7 @@ export async function render_response({
 			headers.set('content-security-policy-report-only', report_only_header);
 		}
 
-		if (options.link_header_preload && link_headers.size) {
+		if (__SVELTEKIT_LINK_HEADER_PRELOAD__ && link_headers.size) {
 			headers.set('link', Array.from(link_headers).join(', '));
 		}
 	}

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -100,7 +100,7 @@ export async function internal_respond(request, manifest, state) {
 
 	if (!__SVELTEKIT_DEV__) {
 		const request_origin = request.headers.get('origin');
-		const self_origin = get_self_origin(options.paths_origin, url.origin);
+		const self_origin = get_self_origin(__SVELTEKIT_PATHS_ORIGIN__, url.origin);
 
 		if (remote_id) {
 			if (
@@ -113,7 +113,7 @@ export async function internal_respond(request, manifest, state) {
 				const message = 'Cross-site remote requests are forbidden';
 				return Response.json({ message }, { status: 403 });
 			}
-		} else if (options.csrf_check_origin) {
+		} else if (__SVELTEKIT_CSRF_CHECK_ORIGIN__) {
 			const forbidden = is_csrf_forbidden({
 				request,
 				request_origin,
@@ -134,7 +134,7 @@ export async function internal_respond(request, manifest, state) {
 		}
 	}
 
-	if (options.hash_routing && url.pathname !== base + '/' && url.pathname !== '/[fallback]') {
+	if (__SVELTEKIT_HASH_ROUTING__ && url.pathname !== base + '/' && url.pathname !== '/[fallback]') {
 		return text('Not found', { status: 404 });
 	}
 
@@ -610,7 +610,7 @@ export async function internal_respond(request, manifest, state) {
 				});
 			}
 
-			if (options.hash_routing || state.prerendering?.fallback) {
+			if (__SVELTEKIT_HASH_ROUTING__ || state.prerendering?.fallback) {
 				return await render_response({
 					event,
 					state,

--- a/packages/kit/src/runtime/server/utils.js
+++ b/packages/kit/src/runtime/server/utils.js
@@ -1,6 +1,5 @@
 import { text } from '@sveltejs/kit';
 import { ENDPOINT_METHODS } from '../../constants.js';
-import { options } from './internal.js';
 
 /**
  * @param {Partial<Record<import('types').HttpMethod, any>>} mod
@@ -28,12 +27,6 @@ export function allowed_methods(mod) {
 	}
 
 	return allowed;
-}
-
-/**
- */
-export function get_global_name() {
-	return __SVELTEKIT_DEV__ ? '__sveltekit_dev' : `__sveltekit_${options.version_hash}`;
 }
 
 /**

--- a/packages/kit/src/types/global-private.d.ts
+++ b/packages/kit/src/types/global-private.d.ts
@@ -13,7 +13,15 @@ declare global {
 	 * it is influenced by `NODE_ENV` which can still be true during `vite preview`
 	 */
 	const __SVELTEKIT_DEV__: boolean;
+	const __SVELTEKIT_CSRF_CHECK_ORIGIN__: boolean;
 	const __SVELTEKIT_EMBEDDED__: boolean;
+	/** True if `config.output.linkHeaderPreload` is `true` */
+	const __SVELTEKIT_LINK_HEADER_PRELOAD__: boolean;
+	const __SVELTEKIT_PATHS_ORIGIN__: string | undefined;
+	/** True if the app has a service worker and `config.serviceWorker.register` is `true` */
+	const __SVELTEKIT_SERVICE_WORKER__: boolean;
+	/** The `__sveltekit_xxx` name the payload object is attached to, without `globalThis.` */
+	const __SVELTEKIT_GLOBAL_NAME__: string;
 	const __SVELTEKIT_PATHS_ASSETS__: string;
 	const __SVELTEKIT_PATHS_BASE__: string;
 	const __SVELTEKIT_PATHS_RELATIVE__: boolean;

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -493,13 +493,7 @@ export type SSRNodeLoader = () => Promise<SSRNode>;
 export interface SSROptions {
 	app_template_contains_nonce: boolean;
 	csp: ValidatedConfig['csp'];
-	csrf_check_origin: boolean;
 	csrf_trusted_origins: string[];
-	embedded: boolean;
-	hash_routing: boolean;
-	link_header_preload: ValidatedConfig['output']['linkHeaderPreload'];
-	paths_origin: string | undefined;
-	service_worker: boolean;
 	service_worker_options: RegistrationOptions;
 	templates: {
 		app(values: {
@@ -511,8 +505,6 @@ export interface SSROptions {
 		}): string;
 		error(values: { message: string; status: number }): string;
 	};
-	version: string;
-	version_hash: string;
 }
 
 export interface PageNodeIndexes {

--- a/packages/kit/vitest.kit.config.js
+++ b/packages/kit/vitest.kit.config.js
@@ -15,6 +15,7 @@ const exclude = [
 export default /** @satisfies {import('vitest/config').ViteUserConfig} */ ({
 	plugins: [svelte({ compilerOptions: { hmr: false, experimental: { async: true } } })],
 	define: {
+		__SVELTEKIT_GLOBAL_NAME__: '"__sveltekit_test"',
 		__SVELTEKIT_SERVER_TRACING_ENABLED__: false,
 		__SVELTEKIT_APP_VERSION_POLL_INTERVAL__: 0,
 		__SVELTEKIT_APP_VERSION_CHECKS_ENABLED__: false


### PR DESCRIPTION
Several `SSROptions` fields are build-time constants that already exist as defines for the client, `__SVELTEKIT_EMBEDDED__` and `__SVELTEKIT_HASH_ROUTING__`. The server took a second route to the same values through `options`, though `app/paths/internal/server.js` already reads `__SVELTEKIT_APP_DIR__`. This moves the server onto those two and adds defines for `csrf_check_origin`, `link_header_preload`, `paths_origin` and `service_worker`.

The app's global name was derived in five places: `exports/vite/index.js` twice, `core/env.js` twice, and `runtime/server/utils.js` in `get_global_name`, which read it back out of `SSROptions.version_hash`. Two of them called `hash(config.version.name)` separately. `get_global_name(version_name, dev)` in `core/utils.js` is now the only derivation, and the server reads the result through `__SVELTEKIT_GLOBAL_NAME__`. `SSROptions.version` had no readers at all.

`csp`, `csrf_trusted_origins`, `service_worker_options` and `templates` stay put: a define is a textual substitution, so a structured value gets re-inlined at every read.

Stacked on #16871.
