### PR TITLE
breaking: remove `SSRManifest` from public types

### DIFF
--- a/.changeset/flat-cases-see.md
+++ b/.changeset/flat-cases-see.md
@@ -1,0 +1,6 @@
+---
+"@sveltejs/kit": major
+---
+
+breaking: remove `SSRManifest` from public types
+  

--- a/packages/kit/src/core/generate_manifest/index.js
+++ b/packages/kit/src/core/generate_manifest/index.js
@@ -102,7 +102,7 @@ export function generate_manifest({
 
 	// prettier-ignore
 	// String representation of
-	/** @template {import('@sveltejs/kit').SSRManifest} T */
+	/** @template {import('types').SSRManifest} T */
 	const manifest_expr = dedent`
 		{
 			appDir: ${s(build_data.app_dir)},

--- a/packages/kit/src/core/postbuild/analyse.js
+++ b/packages/kit/src/core/postbuild/analyse.js
@@ -34,7 +34,7 @@ async function analyse({
 	remotes,
 	vite_config_file
 }) {
-	/** @type {import('@sveltejs/kit').SSRManifest} */
+	/** @type {import('types').SSRManifest} */
 	const manifest = (await import(pathToFileURL(manifest_path).href)).manifest;
 
 	const vite_config = await load_vite_config(vite_config_file);

--- a/packages/kit/src/core/postbuild/fallback.js
+++ b/packages/kit/src/core/postbuild/fallback.js
@@ -24,7 +24,7 @@ async function generate_fallback({ manifest_path, env, out_dir, origin, assets }
 	/** @type {import('types').ServerModule} */
 	const { Server } = await import(pathToFileURL(`${server_root}/server/index.js`).href);
 
-	/** @type {import('@sveltejs/kit').SSRManifest} */
+	/** @type {import('types').SSRManifest} */
 	const manifest = (await import(pathToFileURL(manifest_path).href)).manifest;
 
 	set_building();

--- a/packages/kit/src/core/postbuild/prerender.js
+++ b/packages/kit/src/core/postbuild/prerender.js
@@ -48,7 +48,7 @@ async function prerender({
 	vite_config_file,
 	is_tty
 }) {
-	/** @type {import('@sveltejs/kit').SSRManifest} */
+	/** @type {import('types').SSRManifest} */
 	const manifest = (await import(pathToFileURL(manifest_path).href)).manifest;
 
 	/** @type {import('types').ServerInternalModule} */

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -12,10 +12,9 @@ import {
 	RequestOptions,
 	RouteSegment
 } from '../types/private.js';
-import { BuildData, SSRNodeLoader, SSRRoute, ValidatedConfig } from 'types';
+import { SSRManifest, ValidatedConfig } from 'types';
 import { Plugin } from 'vite';
 import { RouteId as AppRouteId, LayoutParams as AppLayoutParams } from '$app/types';
-import { ParamMatcher } from '@sveltejs/kit/params';
 import { StandardSchemaV1 } from '@standard-schema/spec';
 
 export { PrerenderOption } from '../types/private.js';
@@ -693,32 +692,6 @@ export interface ServerInitOptions {
 	env: Record<string, string | undefined>;
 	/** A function that turns an asset filename into a `ReadableStream`. Required for the `read` export from `$app/server` to work. */
 	read?: (file: string) => MaybePromise<ReadableStream | null>;
-}
-
-/**
- * Information required to instantiate a new `Server` instance.
- */
-export interface SSRManifest {
-	/** The directory where SvelteKit keeps its stuff, including static assets (such as JS and CSS) and internally-used routes. */
-	appDir: string;
-	/** The `base` and `appDir` settings combined without a leading slash. */
-	appPath: string;
-	/** Static files from `config.files.assets` and the service worker (if any). */
-	assets: Set<string>;
-	mimeTypes: Record<string, string>;
-
-	/** @internal private fields */
-	_: {
-		client: BuildData['client'];
-		nodes: SSRNodeLoader[];
-		/** hashed filename -> import to that file */
-		remotes: Record<string, () => Promise<{ default: Record<string, any> }>>;
-		routes: SSRRoute[];
-		prerendered_routes: Set<string>;
-		matchers: () => Promise<Record<string, ParamMatcher>>;
-		/** A `[file]: size` map of all assets imported by server code. */
-		server_assets: Record<string, number>;
-	};
 }
 
 /**

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -1,6 +1,6 @@
-/** @import { RequestEvent, SSRManifest } from '@sveltejs/kit' */
+/** @import { RequestEvent } from '@sveltejs/kit' */
 /** @import { EnvironmentModuleNode, ErrorPayload, ViteDevServer } from 'vite' */
-/** @import { ManifestData, PrerenderOption, RemoteChunk, ServerModule, SSRNode, UniversalNode, ValidatedConfig } from 'types' */
+/** @import { ManifestData, PrerenderOption, RemoteChunk, ServerModule, SSRNode, UniversalNode, ValidatedConfig, SSRManifest } from 'types' */
 import process from 'node:process';
 import fs from 'node:fs';
 import path from 'node:path';

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -43,7 +43,7 @@ export async function preview(vite, svelte_config) {
 	/** @type {ServerModule} */
 	const { Server } = await import(pathToFileURL(join(dir, 'index.js')).href);
 
-	/** @type {{ manifest: import('@sveltejs/kit').SSRManifest }} */
+	/** @type {{ manifest: import('types').SSRManifest }} */
 	const { manifest } = await import(pathToFileURL(join(dir, 'manifest.js')).href);
 
 	set_assets(assets);

--- a/packages/kit/src/runtime/server/data/index.js
+++ b/packages/kit/src/runtime/server/data/index.js
@@ -13,7 +13,7 @@ import { with_version_header } from '../utils.js';
  * @param {import('@sveltejs/kit').RequestEvent} event
  * @param {import('types').RequestState} state
  * @param {{ page: Pick<import('types').PageNodeIndexes, 'layouts' | 'leaf'> | null }} route
- * @param {import('@sveltejs/kit').SSRManifest} manifest
+ * @param {import('types').SSRManifest} manifest
  * @param {boolean[] | undefined} invalidated_data_nodes
  * @param {import('types').TrailingSlash} trailing_slash
  * @returns {Promise<Response>}

--- a/packages/kit/src/runtime/server/fetch.js
+++ b/packages/kit/src/runtime/server/fetch.js
@@ -9,7 +9,7 @@ import { fork_state_for_subrequest } from './state.js';
 /**
  * @param {{
  *   event: import('@sveltejs/kit').RequestEvent;
- *   manifest: import('@sveltejs/kit').SSRManifest;
+ *   manifest: import('types').SSRManifest;
  *   state: import('types').RequestState;
  *   get_cookie_header: (url: URL, header: string | null) => string;
  *   set_internal: (name: string, value: string, opts: import('./page/types.js').Cookie['options']) => void;
@@ -193,7 +193,7 @@ function normalize_fetch_input(info, init, url) {
 
 /**
  * @param {Request} request
- * @param {import('@sveltejs/kit').SSRManifest} manifest
+ * @param {import('types').SSRManifest} manifest
  * @param {import('types').RequestState} state
  * @returns {Promise<Response>}
  */

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -58,10 +58,10 @@ if (DEV) {
 }
 
 export class Server {
-	/** @type {import('@sveltejs/kit').SSRManifest} */
+	/** @type {import('types').SSRManifest} */
 	#manifest;
 
-	/** @param {import('@sveltejs/kit').SSRManifest} manifest */
+	/** @param {import('types').SSRManifest} manifest */
 	constructor(manifest) {
 		this.#manifest = manifest;
 

--- a/packages/kit/src/runtime/server/internal.js
+++ b/packages/kit/src/runtime/server/internal.js
@@ -1,5 +1,4 @@
-/** @import { SSRManifest } from '@sveltejs/kit'; */
-/** @import { ServerHooks, SSROptions } from 'types'; */
+/** @import { ServerHooks, SSROptions, SSRManifest } from 'types'; */
 import { restore, save } from './dev.js';
 import {
 	has_data_suffix,

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -1,5 +1,5 @@
-/** @import { RequestEvent, SSRManifest } from '@sveltejs/kit' */
-/** @import { PageNodeIndexes, RequestState, RequiredResolveOptions, ServerDataNode, SSRNode } from 'types' */
+/** @import { RequestEvent } from '@sveltejs/kit' */
+/** @import { PageNodeIndexes, RequestState, RequiredResolveOptions, ServerDataNode, SSRNode, SSRManifest } from 'types' */
 import { text } from '@sveltejs/kit';
 import { Redirect } from '@sveltejs/kit/internal';
 import { compact } from '../../../utils/array.js';

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -36,7 +36,7 @@ import { options } from '../internal.js';
  * @param {{
  *   branch: Array<import('./types.js').Loaded>;
  *   fetched: Array<import('./types.js').Fetched>;
- *   manifest: import('@sveltejs/kit').SSRManifest;
+ *   manifest: import('types').SSRManifest;
  *   page_config: { ssr: boolean; csr: boolean };
  *   status: number;
  *   error: App.Error | null;

--- a/packages/kit/src/runtime/server/page/respond_with_error.js
+++ b/packages/kit/src/runtime/server/page/respond_with_error.js
@@ -14,7 +14,7 @@ import { server_data_serializer } from './data_serializer.js';
  * @param {{
  *   event: import('@sveltejs/kit').RequestEvent;
  *   state: import('types').RequestState;
- *   manifest: import('@sveltejs/kit').SSRManifest;
+ *   manifest: import('types').SSRManifest;
  *   error: unknown;
  *   resolve_opts: import('types').RequiredResolveOptions;
  * }} opts

--- a/packages/kit/src/runtime/server/page/server_routing.js
+++ b/packages/kit/src/runtime/server/page/server_routing.js
@@ -1,4 +1,4 @@
-/** @import { SSRManifest } from '@sveltejs/kit' */
+/** @import { SSRManifest } from 'types' */
 import { base, assets } from '#app/paths';
 import { relative } from '$app/paths/internal/server';
 import { text } from '@sveltejs/kit';

--- a/packages/kit/src/runtime/server/remote-functions.js
+++ b/packages/kit/src/runtime/server/remote-functions.js
@@ -1,6 +1,6 @@
-/** @import { RequestEvent, SSRManifest } from '@sveltejs/kit' */
+/** @import { RequestEvent } from '@sveltejs/kit' */
 /** @import { RemoteForm } from '$app/server' */
-/** @import { RemoteFormInternals, RemoteFunctionData, RemoteFunctionResponse, RemoteInternals, RequestState, ServerActionResult } from 'types' */
+/** @import { RemoteFormInternals, RemoteFunctionData, RemoteFunctionResponse, RemoteInternals, RequestState, ServerActionResult, SSRManifest } from 'types' */
 
 import { error } from '@sveltejs/kit';
 import { Redirect, SvelteKitError } from '@sveltejs/kit/internal';

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -86,7 +86,7 @@ export const respond = propagate_context(internal_respond);
 
 /**
  * @param {Request} request
- * @param {import('@sveltejs/kit').SSRManifest} manifest
+ * @param {import('types').SSRManifest} manifest
  * @param {import('types').RequestState} state
  * @returns {Promise<Response>}
  */
@@ -824,7 +824,7 @@ export async function internal_respond(request, manifest, state) {
 
 /**
  * @param {import('types').PageNodeIndexes} page
- * @param {import('@sveltejs/kit').SSRManifest} manifest
+ * @param {import('types').SSRManifest} manifest
  */
 export function load_page_nodes(page, manifest) {
 	return Promise.all([

--- a/packages/kit/src/runtime/server/utils.js
+++ b/packages/kit/src/runtime/server/utils.js
@@ -98,7 +98,7 @@ export function serialize_uses(node) {
 
 /**
  * Returns `true` if the given path was prerendered
- * @param {import('@sveltejs/kit').SSRManifest} manifest
+ * @param {import('types').SSRManifest} manifest
  * @param {string} pathname Should include the base and be decoded
  */
 export function has_prerendered_path(manifest, pathname) {

--- a/packages/kit/src/types/ambient-private.d.ts
+++ b/packages/kit/src/types/ambient-private.d.ts
@@ -1,7 +1,6 @@
 /** Internal version of $app/server */
 declare module '<sveltekit:generated>/server.js' {
-	import { SSRManifest } from '@sveltejs/kit';
-	import { SSROptions, ServerHooks } from 'types';
+	import { SSROptions, ServerHooks, SSRManifest } from 'types';
 
 	export const options: SSROptions;
 	export const get_hooks: () => Promise<Partial<ServerHooks>>;

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -7,12 +7,12 @@ import {
 	ServerInitOptions,
 	Actions,
 	RequestEvent,
-	SSRManifest,
 	Emulator,
 	HttpError
 } from '@sveltejs/kit';
 import { RemoteFormIssue, RemoteQuery, RemoteLiveQuery } from '$app/server';
 import { Config } from '@sveltejs/kit/vite';
+import { ParamMatcher } from '@sveltejs/kit/params';
 import {
 	ClientInit,
 	Handle,
@@ -457,6 +457,32 @@ export interface ServerNode {
 	actions?: Actions;
 	config?: Record<string, any>;
 	entries?: PrerenderEntryGenerator;
+}
+
+/**
+ * Information required to instantiate a new `Server` instance.
+ */
+export interface SSRManifest {
+	/** The directory where SvelteKit keeps its stuff, including static assets (such as JS and CSS) and internally-used routes. */
+	appDir: string;
+	/** The `base` and `appDir` settings combined without a leading slash. */
+	appPath: string;
+	/** Static files from `config.files.assets` and the service worker (if any). */
+	assets: Set<string>;
+	mimeTypes: Record<string, string>;
+
+	/** @internal private fields */
+	_: {
+		client: BuildData['client'];
+		nodes: SSRNodeLoader[];
+		/** hashed filename -> import to that file */
+		remotes: Record<string, () => Promise<{ default: Record<string, any> }>>;
+		routes: SSRRoute[];
+		prerendered_routes: Set<string>;
+		matchers: () => Promise<Record<string, ParamMatcher>>;
+		/** A `[file]: size` map of all assets imported by server code. */
+		server_assets: Record<string, number>;
+	};
 }
 
 export interface SSRNode {

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -679,19 +679,6 @@ declare module '@sveltejs/kit' {
 	}
 
 	/**
-	 * Information required to instantiate a new `Server` instance.
-	 */
-	export interface SSRManifest {
-		/** The directory where SvelteKit keeps its stuff, including static assets (such as JS and CSS) and internally-used routes. */
-		appDir: string;
-		/** The `base` and `appDir` settings combined without a leading slash. */
-		appPath: string;
-		/** Static files from `config.files.assets` and the service worker (if any). */
-		assets: Set<string>;
-		mimeTypes: Record<string, string>;
-	}
-
-	/**
 	 * The generic form of `PageServerLoad` and `LayoutServerLoad`. You should import those from `./$types` (see [generated types](https://svelte.dev/docs/kit/types#Generated-types))
 	 * rather than using `ServerLoad` directly.
 	 */
@@ -929,6 +916,19 @@ declare module '@sveltejs/kit' {
 			? RecursiveRequired<T[K]> // recursively continue through.
 			: T[K]; // Use the exact type for everything else
 	};
+
+	/**
+	 * Information required to instantiate a new `Server` instance.
+	 */
+	interface SSRManifest {
+		/** The directory where SvelteKit keeps its stuff, including static assets (such as JS and CSS) and internally-used routes. */
+		appDir: string;
+		/** The `base` and `appDir` settings combined without a leading slash. */
+		appPath: string;
+		/** Static files from `config.files.assets` and the service worker (if any). */
+		assets: Set<string>;
+		mimeTypes: Record<string, string>;
+	}
 
 	type ValidatedConfig = RecursiveRequired<Omit<Config, 'preprocess'>> & {
 		preprocess: Config['preprocess'];


### PR DESCRIPTION
We want `SSRManifest` to be an internal implementation detail rather than a public type that has to remain stable. #16875 removes all adapter uses of `SSRManifest`, this PR moves it to `internal.d.ts`.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>