### PR TITLE
fix: evaluate dynamic image sources once

### DIFF
--- a/.changeset/pre/brave-images-declare.md
+++ b/.changeset/pre/brave-images-declare.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/enhanced-img': major
+---
+
+breaking: require Svelte 5.56 or later for declaration tag support

--- a/.changeset/pre/brave-images-declare.md
+++ b/.changeset/pre/brave-images-declare.md
@@ -1,5 +1,0 @@
----
-'@sveltejs/enhanced-img': major
----
-
-breaking: require Svelte 5.56 or later for declaration tag support

--- a/.changeset/pre/quiet-images-call.md
+++ b/.changeset/pre/quiet-images-call.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/enhanced-img': patch
+---
+
+fix: evaluate dynamic image source expressions once

--- a/packages/enhanced-img/package.json
+++ b/packages/enhanced-img/package.json
@@ -40,7 +40,6 @@
 	"dependencies": {
 		"magic-string": "^1.1.0",
 		"sharp": "^0.35.3",
-		"svelte-parse-markup": "^0.1.5",
 		"vite-imagetools": "^12.0.0",
 		"zimmerframe": "^1.1.4"
 	},

--- a/packages/enhanced-img/package.json
+++ b/packages/enhanced-img/package.json
@@ -53,7 +53,7 @@
 	},
 	"peerDependencies": {
 		"@sveltejs/vite-plugin-svelte": "^7.0.0",
-		"svelte": "^5.56.0",
+		"svelte": "^5.0.0",
 		"vite": ">=8.0.12"
 	},
 	"engines": {

--- a/packages/enhanced-img/package.json
+++ b/packages/enhanced-img/package.json
@@ -54,7 +54,7 @@
 	},
 	"peerDependencies": {
 		"@sveltejs/vite-plugin-svelte": "^7.0.0",
-		"svelte": "^5.0.0",
+		"svelte": "^5.56.0",
 		"vite": ">=8.0.12"
 	},
 	"engines": {

--- a/packages/enhanced-img/src/vite-plugin.js
+++ b/packages/enhanced-img/src/vite-plugin.js
@@ -444,6 +444,7 @@ function dynamic_img_to_picture(content, node, src_expression, src_var_name) {
 	// (they throw a compile error) and are only evaluated once, breaking reactivity when the
 	// expression depends on reactive state. `{@const}` is reactive, memoized, and works in both
 	// legacy and runes mode since Svelte 5.0.
+	// TODO use `{const ...}` when we switch to Svelte 6
 	if (src_expression) {
 		return `{#if true}{@const ${src_var_name} = ${src_expression}}\n${picture}\n{/if}`;
 	}

--- a/packages/enhanced-img/src/vite-plugin.js
+++ b/packages/enhanced-img/src/vite-plugin.js
@@ -88,12 +88,7 @@ export function image_plugin(imagetools_plugin) {
 							throw new Error('ExpressionTag has no range');
 						}
 						const src_expression = content.substring(start, end).trim();
-						const expression = src_attribute.expression;
-						const should_declare =
-							expression.type === 'CallExpression' ||
-							expression.type === 'ConditionalExpression' ||
-							(expression.type === 'ChainExpression' &&
-								expression.expression.type === 'CallExpression');
+						const should_declare = !is_reference(src_attribute.expression);
 						const src_var_name = should_declare ? generate_name() : src_expression;
 
 						s.update(
@@ -334,6 +329,15 @@ function serialize_img_attributes(content, attributes, details) {
  */
 function stringToNumber(param) {
 	return typeof param === 'string' ? parseInt(param) : param;
+}
+
+/**
+ * @param {import('estree').Expression | import('estree').Super} expression
+ */
+function is_reference(expression) {
+	if (expression.type === 'Identifier') return true;
+	if (expression.type !== 'MemberExpression' || expression.computed) return false;
+	return is_reference(expression.object);
 }
 
 /**

--- a/packages/enhanced-img/src/vite-plugin.js
+++ b/packages/enhanced-img/src/vite-plugin.js
@@ -89,11 +89,12 @@ export function image_plugin(imagetools_plugin) {
 						}
 						const src_expression = content.substring(start, end).trim();
 						const expression = src_attribute.expression;
-						const is_call =
+						const should_declare =
 							expression.type === 'CallExpression' ||
+							expression.type === 'ConditionalExpression' ||
 							(expression.type === 'ChainExpression' &&
 								expression.expression.type === 'CallExpression');
-						const src_var_name = is_call ? generate_name() : src_expression;
+						const src_var_name = should_declare ? generate_name() : src_expression;
 
 						s.update(
 							node.start,
@@ -101,7 +102,7 @@ export function image_plugin(imagetools_plugin) {
 							dynamic_img_to_picture(
 								content,
 								node,
-								is_call ? src_expression : undefined,
+								should_declare ? src_expression : undefined,
 								src_var_name
 							)
 						);

--- a/packages/enhanced-img/src/vite-plugin.js
+++ b/packages/enhanced-img/src/vite-plugin.js
@@ -78,9 +78,14 @@ export function image_plugin(imagetools_plugin) {
 						if (typeof start !== 'number' || typeof end !== 'number') {
 							throw new Error('ExpressionTag has no range');
 						}
-						const src_var_name = content.substring(start, end).trim();
+						const src_expression = content.substring(start, end).trim();
+						const src_var_name = `__sveltekit_enhanced_img_${node.start}`;
 
-						s.update(node.start, node.end, dynamic_img_to_picture(content, node, src_var_name));
+						s.update(
+							node.start,
+							node.end,
+							dynamic_img_to_picture(content, node, src_expression, src_var_name)
+						);
 						return;
 					}
 
@@ -355,9 +360,10 @@ function to_value(src) {
  * For images like `<img src={manually_imported} />`
  * @param {string} content
  * @param {import('svelte/compiler').AST.RegularElement} node
+ * @param {string} src_expression
  * @param {string} src_var_name
  */
-function dynamic_img_to_picture(content, node, src_var_name) {
+function dynamic_img_to_picture(content, node, src_expression, src_var_name) {
 	const attributes = node.attributes;
 	/**
 	 * @param attribute_name {string}
@@ -377,7 +383,8 @@ function dynamic_img_to_picture(content, node, src_var_name) {
 		attributes.splice(size_index, 1);
 	}
 
-	return `{#if typeof ${src_var_name} === 'string'}
+	return `{const ${src_var_name} = ${src_expression}}
+{#if typeof ${src_var_name} === 'string'}
 	{#if import.meta.env.DEV && ${!width_index && !height_index}}
 		{${src_var_name}} was not enhanced. Cannot determine dimensions.
 	{:else}

--- a/packages/enhanced-img/src/vite-plugin.js
+++ b/packages/enhanced-img/src/vite-plugin.js
@@ -4,8 +4,7 @@ import { existsSync } from 'node:fs';
 import path from 'node:path';
 import MagicString from 'magic-string';
 import sharp from 'sharp';
-import { parse as parse_svelte } from 'svelte/compiler';
-import { parse } from 'svelte-parse-markup';
+import { parse } from 'svelte/compiler';
 import { walk } from 'zimmerframe';
 
 // TODO: expose this in vite-imagetools rather than duplicating it
@@ -63,7 +62,7 @@ export function image_plugin(imagetools_plugin) {
 				const identifiers = new Set();
 				let generated_name_index = 0;
 
-				walk(/** @type {any} */ (parse_svelte(content, { filename, modern: true })), null, {
+				walk(/** @type {any} */ (ast), null, {
 					_(node, { next }) {
 						if (node.type === 'Identifier') identifiers.add(node.name);
 						next();
@@ -86,12 +85,12 @@ export function image_plugin(imagetools_plugin) {
 				async function update_element(node, src_attribute) {
 					if (src_attribute.type === 'ExpressionTag') {
 						const start =
-							'end' in src_attribute.expression
-								? src_attribute.expression.end
-								: src_attribute.expression.range?.[0];
-						const end =
 							'start' in src_attribute.expression
 								? src_attribute.expression.start
+								: src_attribute.expression.range?.[0];
+						const end =
+							'end' in src_attribute.expression
+								? src_attribute.expression.end
 								: src_attribute.expression.range?.[1];
 
 						if (typeof start !== 'number' || typeof end !== 'number') {

--- a/packages/enhanced-img/src/vite-plugin.js
+++ b/packages/enhanced-img/src/vite-plugin.js
@@ -1,3 +1,4 @@
+/** @import { Expression, Super } from 'estree' */
 /** @import { AST } from 'svelte/compiler' */
 import { existsSync } from 'node:fs';
 import path from 'node:path';
@@ -332,7 +333,7 @@ function stringToNumber(param) {
 }
 
 /**
- * @param {import('estree').Expression | import('estree').Super} expression
+ * @param {Expression | Super} expression
  */
 function is_reference(expression) {
 	if (expression.type === 'Identifier') return true;

--- a/packages/enhanced-img/src/vite-plugin.js
+++ b/packages/enhanced-img/src/vite-plugin.js
@@ -416,7 +416,7 @@ function dynamic_img_to_picture(content, node, src_expression, src_var_name) {
 		attributes.splice(size_index, 1);
 	}
 
-	return `${src_expression ? `{const ${src_var_name} = ${src_expression}}\n` : ''}{#if typeof ${src_var_name} === 'string'}
+	const picture = `{#if typeof ${src_var_name} === 'string'}
 	{#if import.meta.env.DEV && ${!width_index && !height_index}}
 		{${src_var_name}} was not enhanced. Cannot determine dimensions.
 	{:else}
@@ -436,4 +436,17 @@ function dynamic_img_to_picture(content, node, src_expression, src_var_name) {
 		})} />
 	</picture>
 {/if}`;
+
+	// When the source is a computed expression we cache it in a variable to avoid evaluating it
+	// multiple times (e.g. calling a function once per template position). We use a reactive
+	// `{@const}` — wrapped in an `{#if true}` block so it's valid at this position — rather than a
+	// plain `{const}` declaration tag. Declaration tags cannot be used in legacy-mode components
+	// (they throw a compile error) and are only evaluated once, breaking reactivity when the
+	// expression depends on reactive state. `{@const}` is reactive, memoized, and works in both
+	// legacy and runes mode since Svelte 5.0.
+	if (src_expression) {
+		return `{#if true}{@const ${src_var_name} = ${src_expression}}\n${picture}\n{/if}`;
+	}
+
+	return picture;
 }

--- a/packages/enhanced-img/src/vite-plugin.js
+++ b/packages/enhanced-img/src/vite-plugin.js
@@ -4,6 +4,7 @@ import { existsSync } from 'node:fs';
 import path from 'node:path';
 import MagicString from 'magic-string';
 import sharp from 'sharp';
+import { parse as parse_svelte } from 'svelte/compiler';
 import { parse } from 'svelte-parse-markup';
 import { walk } from 'zimmerframe';
 
@@ -59,13 +60,21 @@ export function image_plugin(imagetools_plugin) {
 				 * @type {Map<string, string>}
 				 */
 				const imports = new Map();
+				const identifiers = new Set();
 				let generated_name_index = 0;
+
+				walk(/** @type {any} */ (parse_svelte(content, { filename, modern: true })), null, {
+					_(node, { next }) {
+						if (node.type === 'Identifier') identifiers.add(node.name);
+						next();
+					}
+				});
 
 				function generate_name() {
 					while (true) {
 						const index = generated_name_index++;
 						const name = `__img${index ? `_${index}` : ''}`;
-						if (!new RegExp(`\\b${name}\\b`).test(content)) return name;
+						if (!identifiers.has(name)) return name;
 					}
 				}
 

--- a/packages/enhanced-img/src/vite-plugin.js
+++ b/packages/enhanced-img/src/vite-plugin.js
@@ -58,6 +58,19 @@ export function image_plugin(imagetools_plugin) {
 				 * @type {Map<string, string>}
 				 */
 				const imports = new Map();
+				const generated_names = new Set();
+
+				function generate_name() {
+					let suffix = '';
+					while (true) {
+						const name = `__img${suffix}`;
+						if (!generated_names.has(name) && !new RegExp(`\\b${name}\\b`).test(content)) {
+							generated_names.add(name);
+							return name;
+						}
+						suffix = suffix ? `_${Number(suffix.slice(1)) + 1}` : '_1';
+					}
+				}
 
 				/**
 				 * @param {import('svelte/compiler').AST.RegularElement} node
@@ -79,12 +92,22 @@ export function image_plugin(imagetools_plugin) {
 							throw new Error('ExpressionTag has no range');
 						}
 						const src_expression = content.substring(start, end).trim();
-						const src_var_name = `__sveltekit_enhanced_img_${node.start}`;
+						const expression = src_attribute.expression;
+						const is_call =
+							expression.type === 'CallExpression' ||
+							(expression.type === 'ChainExpression' &&
+								expression.expression.type === 'CallExpression');
+						const src_var_name = is_call ? generate_name() : src_expression;
 
 						s.update(
 							node.start,
 							node.end,
-							dynamic_img_to_picture(content, node, src_expression, src_var_name)
+							dynamic_img_to_picture(
+								content,
+								node,
+								is_call ? src_expression : undefined,
+								src_var_name
+							)
 						);
 						return;
 					}
@@ -360,7 +383,7 @@ function to_value(src) {
  * For images like `<img src={manually_imported} />`
  * @param {string} content
  * @param {import('svelte/compiler').AST.RegularElement} node
- * @param {string} src_expression
+ * @param {string | undefined} src_expression
  * @param {string} src_var_name
  */
 function dynamic_img_to_picture(content, node, src_expression, src_var_name) {
@@ -383,8 +406,7 @@ function dynamic_img_to_picture(content, node, src_expression, src_var_name) {
 		attributes.splice(size_index, 1);
 	}
 
-	return `{const ${src_var_name} = ${src_expression}}
-{#if typeof ${src_var_name} === 'string'}
+	return `${src_expression ? `{const ${src_var_name} = ${src_expression}}\n` : ''}{#if typeof ${src_var_name} === 'string'}
 	{#if import.meta.env.DEV && ${!width_index && !height_index}}
 		{${src_var_name}} was not enhanced. Cannot determine dimensions.
 	{:else}

--- a/packages/enhanced-img/src/vite-plugin.js
+++ b/packages/enhanced-img/src/vite-plugin.js
@@ -58,17 +58,13 @@ export function image_plugin(imagetools_plugin) {
 				 * @type {Map<string, string>}
 				 */
 				const imports = new Map();
-				const generated_names = new Set();
+				let generated_name_index = 0;
 
 				function generate_name() {
-					let suffix = '';
 					while (true) {
-						const name = `__img${suffix}`;
-						if (!generated_names.has(name) && !new RegExp(`\\b${name}\\b`).test(content)) {
-							generated_names.add(name);
-							return name;
-						}
-						suffix = suffix ? `_${Number(suffix.slice(1)) + 1}` : '_1';
+						const index = generated_name_index++;
+						const name = `__img${index ? `_${index}` : ''}`;
+						if (!new RegExp(`\\b${name}\\b`).test(content)) return name;
 					}
 				}
 

--- a/packages/enhanced-img/test/Input.svelte
+++ b/packages/enhanced-img/test/Input.svelte
@@ -5,6 +5,7 @@
 	const src = manual_image1;
 	const images = [manual_image1, manual_image2];
 	const get_image = (image_key: number) => images[image_key];
+	const __img = 'existing declaration';
 
 	let foo: string = 'bar';
 </script>
@@ -51,6 +52,10 @@
 
 {#each images as _, i}
 	<enhanced:img src={get_image(i)} alt="opt-in test" />
+{/each}
+
+{#each images as _, j}
+	<enhanced:img src={get_image(j)} alt="collision test" />
 {/each}
 
 <picture>

--- a/packages/enhanced-img/test/Input.svelte
+++ b/packages/enhanced-img/test/Input.svelte
@@ -58,6 +58,8 @@
 	<enhanced:img src={get_image(j)} alt="collision test" />
 {/each}
 
+<enhanced:img src={foo ? manual_image1 : manual_image2} alt="conditional test" />
+
 <picture>
 	<source src="./dev.avif" />
 	<source srcset="./dev.avif 500v ./bar.avif 100v" />

--- a/packages/enhanced-img/test/Input.svelte
+++ b/packages/enhanced-img/test/Input.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 	import manual_image1 from './no.png';
 	import manual_image2 from './no.svg';
+	import { default as __img } from './dev.png';
 
 	const src = manual_image1;
 	const images = [manual_image1, manual_image2];
 	const object = { image: manual_image1 };
 	const get_image = (image_key: number) => images[image_key];
-	const __img = 'existing declaration';
 
 	let foo: string = 'bar';
 </script>

--- a/packages/enhanced-img/test/Input.svelte
+++ b/packages/enhanced-img/test/Input.svelte
@@ -4,6 +4,7 @@
 
 	const src = manual_image1;
 	const images = [manual_image1, manual_image2];
+	const object = { image: manual_image1 };
 	const get_image = (image_key: number) => images[image_key];
 	const __img = 'existing declaration';
 
@@ -59,6 +60,8 @@
 {/each}
 
 <enhanced:img src={foo ? manual_image1 : manual_image2} alt="conditional test" />
+
+<enhanced:img src={object.image} alt="member access test" />
 
 <picture>
 	<source src="./dev.avif" />

--- a/packages/enhanced-img/test/Output.svelte
+++ b/packages/enhanced-img/test/Output.svelte
@@ -110,6 +110,23 @@
 {/if}
 {/each}
 
+{const __img_3 = foo ? manual_image1 : manual_image2}
+{#if typeof __img_3 === 'string'}
+	{#if
+	import.meta.env.DEV && false}
+		{__img_3} was not enhanced. Cannot determine dimensions.
+	{:else}
+		<img src={__img_3} alt="conditional test" />
+	{/if}
+{:else}
+	<picture>
+		{#each Object.entries(__img_3.sources) as [format, srcset]}
+			<source {srcset} type={'image/' + format} />
+		{/each}
+		<img src={__img_3.img.src} alt="conditional test" width={__img_3.img.w} height={__img_3.img.h} />
+	</picture>
+{/if}
+
 <picture>
 	<source src="./dev.avif" />
 	<source srcset="./dev.avif 500v ./bar.avif 100v" />

--- a/packages/enhanced-img/test/Output.svelte
+++ b/packages/enhanced-img/test/Output.svelte
@@ -7,6 +7,7 @@
 	const src = manual_image1;
 	const images = [manual_image1, manual_image2];
 	const get_image = (image_key: number) => images[image_key];
+	const __img = 'existing declaration';
 
 	let foo: string = 'bar';
 </script>
@@ -37,57 +38,74 @@
 
 <picture><source srcset="/1 1440w, /2 960w" type="image/avif" /><source srcset="/3 1440w, /4 960w" type="image/webp" /><source srcset="5 1440w, /6 960w" type="image/png" /><img src="/7" alt="absolute path test" width=1440 height=1440 /></picture>
 
-{const __sveltekit_enhanced_img_1072 = src}
-{#if typeof __sveltekit_enhanced_img_1072 === 'string'}
-	{#if 
+{#if typeof src === 'string'}
+	{#if
 	import.meta.env.DEV && false}
-		{__sveltekit_enhanced_img_1072} was not enhanced. Cannot determine dimensions.
+		{src} was not enhanced. Cannot determine dimensions.
 	{:else}
-		<img src={__sveltekit_enhanced_img_1072} alt="attribute shorthand test" />
+		<img src={src} alt="attribute shorthand test" />
 	{/if}
 {:else}
 	<picture>
-		{#each Object.entries(__sveltekit_enhanced_img_1072.sources) as [format, srcset]}
+		{#each Object.entries(src.sources) as [format, srcset]}
 			<source {srcset} type={'image/' + format} />
 		{/each}
-		<img src={__sveltekit_enhanced_img_1072.img.src} alt="attribute shorthand test" width={__sveltekit_enhanced_img_1072.img.w} height={__sveltekit_enhanced_img_1072.img.h} />
+		<img src={src.img.src} alt="attribute shorthand test" width={src.img.w} height={src.img.h} />
 	</picture>
 {/if}
 
 {#each images as image}
-	{const __sveltekit_enhanced_img_1152 = image}
-{#if typeof __sveltekit_enhanced_img_1152 === 'string'}
-	{#if 
+	{#if typeof image === 'string'}
+	{#if
 	import.meta.env.DEV && false}
-		{__sveltekit_enhanced_img_1152} was not enhanced. Cannot determine dimensions.
+		{image} was not enhanced. Cannot determine dimensions.
 	{:else}
-		<img src={__sveltekit_enhanced_img_1152} alt="opt-in test" />
+		<img src={image} alt="opt-in test" />
 	{/if}
 {:else}
 	<picture>
-		{#each Object.entries(__sveltekit_enhanced_img_1152.sources) as [format, srcset]}
+		{#each Object.entries(image.sources) as [format, srcset]}
 			<source {srcset} type={'image/' + format} />
 		{/each}
-		<img src={__sveltekit_enhanced_img_1152.img.src} alt="opt-in test" width={__sveltekit_enhanced_img_1152.img.w} height={__sveltekit_enhanced_img_1152.img.h} />
+		<img src={image.img.src} alt="opt-in test" width={image.img.w} height={image.img.h} />
 	</picture>
 {/if}
 {/each}
 
 {#each images as _, i}
-	{const __sveltekit_enhanced_img_1232 = get_image(i)}
-{#if typeof __sveltekit_enhanced_img_1232 === 'string'}
-	{#if 
+	{const __img_1 = get_image(i)}
+{#if typeof __img_1 === 'string'}
+	{#if
 	import.meta.env.DEV && false}
-		{__sveltekit_enhanced_img_1232} was not enhanced. Cannot determine dimensions.
+		{__img_1} was not enhanced. Cannot determine dimensions.
 	{:else}
-		<img src={__sveltekit_enhanced_img_1232} alt="opt-in test" />
+		<img src={__img_1} alt="opt-in test" />
 	{/if}
 {:else}
 	<picture>
-		{#each Object.entries(__sveltekit_enhanced_img_1232.sources) as [format, srcset]}
+		{#each Object.entries(__img_1.sources) as [format, srcset]}
 			<source {srcset} type={'image/' + format} />
 		{/each}
-		<img src={__sveltekit_enhanced_img_1232.img.src} alt="opt-in test" width={__sveltekit_enhanced_img_1232.img.w} height={__sveltekit_enhanced_img_1232.img.h} />
+		<img src={__img_1.img.src} alt="opt-in test" width={__img_1.img.w} height={__img_1.img.h} />
+	</picture>
+{/if}
+{/each}
+
+{#each images as _, j}
+	{const __img_2 = get_image(j)}
+{#if typeof __img_2 === 'string'}
+	{#if
+	import.meta.env.DEV && false}
+		{__img_2} was not enhanced. Cannot determine dimensions.
+	{:else}
+		<img src={__img_2} alt="collision test" />
+	{/if}
+{:else}
+	<picture>
+		{#each Object.entries(__img_2.sources) as [format, srcset]}
+			<source {srcset} type={'image/' + format} />
+		{/each}
+		<img src={__img_2.img.src} alt="collision test" width={__img_2.img.w} height={__img_2.img.h} />
 	</picture>
 {/if}
 {/each}

--- a/packages/enhanced-img/test/Output.svelte
+++ b/packages/enhanced-img/test/Output.svelte
@@ -1,14 +1,15 @@
 <script lang="ts">
-	
+
 	import manual_image1 from './no.png';
-	
+
 	import manual_image2 from './no.svg';
+
+	import { default as __img } from './dev.png';
 
 	const src = manual_image1;
 	const images = [manual_image1, manual_image2];
 	const object = { image: manual_image1 };
 	const get_image = (image_key: number) => images[image_key];
-	const __img = 'existing declaration';
 
 	let foo: string = 'bar';
 </script>

--- a/packages/enhanced-img/test/Output.svelte
+++ b/packages/enhanced-img/test/Output.svelte
@@ -37,54 +37,57 @@
 
 <picture><source srcset="/1 1440w, /2 960w" type="image/avif" /><source srcset="/3 1440w, /4 960w" type="image/webp" /><source srcset="5 1440w, /6 960w" type="image/png" /><img src="/7" alt="absolute path test" width=1440 height=1440 /></picture>
 
-{#if typeof src === 'string'}
+{const __sveltekit_enhanced_img_1072 = src}
+{#if typeof __sveltekit_enhanced_img_1072 === 'string'}
 	{#if 
 	import.meta.env.DEV && false}
-		{src} was not enhanced. Cannot determine dimensions.
+		{__sveltekit_enhanced_img_1072} was not enhanced. Cannot determine dimensions.
 	{:else}
-		<img src={src} alt="attribute shorthand test" />
+		<img src={__sveltekit_enhanced_img_1072} alt="attribute shorthand test" />
 	{/if}
 {:else}
 	<picture>
-		{#each Object.entries(src.sources) as [format, srcset]}
+		{#each Object.entries(__sveltekit_enhanced_img_1072.sources) as [format, srcset]}
 			<source {srcset} type={'image/' + format} />
 		{/each}
-		<img src={src.img.src} alt="attribute shorthand test" width={src.img.w} height={src.img.h} />
+		<img src={__sveltekit_enhanced_img_1072.img.src} alt="attribute shorthand test" width={__sveltekit_enhanced_img_1072.img.w} height={__sveltekit_enhanced_img_1072.img.h} />
 	</picture>
 {/if}
 
 {#each images as image}
-	{#if typeof image === 'string'}
+	{const __sveltekit_enhanced_img_1152 = image}
+{#if typeof __sveltekit_enhanced_img_1152 === 'string'}
 	{#if 
 	import.meta.env.DEV && false}
-		{image} was not enhanced. Cannot determine dimensions.
+		{__sveltekit_enhanced_img_1152} was not enhanced. Cannot determine dimensions.
 	{:else}
-		<img src={image} alt="opt-in test" />
+		<img src={__sveltekit_enhanced_img_1152} alt="opt-in test" />
 	{/if}
 {:else}
 	<picture>
-		{#each Object.entries(image.sources) as [format, srcset]}
+		{#each Object.entries(__sveltekit_enhanced_img_1152.sources) as [format, srcset]}
 			<source {srcset} type={'image/' + format} />
 		{/each}
-		<img src={image.img.src} alt="opt-in test" width={image.img.w} height={image.img.h} />
+		<img src={__sveltekit_enhanced_img_1152.img.src} alt="opt-in test" width={__sveltekit_enhanced_img_1152.img.w} height={__sveltekit_enhanced_img_1152.img.h} />
 	</picture>
 {/if}
 {/each}
 
 {#each images as _, i}
-	{#if typeof get_image(i) === 'string'}
+	{const __sveltekit_enhanced_img_1232 = get_image(i)}
+{#if typeof __sveltekit_enhanced_img_1232 === 'string'}
 	{#if 
 	import.meta.env.DEV && false}
-		{get_image(i)} was not enhanced. Cannot determine dimensions.
+		{__sveltekit_enhanced_img_1232} was not enhanced. Cannot determine dimensions.
 	{:else}
-		<img src={get_image(i)} alt="opt-in test" />
+		<img src={__sveltekit_enhanced_img_1232} alt="opt-in test" />
 	{/if}
 {:else}
 	<picture>
-		{#each Object.entries(get_image(i).sources) as [format, srcset]}
+		{#each Object.entries(__sveltekit_enhanced_img_1232.sources) as [format, srcset]}
 			<source {srcset} type={'image/' + format} />
 		{/each}
-		<img src={get_image(i).img.src} alt="opt-in test" width={get_image(i).img.w} height={get_image(i).img.h} />
+		<img src={__sveltekit_enhanced_img_1232.img.src} alt="opt-in test" width={__sveltekit_enhanced_img_1232.img.w} height={__sveltekit_enhanced_img_1232.img.h} />
 	</picture>
 {/if}
 {/each}

--- a/packages/enhanced-img/test/Output.svelte
+++ b/packages/enhanced-img/test/Output.svelte
@@ -6,6 +6,7 @@
 
 	const src = manual_image1;
 	const images = [manual_image1, manual_image2];
+	const object = { image: manual_image1 };
 	const get_image = (image_key: number) => images[image_key];
 	const __img = 'existing declaration';
 
@@ -124,6 +125,22 @@
 			<source {srcset} type={'image/' + format} />
 		{/each}
 		<img src={__img_3.img.src} alt="conditional test" width={__img_3.img.w} height={__img_3.img.h} />
+	</picture>
+{/if}
+
+{#if typeof object.image === 'string'}
+	{#if
+	import.meta.env.DEV && false}
+		{object.image} was not enhanced. Cannot determine dimensions.
+	{:else}
+		<img src={object.image} alt="member access test" />
+	{/if}
+{:else}
+	<picture>
+		{#each Object.entries(object.image.sources) as [format, srcset]}
+			<source {srcset} type={'image/' + format} />
+		{/each}
+		<img src={object.image.img.src} alt="member access test" width={object.image.img.w} height={object.image.img.h} />
 	</picture>
 {/if}
 

--- a/packages/enhanced-img/test/Output.svelte
+++ b/packages/enhanced-img/test/Output.svelte
@@ -75,7 +75,7 @@
 {/each}
 
 {#each images as _, i}
-	{const __img_1 = get_image(i)}
+	{#if true}{@const __img_1 = get_image(i)}
 {#if typeof __img_1 === 'string'}
 	{#if
 	import.meta.env.DEV && false}
@@ -91,10 +91,11 @@
 		<img src={__img_1.img.src} alt="opt-in test" width={__img_1.img.w} height={__img_1.img.h} />
 	</picture>
 {/if}
+{/if}
 {/each}
 
 {#each images as _, j}
-	{const __img_2 = get_image(j)}
+	{#if true}{@const __img_2 = get_image(j)}
 {#if typeof __img_2 === 'string'}
 	{#if
 	import.meta.env.DEV && false}
@@ -110,9 +111,10 @@
 		<img src={__img_2.img.src} alt="collision test" width={__img_2.img.w} height={__img_2.img.h} />
 	</picture>
 {/if}
+{/if}
 {/each}
 
-{const __img_3 = foo ? manual_image1 : manual_image2}
+{#if true}{@const __img_3 = foo ? manual_image1 : manual_image2}
 {#if typeof __img_3 === 'string'}
 	{#if
 	import.meta.env.DEV && false}
@@ -127,6 +129,7 @@
 		{/each}
 		<img src={__img_3.img.src} alt="conditional test" width={__img_3.img.w} height={__img_3.img.h} />
 	</picture>
+{/if}
 {/if}
 
 {#if typeof object.image === 'string'}

--- a/packages/enhanced-img/test/markup-plugin.spec.js
+++ b/packages/enhanced-img/test/markup-plugin.spec.js
@@ -46,6 +46,7 @@ it('Image preprocess snapshot test', async () => {
 	expect(transformed_code.match(/get_image\(j\)/g)).toHaveLength(1);
 	expect(transformed_code).toContain('{const __img_1 = get_image(i)}');
 	expect(transformed_code).toContain('{const __img_2 = get_image(j)}');
+	expect(transformed_code).toContain('{const __img_3 = foo ? manual_image1 : manual_image2}');
 	expect(transformed_code).not.toContain('{const __img_1 = src}');
 	expect(transformed_code).not.toContain('{const __img_1 = image}');
 	expect(() => compile(transformed_code, { filename })).not.toThrow();

--- a/packages/enhanced-img/test/markup-plugin.spec.js
+++ b/packages/enhanced-img/test/markup-plugin.spec.js
@@ -1,5 +1,6 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { compile } from 'svelte/compiler';
 import { expect, it } from 'vitest';
 import { image_plugin, parse_object } from '../src/vite-plugin.js';
 
@@ -39,9 +40,13 @@ it('Image preprocess snapshot test', async () => {
 	if (!transformed) throw new Error('transform unexpectedly returned no results');
 	if (typeof transformed === 'string') throw new Error('transform did not return a sourcemap');
 	if (!transformed.code) throw new Error('transform did not return any code');
+	const transformed_code = transformed.code.toString();
+
+	expect(transformed_code.match(/get_image\(i\)/g)).toHaveLength(1);
+	expect(() => compile(transformed_code, { filename })).not.toThrow();
 
 	// Make imports readable
-	const ouput = transformed.code.toString().replace(/import/g, '\n\timport');
+	const ouput = transformed_code.replace(/import/g, '\n\timport');
 
 	await expect(ouput).toMatchFileSnapshot('./Output.svelte');
 });

--- a/packages/enhanced-img/test/markup-plugin.spec.js
+++ b/packages/enhanced-img/test/markup-plugin.spec.js
@@ -44,12 +44,12 @@ it('Image preprocess snapshot test', async () => {
 
 	expect(transformed_code.match(/get_image\(i\)/g)).toHaveLength(1);
 	expect(transformed_code.match(/get_image\(j\)/g)).toHaveLength(1);
-	expect(transformed_code).toContain('{const __img_1 = get_image(i)}');
-	expect(transformed_code).toContain('{const __img_2 = get_image(j)}');
-	expect(transformed_code).toContain('{const __img_3 = foo ? manual_image1 : manual_image2}');
-	expect(transformed_code).not.toMatch(/{const __img(?:_\d+)? = src}/);
-	expect(transformed_code).not.toMatch(/{const __img(?:_\d+)? = image}/);
-	expect(transformed_code).not.toMatch(/{const __img(?:_\d+)? = object\.image}/);
+	expect(transformed_code).toContain('{@const __img_1 = get_image(i)}');
+	expect(transformed_code).toContain('{@const __img_2 = get_image(j)}');
+	expect(transformed_code).toContain('{@const __img_3 = foo ? manual_image1 : manual_image2}');
+	expect(transformed_code).not.toMatch(/{@const __img(?:_\d+)? = src}/);
+	expect(transformed_code).not.toMatch(/{@const __img(?:_\d+)? = image}/);
+	expect(transformed_code).not.toMatch(/{@const __img(?:_\d+)? = object\.image}/);
 	expect(() => compile(transformed_code, { filename })).not.toThrow();
 
 	// Make imports readable

--- a/packages/enhanced-img/test/markup-plugin.spec.js
+++ b/packages/enhanced-img/test/markup-plugin.spec.js
@@ -43,10 +43,15 @@ it('Image preprocess snapshot test', async () => {
 	const transformed_code = transformed.code.toString();
 
 	expect(transformed_code.match(/get_image\(i\)/g)).toHaveLength(1);
+	expect(transformed_code.match(/get_image\(j\)/g)).toHaveLength(1);
+	expect(transformed_code).toContain('{const __img_1 = get_image(i)}');
+	expect(transformed_code).toContain('{const __img_2 = get_image(j)}');
+	expect(transformed_code).not.toContain('{const __img_1 = src}');
+	expect(transformed_code).not.toContain('{const __img_1 = image}');
 	expect(() => compile(transformed_code, { filename })).not.toThrow();
 
 	// Make imports readable
-	const ouput = transformed_code.replace(/import/g, '\n\timport');
+	const ouput = transformed_code.replace(/import/g, '\n\timport').replaceAll('{#if \n', '{#if\n');
 
 	await expect(ouput).toMatchFileSnapshot('./Output.svelte');
 });

--- a/packages/enhanced-img/test/markup-plugin.spec.js
+++ b/packages/enhanced-img/test/markup-plugin.spec.js
@@ -53,7 +53,10 @@ it('Image preprocess snapshot test', async () => {
 	expect(() => compile(transformed_code, { filename })).not.toThrow();
 
 	// Make imports readable
-	const ouput = transformed_code.replace(/import/g, '\n\timport').replaceAll('{#if \n', '{#if\n');
+	const ouput = transformed_code
+		.replace(/import/g, '\n\timport')
+		.replaceAll('{#if \n', '{#if\n')
+		.replace(/^[\t ]+$/gm, '');
 
 	await expect(ouput).toMatchFileSnapshot('./Output.svelte');
 });

--- a/packages/enhanced-img/test/markup-plugin.spec.js
+++ b/packages/enhanced-img/test/markup-plugin.spec.js
@@ -47,8 +47,9 @@ it('Image preprocess snapshot test', async () => {
 	expect(transformed_code).toContain('{const __img_1 = get_image(i)}');
 	expect(transformed_code).toContain('{const __img_2 = get_image(j)}');
 	expect(transformed_code).toContain('{const __img_3 = foo ? manual_image1 : manual_image2}');
-	expect(transformed_code).not.toContain('{const __img_1 = src}');
-	expect(transformed_code).not.toContain('{const __img_1 = image}');
+	expect(transformed_code).not.toMatch(/{const __img(?:_\d+)? = src}/);
+	expect(transformed_code).not.toMatch(/{const __img(?:_\d+)? = image}/);
+	expect(transformed_code).not.toMatch(/{const __img(?:_\d+)? = object\.image}/);
 	expect(() => compile(transformed_code, { filename })).not.toThrow();
 
 	// Make imports readable

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -515,9 +515,6 @@ importers:
       sharp:
         specifier: ^0.35.3
         version: 0.35.3(@types/node@22.19.19)
-      svelte-parse-markup:
-        specifier: ^0.1.5
-        version: 0.1.5(svelte@5.56.8(@typescript-eslint/types@8.61.1))
       vite-imagetools:
         specifier: ^12.0.0
         version: 12.0.0(@types/node@22.19.19)(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(jiti@2.4.2)(yaml@2.9.0))
@@ -4240,11 +4237,6 @@ packages:
       svelte:
         optional: true
 
-  svelte-parse-markup@0.1.5:
-    resolution: {integrity: sha512-T6mqZrySltPCDwfKXWQ6zehipVLk4GWfH1zCMGgRtLlOIFPuw58ZxVYxVvotMJgJaurKi1i14viB2GIRKXeJTQ==}
-    peerDependencies:
-      svelte: ^3.0.0 || ^4.0.0 || ^5.0.0-next.1
-
   svelte-preprocess@6.0.5:
     resolution: {integrity: sha512-sgwew5yV/2eMeQobIWgAxCNarKwiTUDIc3siAUbq3sp0G6ONtzk0W+wJihMdqjbYb3iGU3ubpGv0usnnuXT3qg==}
     engines: {node: '>= 18.0.0'}
@@ -6923,10 +6915,6 @@ snapshots:
       postcss-selector-parser: 7.1.4
       semver: 7.8.5
     optionalDependencies:
-      svelte: 5.56.8(@typescript-eslint/types@8.61.1)
-
-  svelte-parse-markup@0.1.5(svelte@5.56.8(@typescript-eslint/types@8.61.1)):
-    dependencies:
       svelte: 5.56.8(@typescript-eslint/types@8.61.1)
 
   svelte-preprocess@6.0.5(postcss-load-config@3.1.4(postcss@8.5.26))(postcss@8.5.26)(svelte@5.56.8(@typescript-eslint/types@8.61.1))(typescript@6.0.3):


### PR DESCRIPTION
Fixes: #12231

This PR tries to add a Svelte declaration tag if the image source is an expression that should only be computed once.

- ~It requires a newer version of Svelte to do so, which is a a breaking change.~ uses the old declaration tag by wrapping it in an if block that is always true. This works in both legacy and runes mode
- It also replaces `svelte-markup-parser` with the official Svelte parser so that we can check for colliding declaration references.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

Targeted validation: enhanced-img formatting and type checks, unit tests, integration tests, and diff checks.

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Added a patch changeset for `@sveltejs/enhanced-img`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.