### PR TITLE
chore: don't change directory in the basics test setup

### DIFF
--- a/packages/kit/test/apps/basics/test/setup.js
+++ b/packages/kit/test/apps/basics/test/setup.js
@@ -1,10 +1,9 @@
 import fs from 'node:fs';
 import process from 'node:process';
 
-if (process.platform !== 'win32') {
-	process.chdir('src/routes/routing');
-	fs.rmSync('symlink-from', { recursive: true, force: true });
-	fs.symlinkSync('symlink-to', 'symlink-from', 'dir');
-}
-
 fs.rmSync('test/errors.jsonl', { force: true });
+
+if (process.platform !== 'win32') {
+	fs.rmSync('src/routes/routing/symlink-from', { recursive: true, force: true });
+	fs.symlinkSync('symlink-to', 'src/routes/routing/symlink-from', 'dir');
+}


### PR DESCRIPTION
`packages/kit/test/apps/basics/test/setup.js` changes directory to `src/routes/routing` to create the route symlink, then deletes `test/errors.jsonl` with a path relative to the app root. On non-Windows the `chdir` happens first, so the delete resolves under `src/routes/routing/` and the log written by `hooks.server.js` is never cleared between runs on Linux and macOS. `read_errors` in `test/utils.js` picks the last record matching a path, so a stale record from an earlier run can satisfy an assertion. The `rmSync` came in with #16664; the `chdir` block predates it.

Node resolves a symlink's target relative to the link's own directory, so the symlink can be created from the app root. Dropping the `chdir` keeps every path in the script relative to the same place, so line order can't matter again.