### PR TITLE
fix: build Bun apps that use server instrumentation

### DIFF
--- a/.changeset/bun-adapter-instrumented-build.md
+++ b/.changeset/bun-adapter-instrumented-build.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-bun': patch
+---
+
+fix: build apps that use server instrumentation

--- a/packages/adapter-bun/index.js
+++ b/packages/adapter-bun/index.js
@@ -170,9 +170,28 @@ export default function (opts = {}) {
 				if (!buildOptions.compile) entrypoints.push(start_file);
 			}
 
+			// Side-effect-only chunks (e.g. Svelte's events.js, kit's env re-export) compile to
+			// identical stubs whose content hashes collide on one output path, failing the build
+			// with "Multiple files share the same output path" (oven-sh/bun#37576). Resolving a
+			// distinct identity per importer keeps every emitted copy unique; delete this once
+			// the Bun fix ships.
 			const chunks_dir = path.resolve(server, 'chunks');
-			/** @type {Map<string, string | false>} */
+			/** @type {Map<string, string>} */
 			const side_effect_sources = new Map();
+			for (const { abs } of read_files_recursive(chunks_dir)) {
+				const source = fs.readFileSync(abs, 'utf8');
+				if (/^import\s+["'][^"']+["'];\s*export\s*\{\s*\};?\s*$/.test(source)) {
+					side_effect_sources.set(abs, source);
+				}
+			}
+
+			// only the stubs above, because a hook that matches without resolving sends Bun back
+			// to the filesystem, where the virtual entrypoints do not exist
+			const side_effect_filter = new RegExp(
+				`/(?:${[...side_effect_sources.keys()]
+					.map((file) => path.basename(file).replaceAll('.', '\\.'))
+					.join('|')})$`
+			);
 
 			/** @type {BunPlugin} */
 			const adapter_plugin = {
@@ -185,21 +204,12 @@ export default function (opts = {}) {
 						if (path === 'SERVER_OPTIONS') return { path: server_options_file };
 					});
 
