### PR TITLE
chore: fix flaky timeout in the options vite spec

### DIFF
--- a/packages/kit/test/apps/options/unit-test/vite.spec.js
+++ b/packages/kit/test/apps/options/unit-test/vite.spec.js
@@ -6,7 +6,7 @@ const timeout = 60_000;
 
 const cwd = path.resolve(import.meta.dirname, '..');
 
-test('no overridden options warning', () => {
+test('no overridden options warning', { timeout }, () => {
 	const result = spawnSync(
 		'pnpm',
 		['vitest', 'run', '--config', './vite.custom.config.js', '-t', 'noop'],


### PR DESCRIPTION
The options app's `unit-test/vite.spec.js` spawns a nested `pnpm vitest run` with a 60s child timeout, but the test itself runs under vitest's default 5s `testTimeout`, so on a slow runner the outer test dies while the child is still booting ([example failure](https://github.com/sveltejs/kit/actions/runs/32603897316/job/97106102130)). Pass the existing `timeout` to the test, the same shape the build-errors specs use.