### PR TITLE
fix: Reject all pending query promises when a query fails before resolving with a value for the first time

### DIFF
--- a/.changeset/yellow-apes-unite.md
+++ b/.changeset/yellow-apes-unite.md
@@ -1,0 +1,6 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: Reject all pending query promises when a query fails before resolving with a value for the first time
+  

--- a/packages/kit/src/runtime/client/remote-functions/instance.unhandled.svelte.spec.js
+++ b/packages/kit/src/runtime/client/remote-functions/instance.unhandled.svelte.spec.js
@@ -1,7 +1,7 @@
 /* eslint-disable n/prefer-global/process */
 import { describe, expect, test, vi } from 'vitest';
 import { tick } from 'svelte';
-import { HttpError } from '@sveltejs/kit/internal';
+import { HandledHttpError, HttpError } from '@sveltejs/kit/internal';
 
 // Mock `client.js` because the real one pulls in the SvelteKit
 // router/hydration machinery and resolves `$app/paths` to a server-side
@@ -91,5 +91,43 @@ describe('reactive consumption never produces unhandled rejections', () => {
 			globalThis.fetch = original_fetch;
 			tracker.stop();
 		}
+	});
+});
+
+describe('Query errors', () => {
+	test('a failed newer run rejects superseded awaiters before the first value', async () => {
+		const first = Promise.withResolvers();
+		const second = Promise.withResolvers();
+		let runs = 0;
+		const query = new Query('overlap', () => (runs++ === 0 ? first.promise : second.promise));
+
+		const first_result = Promise.resolve(query);
+		await tick();
+		const second_result = query.refresh();
+		second.reject(new Error('nope'));
+
+		const [first_error, second_error] = await Promise.all([
+			first_result.catch((error) => error),
+			second_result.catch((error) => error)
+		]);
+		expect(first_error).toBeInstanceOf(HandledHttpError);
+		expect(second_error).toBeInstanceOf(HandledHttpError);
+		expect(first_error.body).toBe(second_error.body);
+		expect(query.ready).toBe(false);
+		expect(query.current).toBeUndefined();
+	});
+
+	test('fail rejects existing awaiters before the first value', async () => {
+		const pending = Promise.withResolvers();
+		const query = new Query('fail', () => pending.promise);
+		const result = Promise.resolve(query);
+		await tick();
+
+		query.fail(new HttpError({ status: 503, message: 'unavailable' }));
+
+		await expect(result).rejects.toMatchObject({
+			status: 503,
+			body: { message: 'unavailable' }
+		});
 	});
 });

--- a/packages/kit/src/runtime/client/remote-functions/query/instance.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query/instance.svelte.js
@@ -49,7 +49,15 @@ export class Query {
 		this.#overrides.length;
 
 		return (resolve, reject) => {
-			const result = p.then(tick).then(() => /** @type {T} */ (this.#current));
+			const result = p.then(tick).then(() => {
+				if (!this.#ready) {
+					throw new HandledHttpError(
+						this.#error ?? { status: 500, message: 'Query resolved without a value' }
+					);
+				}
+
+				return /** @type {T} */ (this.#current);
+			});
 
 			if (resolve || reject) {
 				return result.then(resolve, reject);


### PR DESCRIPTION
Closes #16848

### Failure Sequence

1. Query request A starts before the query has ever loaded successfully. `#ready` is `false`.
2. A refresh starts request B while A is still pending.
3. B fails.
4. The query marks B’s error, but resolves A’s internal promise because B superseded it.
5. A’s public promise waits for `tick()`, then returns `#current`.
6. Because no request has succeeded, `#current` is `undefined`.
7. The component receives `undefined` rather than a rejected promise, so `<svelte:boundary>` does not render its failure snippet. Accessing something like `result.map(...)` instead throws later.

The same problem occurs when `fail()` clears pending requests.

### Fix

If we see that the internal promise has resolved but `#ready` has not yet been set, reject with `#error` (or a fallback, which shouldn't ever be reached).
