### PR TITLE
fix: allow resolve to accept asset paths from $app/manifest in service workers

### DIFF
--- a/.changeset/fix-16802-resolve-asset.md
+++ b/.changeset/fix-16802-resolve-asset.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: allow `resolve` to accept asset paths from `$app/manifest` in service workers

--- a/packages/kit/src/runtime/app/paths/client.js
+++ b/packages/kit/src/runtime/app/paths/client.js
@@ -60,7 +60,7 @@ const pathname_prefix = hash_routing ? '#' : '';
  * ```
  * @since 2.26
  *
- * @template {RouteIdWithSearchOrHash | PathnameWithSearchOrHash} T
+ * @template {RouteIdWithSearchOrHash | PathnameWithSearchOrHash | AssetPath | (string & {})} T
  * @param {ResolveArgs<T>} args
  * @returns {ResolvedPathname}
  */

--- a/packages/kit/src/runtime/app/paths/types.d.ts
+++ b/packages/kit/src/runtime/app/paths/types.d.ts
@@ -6,7 +6,7 @@ type StripSearchOrHash<T extends string> = T extends `${infer U}?${string}`
 		? U
 		: T;
 
-export type ResolveArgs<T> = T extends `/${string}`
+export type ResolveArgs<T extends string> = T extends `/${string}`
 	? StripSearchOrHash<T> extends infer U extends RouteId
 		? RouteParams<U> extends Record<string, never>
 			? [route: T]


### PR DESCRIPTION
Closes #16802

The service worker example in the docs maps over `immutable` and `assets` from `$app/manifest` and passes each `asset.path` to `resolve()`.

- `immutable` is typed as `Array<{ path: string }>` (Vite-generated, hashed)
- `assets` is typed as `Array<{ path: AssetPath }>`

But `resolve` only accepted `RouteId` / `Path` unions (e.g. `"" | "poem" | "poem/editor"`), so `string` and `AssetPath` were not assignable:

```
Argument of type 'string' is not assignable to parameter of type '[pathname: ""] | [pathname: "poem"] | ...'
```

**Fix**

- Widen `resolve` generic in `packages/kit/src/runtime/app/paths/client.js:63` to also accept `AssetPath | (string & {})` so manifest-provided paths (relative without leading "/") are accepted as pathname fallbacks
- Make `ResolveArgs<T extends string>` explicit in `packages/kit/src/runtime/app/paths/types.d.ts:9` so generic string inference works correctly (slash-prefixed route IDs remain strictly checked via `[never]` branch)

Verified: `pnpm -F @sveltejs/kit test:unit` passes except pre-existing @typescript/native fixture failures unrelated to this change; the docs service-worker snippet now type-checks without `resolve<any>` workaround.