### PR TITLE
docs: clarify that #lib imports should use the .js extension

### DIFF
--- a/documentation/docs/60-appendix/35-migrating-to-sveltekit-3.md
+++ b/documentation/docs/60-appendix/35-migrating-to-sveltekit-3.md
@@ -84,7 +84,7 @@ The `$lib` alias is no longer generated automatically by SvelteKit. It is replac
 }
 ```
 
-...and replace `$lib` with `#lib` across your codebase. Note that you will also have to add the module extensions (e.g. `.js` or `.ts`) to these imports.
+...and replace `$lib` with `#lib` across your codebase. Note that you will also have to add the module extensions to these imports. Use the `.js` extension even when the file you are importing is written in TypeScript — `src/lib/server/auth.ts` is imported as `#lib/server/auth.js`. Subpath imports are not _relative_ imports, so they are not covered by [`rewriteRelativeImportExtensions`](https://www.typescriptlang.org/tsconfig/#rewriteRelativeImportExtensions), which newly scaffolded projects enable — importing `#lib/server/auth.ts` instead results in a TypeScript error (2877).
 
 ```js
 // @errors: 2307 imported module has no types

--- a/documentation/docs/98-reference/26-$lib.md
+++ b/documentation/docs/98-reference/26-$lib.md
@@ -15,6 +15,8 @@ When scaffolding a new SvelteKit project through the [`sv` CLI](/docs/cli/overvi
 
 The `#` prefix leverages Node's built-in [subpath imports](https://nodejs.org/api/packages.html#subpath-imports) feature, which reserves `#` for package-internal aliases. Vite and TypeScript both resolve these natively.
 
+Because these are subpath imports rather than relative imports, they must include a file extension. Use the `.js` extension even when importing a `.ts` module — `import { foo } from '#lib/server/auth.js'` resolves to `src/lib/server/auth.ts`. Unlike relative imports, subpath imports are not covered by [`rewriteRelativeImportExtensions`](https://www.typescriptlang.org/tsconfig/#rewriteRelativeImportExtensions), so importing `#lib/server/auth.ts` directly results in a TypeScript error (2877) in projects where that option is enabled.
+
 > [!LEGACY]
 > Previously, this alias was `$lib` and was automatically configured by SvelteKit. It is now `#lib` and must be declared in your `package.json` `imports` field. `import { foo } from '$lib/foo.js'` becomes `import { foo } from '#lib/foo.js'`.
 


### PR DESCRIPTION
## Summary
Closes #16831

The `$lib` → `#lib` migration guidance said to add module extensions "(e.g. `.js` or `.ts`)", but `.ts` is not a safe recommendation: subpath imports are not relative imports, so TypeScript's `rewriteRelativeImportExtensions` — which newly scaffolded `sv` projects enable — never rewrites them, and importing `#lib/server/auth.ts` fails with error TS2877. The `.js` extension is the only universally correct choice and resolves to `.ts` sources under the shipped config (`moduleResolution: 'bundler'`).

- **Migration guide** (`35-migrating-to-sveltekit-3.md`): replaced the misleading `(e.g. .js or .ts)` with explicit `.js`-for-`.ts`-files guidance and a short explanation of why `.ts` fails.
- **`#lib` reference** (`26-$lib.md`): added a paragraph stating that subpath imports must include a file extension and that `.js` should be used even for `.ts` modules.

## Testing
- docs change only
- claims verified against the repo's shipped tsconfig options (`packages/kit/src/core/sync/write_tsconfig/utils.js`) and TypeScript 6.0.3 source (ts(2877) gated on `rewriteRelativeImportExtensions`, non-relative specifiers never rewritten); `.js → .ts` resolution empirically reproduced with the workspace compiler
- all existing `#lib/*.js` doc examples already follow this convention; no other files needed changes
