### PR TITLE
breaking: require Bun 1.4

### DIFF
--- a/.changeset/bun-adapter-requires-1-4.md
+++ b/.changeset/bun-adapter-requires-1-4.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-bun': patch
+---
+
+chore: require Bun 1.4, which routes `HEAD` to `GET` handlers and settles `stop()` after a force close

--- a/.changeset/bun-adapter-requires-1-4.md
+++ b/.changeset/bun-adapter-requires-1-4.md
@@ -1,5 +1,5 @@
 ---
-'@sveltejs/adapter-bun': patch
+'@sveltejs/adapter-bun': major
 ---
 
-chore: require Bun 1.4, which routes `HEAD` to `GET` handlers and settles `stop()` after a force close
+breaking: require Bun 1.4, which routes `HEAD` to `GET` handlers and settles `stop()` after a force close

--- a/.github/workflows/platform-tests-bun.yml
+++ b/.github/workflows/platform-tests-bun.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.0
 
       - uses: ./.github/actions/platform-test
         with:

--- a/documentation/docs/25-build-and-deploy/45-adapter-bun.md
+++ b/documentation/docs/25-build-and-deploy/45-adapter-bun.md
@@ -6,7 +6,7 @@ title: Bun servers
 
 ## Usage
 
-The adapter requires Bun 1.4 or newer. Install it:
+Install the adapter:
 
 ```sh
 bun add -D @sveltejs/adapter-bun

--- a/documentation/docs/25-build-and-deploy/45-adapter-bun.md
+++ b/documentation/docs/25-build-and-deploy/45-adapter-bun.md
@@ -3,6 +3,7 @@ title: Bun servers
 ---
 
 [`adapter-bun`](https://github.com/sveltejs/kit/tree/main/packages/adapter-bun) builds a SvelteKit application into a standalone [Bun](https://bun.com/) server. The generated server uses `Bun.serve` for requests and `Bun.file` responses for client assets, prerendered output, and files read with [`read`](https://svelte.dev/docs/kit/$app-server#read) from `$app/server`.
+
 > [!NOTE] Bun 1.4 or newer is required.
 
 ## Usage

--- a/documentation/docs/25-build-and-deploy/45-adapter-bun.md
+++ b/documentation/docs/25-build-and-deploy/45-adapter-bun.md
@@ -6,7 +6,7 @@ title: Bun servers
 
 ## Usage
 
-Install the adapter:
+The adapter requires Bun 1.4 or newer. Install it:
 
 ```sh
 bun add -D @sveltejs/adapter-bun

--- a/documentation/docs/25-build-and-deploy/45-adapter-bun.md
+++ b/documentation/docs/25-build-and-deploy/45-adapter-bun.md
@@ -3,6 +3,7 @@ title: Bun servers
 ---
 
 [`adapter-bun`](https://github.com/sveltejs/kit/tree/main/packages/adapter-bun) builds a SvelteKit application into a standalone [Bun](https://bun.com/) server. The generated server uses `Bun.serve` for requests and `Bun.file` responses for client assets, prerendered output, and files read with [`read`](https://svelte.dev/docs/kit/$app-server#read) from `$app/server`.
+> [!NOTE] Bun 1.4 or newer is required.
 
 ## Usage
 

--- a/packages/adapter-bun/package.json
+++ b/packages/adapter-bun/package.json
@@ -50,5 +50,8 @@
 	},
 	"peerDependencies": {
 		"@sveltejs/kit": "^3.0.0-next.0"
+	},
+	"engines": {
+		"bun": ">=1.4.0"
 	}
 }

--- a/packages/adapter-bun/src/index.js
+++ b/packages/adapter-bun/src/index.js
@@ -6,8 +6,9 @@ import { routes } from 'ROUTES';
 import { handler } from './handler.js';
 import { boolean_env, bytes_env, env, number_env } from './env.js';
 
