### PR TITLE
fix: keep remote form radio/checkbox selections in sync after submit

### DIFF
--- a/.changeset/lucky-radios-resync.md
+++ b/.changeset/lucky-radios-resync.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: keep radio/checkbox selections in sync after remote form submission reset

--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -819,34 +819,52 @@ export function create_field_proxy(context, target = {}, path = []) {
 						}
 
 						if (type === 'checkbox' && !is_array) {
+							// defaultChecked mirrors checked so that the post-submission
+							// form.reset() restores the current field state rather than
+							// first-render defaults
+							const is_checked = () => get_value() ?? input_value;
+
 							return Object.defineProperties(base_props, {
 								defaultChecked: {
 									enumerable: true,
 									get() {
-										return input_value;
+										return is_checked();
 									}
 								},
 								checked: {
 									enumerable: true,
 									get() {
-										return get_value() ?? input_value;
+										return is_checked();
 									}
 								}
 							});
 						}
 
+						// as with single checkboxes, defaultChecked mirrors checked so
+						// that the post-submission form.reset() restores the current
+						// field state rather than first-render defaults
+						const is_checked = () => {
+							const value = get_value();
+
+							if (type === 'radio') {
+								return value === input_value;
+							}
+
+							return (value ?? []).includes(input_value);
+						};
+
 						return Object.defineProperties(base_props, {
 							value: { value: input_value ?? 'on', enumerable: true },
+							defaultChecked: {
+								enumerable: true,
+								get() {
+									return is_checked();
+								}
+							},
 							checked: {
 								enumerable: true,
 								get() {
-									const value = get_value();
-
-									if (type === 'radio') {
-										return value === input_value;
-									}
-
-									return (value ?? []).includes(input_value);
+									return is_checked();
 								}
 							}
 						});