-					// Side-effect-only chunks (e.g. Svelte's events.js, kit's env re-export) compile to
-					// identical stubs whose content hashes collide on one output path, failing the build
-					// with "Multiple files share the same output path" (oven-sh/bun#37576). Resolving a
-					// distinct identity per importer keeps every emitted copy unique; delete this once
-					// the Bun fix ships.
-					build.onResolve({ filter: /\.js$/ }, (args) => {
+					if (side_effect_sources.size === 0) return;
+
+					build.onResolve({ filter: side_effect_filter }, (args) => {
 						const file = path.resolve(args.resolveDir, args.path);
-						if (path.dirname(file) !== chunks_dir) return;
-						let source = side_effect_sources.get(file);
-						if (source === undefined) {
-							const text = fs.readFileSync(file, 'utf8');
-							source = /^import\s+["'][^"']+["'];\s*export\s*\{\s*\};?\s*$/.test(text) && text;
-							side_effect_sources.set(file, source);
-						}
-						if (source === false) return;
+						if (!side_effect_sources.has(file))
+							return virtual_files[file] ? { path: file } : undefined;
 						// The `?` suffix keeps dirname(path) inside chunks/ — Bun resolves the synthetic
 						// module's relative imports against that, ignoring onLoad's resolveDir.
 						return {

--- a/packages/adapter-bun/index.js
+++ b/packages/adapter-bun/index.js
@@ -189,7 +189,7 @@ export default function (opts = {}) {
 			// to the filesystem, where the virtual entrypoints do not exist
 			const side_effect_filter = new RegExp(
 				`/(?:${[...side_effect_sources.keys()]
-					.map((file) => path.basename(file).replaceAll('.', '\\.'))
+					.map((file) => path.basename(file).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
 					.join('|')})$`
 			);
 

--- a/packages/adapter-bun/test/adapter.spec.ts
+++ b/packages/adapter-bun/test/adapter.spec.ts
@@ -146,20 +146,19 @@ describe('Bun build configuration', () => {
 	});
 
 	test('gives side-effect-only chunks a per-importer identity so their copies cannot collide', async () => {
+		const chunks_dir = path.resolve('.svelte-kit/output/server/chunks');
+		mock_chunks(chunks_dir, { 'events.js': "import './other.js';\nexport {};\n" });
+
 		await adapter().adapt(create_builder());
 		const on_resolve = vi.fn();
 		const on_load = vi.fn();
 		bun.build.mock.calls[0][0].plugins[0].setup({ onResolve: on_resolve, onLoad: on_load });
 
-		const chunks_dir = path.resolve('.svelte-kit/output/server/chunks');
-		const resolve_chunk = on_resolve.mock.calls.find(
-			([options]) => String(options.filter) === String(/\.js$/)
-		)![1];
+		const resolve_chunk = on_resolve.mock.calls[1][1];
 		const load_chunk = on_load.mock.calls.find(
 			([options]) => options.namespace === 'adapter-bun-side-effect'
 		)![1];
 
-		vi.mocked(fs.readFileSync).mockReturnValue("import './other.js';\nexport {};\n");
 		const first = resolve_chunk({
 			path: './events.js',
 			resolveDir: chunks_dir,
@@ -173,7 +172,6 @@ describe('Bun build configuration', () => {
 		expect(first.namespace).toBe('adapter-bun-side-effect');
 		expect(first.path.startsWith(`${chunks_dir}/events.js?`)).toBe(true);
 		expect(first.path).not.toBe(second.path);
-		expect(fs.readFileSync).toHaveBeenCalledTimes(1);
 
 		const first_load = load_chunk({ path: first.path });
 		const second_load = load_chunk({ path: second.path });
@@ -181,19 +179,35 @@ describe('Bun build configuration', () => {
 		expect(first_load.contents).not.toBe(second_load.contents);
 
 		// chunks with real exports keep their shared identity
-		vi.mocked(fs.readFileSync).mockReturnValue('export const x = 1;\n');
 		expect(
 			resolve_chunk({ path: './real.js', resolveDir: chunks_dir, importer: `${chunks_dir}/a.js` })
 		).toBeUndefined();
+	});
 
-		// modules outside chunks/ are never rewritten
-		expect(
-			resolve_chunk({
-				path: './index.js',
-				resolveDir: path.resolve('.svelte-kit/output/server'),
-				importer: `${chunks_dir}/a.js`
-			})
-		).toBeUndefined();
+	test('leaves the plugin out when no chunk is side-effect-only', async () => {
+		mock_chunks(path.resolve('.svelte-kit/output/server/chunks'), {
+			'real.js': 'export const x = 1;\n'
+		});
+
+		await adapter().adapt(create_builder());
+		const on_resolve = vi.fn();
+		bun.build.mock.calls[0][0].plugins[0].setup({ onResolve: on_resolve, onLoad: vi.fn() });
+
+		expect(on_resolve).toHaveBeenCalledOnce();
+	});
+
+	test('keeps virtual entrypoints resolvable when a chunk shares their name', async () => {
+		const chunks_dir = path.resolve('.svelte-kit/output/server/chunks');
+		mock_chunks(chunks_dir, { 'start.js': "import './other.js';\nexport {};\n" });
+
+		await adapter().adapt(create_builder({ instrumentation: true }));
+		const on_resolve = vi.fn();
+		bun.build.mock.calls[0][0].plugins[0].setup({ onResolve: on_resolve, onLoad: vi.fn() });
+
+		// resolving nothing here would send Bun to the filesystem, where start.js does not exist
+		expect(on_resolve.mock.calls[1][1]({ path: start_file, resolveDir: package_dir })).toEqual({
+			path: start_file
+		});
 	});
 
 	test('passes supported advanced options while retaining reserved options', async () => {
@@ -486,6 +500,21 @@ describe('generated routes', () => {
 		).rejects.toThrow('Could not find server asset missing.txt');
 	});
 });
+
+function mock_chunks(chunks_dir: string, sources: Record<string, string>) {
+	vi.mocked(fs.readdirSync).mockImplementation((directory) =>
+		String(directory) === chunks_dir
+			? (Object.keys(sources).map((name) => ({
+					name,
+					parentPath: chunks_dir,
+					isFile: () => true
+				})) as unknown as ReturnType<typeof fs.readdirSync>)
+			: []
+	);
+	vi.mocked(fs.readFileSync).mockImplementation(
+		(file) => sources[path.basename(String(file))] as unknown as ReturnType<typeof fs.readFileSync>
+	);
+}
 
 function mock_files({
 	client = [],

--- a/packages/adapter-bun/test/apps/basic/test/server.test.js
+++ b/packages/adapter-bun/test/apps/basic/test/server.test.js
@@ -88,8 +88,9 @@ test('serves prerendered pages, endpoints, and canonical redirects', async ({ re
 });
 
 test('uses SvelteKit for non-GET requests that share a static pathname', async ({ request }) => {
+	// the adapter assumes TLS terminates upstream, so the origin it computes is https
 	const response = await request.post('/data.json', {
-		headers: { origin: 'http://localhost:4174' }
+		headers: { origin: 'https://localhost:4174' }
 	});
 	expect(response.status()).toBe(200);
 	expect(await response.json()).toEqual({ message: 'hello from a server endpoint' });


### PR DESCRIPTION
The side-effect chunk workaround in `packages/adapter-bun/index.js` registers `build.onResolve({ filter: /\.js$/ })` and returns undefined for anything outside `server/chunks/`. A `Bun.build` hook that matches without resolving sends Bun to the filesystem, past the `files` virtual entries. An app with `src/instrumentation.server.js` gets a virtual `src/start.js` entrypoint that exists nowhere on disk, so its build fails with `ModuleNotFound resolving ".../adapter-bun/src/start.js" (entry point)`.

The plugin now reads `server/chunks/` once up front, keeps the stubs it matches in `side_effect_sources`, and builds `side_effect_filter` from their basenames, so no other specifier reaches the hook. A path that still matches without being a stub resolves to its virtual entry when there is one.

The non-GET e2e test posted an `http` origin, which fails the CSRF check against the `https` origin the adapter computes. `platform-tests-bun.yml` runs on `workflow_dispatch` only, so neither of these showed up in CI.

#16880 is stacked on this.