-// nothing enforces `engines.bun` at install time, and the build may have run on a newer Bun
-if (!Bun.semver.satisfies(Bun.version, '>=1.4.0')) {
+// nothing enforces `engines.bun` at install time, and the build may have run on a newer Bun.
+// order() rather than satisfies(): a range would reject canary builds such as 1.5.0-canary.1
+if (Bun.semver.order(Bun.version, '1.4.0') < 0) {
 	throw new Error(
 		`@sveltejs/adapter-bun requires Bun 1.4 or newer, but this is Bun ${Bun.version}`
 	);

--- a/packages/adapter-bun/src/index.js
+++ b/packages/adapter-bun/src/index.js
@@ -65,8 +65,9 @@ async function graceful_shutdown(reason) {
 		);
 	}
 
-	// stop() waits forever on idle connections such as open event streams, and once it
-	// is pending its promise never settles even after a force-close, so race it instead
+	// stop() waits for in-flight requests, and an open event stream is one forever,
+	// so race the drain against the deadline. The timer must stay referenced: a
+	// draining server no longer holds the event loop open on its own
 	/** @type {ReturnType<typeof setTimeout> | undefined} */
 	let deadline;
 	const drained = await Promise.race([
@@ -77,20 +78,9 @@ async function graceful_shutdown(reason) {
 	]);
 	clearTimeout(deadline);
 
-	if (!drained) {
-		// give the force-close a moment to abort in-flight handlers, so shutdown
-		// listeners do not tear down resources those handlers still hold; the stop
-		// promise may never settle, so the timer bounds the wait
-		/** @type {ReturnType<typeof setTimeout> | undefined} */
-		let grace;
-		await Promise.race([
-			server.stop(true),
-			new Promise((resolve) => {
-				grace = setTimeout(resolve, 1000);
-			})
-		]);
-		clearTimeout(grace);
-	}
+	// force-close aborts the in-flight handlers, so shutdown listeners do not tear
+	// down resources those handlers still hold
+	if (!drained) await server.stop(true);
 
 	// @ts-expect-error custom events cannot be typed
 	process.emit('sveltekit:shutdown', reason);

--- a/packages/adapter-bun/src/index.js
+++ b/packages/adapter-bun/src/index.js
@@ -6,6 +6,13 @@ import { routes } from 'ROUTES';
 import { handler } from './handler.js';
 import { boolean_env, bytes_env, env, number_env } from './env.js';
 
+// nothing enforces `engines.bun` at install time, and the build may have run on a newer Bun
+if (!Bun.semver.satisfies(Bun.version, '>=1.4.0')) {
+	throw new Error(
+		`@sveltejs/adapter-bun requires Bun 1.4 or newer, but this is Bun ${Bun.version}`
+	);
+}
+
 const options = /** @type {Serve.Options<undefined>} */ ({ ...server_options });
 
 const unix = env('SOCKET_PATH', options.unix);

--- a/packages/adapter-bun/src/routes-util.js
+++ b/packages/adapter-bun/src/routes-util.js
@@ -115,16 +115,6 @@ function negotiate(accept, meta) {
 }
 
 /**
- * Bun does not route HEAD requests to a GET function handler, so every route
- * registers both methods.
- * @param {((request: BunRequest) => Response) | Response} handler
- * @returns {RouteHandler}
- */
-function handlers(handler) {
-	return { GET: handler, HEAD: handler };
-}
-
-/**
  * @param {string[]} paths
  * @param {RouteHandler} route
  * @returns {Array<[string, RouteHandler]>}
@@ -174,7 +164,7 @@ function file_route(file, meta, extra_headers = {}) {
 		return new Response(Bun.file(body_file), { headers: response_headers });
 	};
 
-	return handlers(handler);
+	return { GET: handler };
 }
 
 /**
@@ -236,11 +226,14 @@ export function prerendered_page(url, filename, meta) {
 	const inverted = url.endsWith('/') ? url.slice(0, -1) : `${url}/`;
 	if (inverted) {
 		const canonical = encode_pathname(url);
-		const redirect = handlers((req) => {
-			const location = canonical + new URL(req.url).search;
-			return new Response(null, { status: 308, headers: { location } });
-		});
-		entries.push(...route_entries(route_paths(inverted), redirect));
+		entries.push(
+			...route_entries(route_paths(inverted), {
+				GET: (req) => {
+					const location = canonical + new URL(req.url).search;
+					return new Response(null, { status: 308, headers: { location } });
+				}
+			})
+		);
 	}
 
 	return entries;
@@ -253,7 +246,7 @@ export function prerendered_page(url, filename, meta) {
  * @returns {Array<[string, RouteHandler]>}
  */
 export function prerendered_redirect(url, status, location) {
-	const route = handlers(new Response(null, { status, headers: { location } }));
+	const route = { GET: new Response(null, { status, headers: { location } }) };
 	// path already contains base, no need to add it here
 	return route_entries(route_paths(url), route);
 }

--- a/packages/adapter-bun/test/routes.spec.ts
+++ b/packages/adapter-bun/test/routes.spec.ts
@@ -147,13 +147,6 @@ test('static routes revalidate by date when the client has no ETag', async () =>
 	expect(stale_etag_wins.status).toBe(200);
 });
 
-test('static routes answer HEAD with the same handler', async () => {
-	const { routes } = await load_routes();
-
-	const route = routes.client_asset('data.json', undefined, meta)[0][1] as any;
-	expect(route.HEAD).toBe(route.GET);
-});
-
 test('precompressed variants are negotiated with their own validators', async () => {
 	const { routes, file } = await load_routes();
 
@@ -259,7 +252,6 @@ test.each([
 
 		expect(entries[0][0]).toBe(canonical);
 		expect(entries[1][0]).toBe(alternate);
-		expect((entries[1][1] as any).HEAD).toBe((entries[1][1] as any).GET);
 		const response = (entries[1][1] as any).GET(
 			new Request(`http://localhost${alternate}?from=test`)
 		);
@@ -290,7 +282,6 @@ test('prerendered redirects retain their status and location', async () => {
 	expect(path).toBe('/old%20path');
 	expect((handler as any).GET.status).toBe(307);
 	expect((handler as any).GET.headers.get('location')).toBe('/new');
-	expect((handler as any).HEAD).toBe((handler as any).GET);
 });
 
 async function load_routes({ base = '/', embed = false, appDir = '_app' } = {}) {

--- a/packages/adapter-bun/test/start.spec.ts
+++ b/packages/adapter-bun/test/start.spec.ts
@@ -119,9 +119,13 @@ test.each(['SIGINT', 'SIGTERM'] as const)(
 test('force-closes lingering connections after SHUTDOWN_TIMEOUT', async () => {
 	vi.useFakeTimers();
 	try {
+		let finish_force: (() => void) | undefined;
 		const loaded = await load_start({
 			env: { SHUTDOWN_TIMEOUT: '5' },
-			stop: () => new Promise<void>(() => {})
+			stop: (force) =>
+				force
+					? new Promise<void>((resolve) => (finish_force = resolve))
+					: new Promise<void>(() => {})
 		});
 
 		const shutdown = loaded.listeners.get('SIGTERM')?.();
@@ -130,7 +134,7 @@ test('force-closes lingering connections after SHUTDOWN_TIMEOUT', async () => {
 		expect(loaded.stop).toHaveBeenLastCalledWith(true);
 		expect(loaded.emit).not.toHaveBeenCalled();
 
-		await vi.advanceTimersByTimeAsync(1000);
+		finish_force?.();
 		await shutdown;
 		expect(loaded.emit).toHaveBeenCalledWith('sveltekit:shutdown', 'SIGTERM');
 	} finally {
@@ -163,7 +167,7 @@ async function load_start({
 	env?: Record<string, string>;
 	envPrefix?: string;
 	pendingRequests?: number;
-	stop?: () => Promise<void>;
+	stop?: (force?: boolean) => Promise<void>;
 } = {}) {
 	vi.resetModules();
 	const listeners = new Map<string, () => Promise<void> | void>();

--- a/packages/adapter-bun/test/start.spec.ts
+++ b/packages/adapter-bun/test/start.spec.ts
@@ -105,6 +105,11 @@ test('refuses to start on a Bun older than 1.4', async () => {
 	await expect(load_start({ bunVersion: '1.3.14' })).rejects.toThrow('requires Bun 1.4');
 });
 
+test.each(['1.4.1', '1.5.0-canary.1', '2.0.0'])('starts on Bun %s', async (bunVersion) => {
+	const loaded = await load_start({ bunVersion });
+	expect(loaded.serve).toHaveBeenCalled();
+});
+
 test.each(['SIGINT', 'SIGTERM'] as const)(
 	'gracefully stops the server and emits sveltekit:shutdown for %s',
 	async (signal) => {
@@ -203,10 +208,10 @@ async function load_start({
 		stop
 	};
 	const serve = vi.fn((_options: any) => server);
-	// vitest runs under Node, so a minimal `>=` stands in for Bun.semver
-	const satisfies = (version: string, range: string) =>
-		version.localeCompare(range.slice(2), undefined, { numeric: true }) >= 0;
-	vi.stubGlobal('Bun', { serve, version: bunVersion, semver: { satisfies } });
+	// vitest runs under Node, so a numeric compare stands in for Bun.semver.order
+	const order = (a: string, b: string) =>
+		a.replace('-', '.').localeCompare(b.replace('-', '.'), undefined, { numeric: true });
+	vi.stubGlobal('Bun', { serve, version: bunVersion, semver: { order } });
 	const log = vi.spyOn(console, 'log').mockImplementation(() => {});
 
 	await import('../src/index.js');

--- a/packages/adapter-bun/test/start.spec.ts
+++ b/packages/adapter-bun/test/start.spec.ts
@@ -101,6 +101,10 @@ test.each([
 	await expect(load_start({ env })).rejects.toThrow(message);
 });
 
+test('refuses to start on a Bun older than 1.4', async () => {
+	await expect(load_start({ bunVersion: '1.3.14' })).rejects.toThrow('requires Bun 1.4');
+});
+
 test.each(['SIGINT', 'SIGTERM'] as const)(
 	'gracefully stops the server and emits sveltekit:shutdown for %s',
 	async (signal) => {
@@ -161,12 +165,14 @@ async function load_start({
 	env = {},
 	envPrefix = '',
 	pendingRequests = 0,
+	bunVersion = '1.4.0',
 	stop: stop_implementation
 }: {
 	serverOptions?: Record<string, unknown>;
 	env?: Record<string, string>;
 	envPrefix?: string;
 	pendingRequests?: number;
+	bunVersion?: string;
 	stop?: (force?: boolean) => Promise<void>;
 } = {}) {
 	vi.resetModules();
@@ -197,7 +203,10 @@ async function load_start({
 		stop
 	};
 	const serve = vi.fn((_options: any) => server);
-	vi.stubGlobal('Bun', { serve });
+	// vitest runs under Node, so a minimal `>=` stands in for Bun.semver
+	const satisfies = (version: string, range: string) =>
+		version.localeCompare(range.slice(2), undefined, { numeric: true }) >= 0;
+	vi.stubGlobal('Bun', { serve, version: bunVersion, semver: { satisfies } });
 	const log = vi.spyOn(console, 'log').mockImplementation(() => {});
 
 	await import('../src/index.js');


### PR DESCRIPTION
Stacked on #16898

Follow-ups to the Bun 1.4 release. `HEAD` now reaches `GET` handlers and `stop()` settles after a force close, so routes stop registering both methods and shutdown stops racing a timer. That makes 1.4 the floor.