--- a/packages/kit/test/apps/async/src/routes/remote/form/radio-reset/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/radio-reset/+page.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	import { get_settings, update_settings } from './form.remote.ts';
+
+	const settings = $derived(await get_settings());
+
+	const options = ['public', 'private'];
+	const tags = ['red', 'green', 'blue'];
+</script>
+
+<p id="query-value">{JSON.stringify(settings)}</p>
+
+<form {...update_settings}>
+	{#each options as option}
+		<label>
+			<input {...update_settings.fields.visibility.as('radio', option)} />
+			{option}
+		</label>
+	{/each}
+
+	{#each tags as tag}
+		<label>
+			<input {...update_settings.fields.tags.as('checkbox', tag)} />
+			{tag}
+		</label>
+	{/each}
+
+	<label>
+		<input {...update_settings.fields.notifications.as('checkbox')} />
+		notifications
+	</label>
+
+	<button id="save">Save</button>
+</form>
+
+<p id="fields-value">{JSON.stringify(update_settings.fields.value())}</p>

--- a/packages/kit/test/apps/async/src/routes/remote/form/radio-reset/form.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/form/radio-reset/form.remote.ts
@@ -1,0 +1,24 @@
+import { form, query } from '$app/server';
+import * as v from 'valibot';
+import { per_session } from '../../per-session.js';
+
+const SettingsSchema = v.object({
+	visibility: v.picklist(['public', 'private']),
+	tags: v.array(v.string()),
+	notifications: v.optional(v.boolean(), false)
+});
+
+const session = per_session(() => ({
+	settings: {
+		visibility: 'public',
+		tags: ['red'],
+		notifications: false
+	} as v.InferOutput<typeof SettingsSchema>
+}));
+
+export const get_settings = query(() => session().settings);
+
+export const update_settings = form(SettingsSchema, async (data) => {
+	session().settings = data;
+	await get_settings().refresh();
+});

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -1121,6 +1121,61 @@ test.describe('remote function mutations', () => {
 		// the value display should also show the updated value
 		await expect(page.locator('#set-value-display')).toHaveText('Set via method');
 	});
+
+	test('radio and checkbox selections survive the post-submission reset', async ({ page }) => {
+		await page.goto('/remote/form/radio-reset');
+
+		const form = page.locator('form');
+
+		// change the selection away from the initial values
+		await form.locator('input[name^="visibility"][value="private"]').check();
+		await form.locator('input[name^="tags"][value="green"]').check();
+		await form.locator('input[name^="b:notifications"]').check();
+
+		await page.click('#save');
+
+		// the query reflects the new values...
+		await expect(page.locator('#query-value')).toHaveText(
+			JSON.stringify({ visibility: 'private', tags: ['green'], notifications: true })
+		);
+
+		// ...and the controls keep their selection after the default reset
+		await expect(form.locator('input[name^="visibility"][value="public"]')).not.toBeChecked();
+		await expect(form.locator('input[name^="visibility"][value="private"]')).toBeChecked();
+		await expect(form.locator('input[name^="tags"][value="red"]')).not.toBeChecked();
+		await expect(form.locator('input[name^="tags"][value="green"]')).toBeChecked();
+		await expect(form.locator('input[name^="b:notifications"]')).toBeChecked();
+
+		// fields.value() stays in sync with the controls
+		await expect(page.locator('#fields-value')).toHaveText(
+			JSON.stringify({ visibility: 'private', tags: ['green'], notifications: true })
+		);
+	});
+
+	test('unselected radio keeps a failed submission from resetting the form', async ({ page }) => {
+		await page.goto('/remote/form/radio-reset');
+
+		const form = page.locator('form');
+
+		// visibility is required but left unselected, so validation fails
+		await form.locator('input[name^="tags"][value="blue"]').check();
+		await page.click('#save');
+
+		// no reset happened: the checked controls keep their state
+		await expect(form.locator('input[name^="tags"][value="blue"]')).toBeChecked();
+		await expect(page.locator('#query-value')).not.toContainText('blue');
+
+		// completing the submission persists and preserves the selection
+		await form.locator('input[name^="visibility"][value="private"]').check();
+		await page.click('#save');
+
+		await expect(page.locator('#query-value')).toHaveText(
+			JSON.stringify({ visibility: 'private', tags: ['blue'], notifications: false })
+		);
+		await expect(form.locator('input[name^="visibility"][value="private"]')).toBeChecked();
+		await expect(form.locator('input[name^="tags"][value="blue"]')).toBeChecked();
+	});
+
 	test('form does refresh queries when a remote request', async ({ page }) => {
 		await page.goto(`/remote/form/noop-refresh-non-enhanced/${Date.now()}${Math.random()}`);
 


### PR DESCRIPTION
## Summary
Closes #16820

After a successful same-URL remote `form()` submission, the default enhance resets the element ([#14322](https://github.com/sveltejs/kit/issues/14322)). Text inputs survived this because `.as('text', liveQueryValue)` keeps their `defaultValue` in sync with field state, so `reset()` landed on the persisted value. Radio, checkbox-array and single-checkbox inputs had no equivalent reset-target channel: radio's `.as` second argument is the option identity, single-checkbox `defaultChecked` was a static second argument (usually omitted), so controls snapped back to first-render defaults and `fields.value()` went stale.

**Fix** (`packages/kit/src/runtime/form-utils.js`):
- radio / checkbox-array spreads now also emit `defaultChecked`, computed by the same `is_checked()` closure as `checked` — the reset target always mirrors current field state
- single-checkbox `defaultChecked` now follows `get_value() ?? input_value` (its existing `checked` computation) instead of the static second argument

Since defaults now track state, the post-submit `reset()` becomes a visual no-op for these controls and `handle_reset`'s FormData snapshot re-seeds `fields.value()` with the correct data — text's existing mechanism, generalized. The public types already declared `defaultChecked` for checkbox/radio fields, so no type surface changes.

## Out of scope (flagging explicitly)
- **`select`** still reverts to its first option after the post-submission reset — its default selection lives on `<option selected>` attributes, which can't be expressed through the `<select>` element spread. Needs separate design work.
- **text/number/etc. with a *static literal* second argument** (`.as('text', 'constant')`) retain their pre-fix behavior — only reactive/live values survive the reset.

## Testing
- new route `packages/kit/test/apps/async/src/routes/remote/form/radio-reset/` + two Playwright cases:
  - changed radio + checkbox-array + single-checkbox selections all survive the default post-success reset; `fields.value()` stays in sync
  - failed validation (missing required radio) does not reset; completing the submission then persists and preserves selection
- `client.test.js`: 92 passed (dev); new tests also pass on the build project; cross-project `form works` incl. no-JS SSR green
- `pnpm run lint` / `pnpm run format` clean; changeset included
