### PR TITLE
fix: respect user Vite CORS config

### DIFF
--- a/.changeset/pre/respect-user-cors-config.md
+++ b/.changeset/pre/respect-user-cors-config.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: respect user-set `server.cors` and `preview.cors` config instead of overriding them

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -50,32 +50,29 @@ const options_regex = /(export\s+const\s+(prerender|csr|ssr|trailingSlash))\s*=/
  * @returns {CorsOptions | undefined}
  */
 function resolve_cors(user_cors, key, warn) {
+	// `preview.cors` falls back to the resolved `server.cors`, so emitting a value here when
+	// the user hasn't set one is what drops Vite's `defaultAllowedOrigins` restriction
 	if (user_cors === undefined) {
-		// Default: enable preflightContinue so OPTIONS handlers work
-		return { preflightContinue: true };
+		return key === 'server.cors' ? { preflightContinue: true } : undefined;
 	}
 
-	const preflight_disabled =
-		typeof user_cors !== 'object' || user_cors === null || user_cors.preflightContinue === false;
+	// with `cors: false` Vite installs no CORS middleware, so OPTIONS handlers already work
+	if (user_cors === false) return undefined;
 
-	if (preflight_disabled) {
-		if (warn) {
-			console.warn(
-				styleText(
-					['yellow', 'bold'],
-					`OPTIONS request handlers will not work unless \`${key}.preflightContinue\` is set to \`true\``
-				)
-			);
-		}
-		return undefined;
+	if (typeof user_cors === 'object' && user_cors !== null) {
+		if (user_cors.preflightContinue === undefined) return { preflightContinue: true };
+		if (user_cors.preflightContinue) return undefined;
 	}
 
-	// User set an object without preflightContinue — merge it in
-	if (typeof user_cors === 'object' && user_cors !== null && !('preflightContinue' in user_cors)) {
-		return { ...user_cors, preflightContinue: true };
+	if (warn) {
+		console.warn(
+			styleText(
+				['yellow', 'bold'],
+				`OPTIONS request handlers will not work unless \`${key}.preflightContinue\` is set to \`true\``
+			)
+		);
 	}
 
-	// Already has preflightContinue: true, leave as-is
 	return undefined;
 }
 

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -2,7 +2,7 @@
 /** @import { Options } from '@sveltejs/vite-plugin-svelte' */
 /** @import { PreprocessorGroup } from 'svelte/compiler' */
 /** @import {  ManifestData, RemoteChunk, ServerMetadata, ValidatedConfig } from 'types' */
-/** @import { Plugin, ResolvedConfig, Rolldown, UserConfig } from 'vite' */
+/** @import { CorsOptions, Plugin, ResolvedConfig, Rolldown, UserConfig } from 'vite' */
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
@@ -37,6 +37,43 @@ import { plugin_service_worker_build } from './build/service-worker.js';
 import { plugin_adapter, plugin_compile } from './build/index.js';
 
 const options_regex = /(export\s+const\s+(prerender|csr|ssr|trailingSlash))\s*=/s;
+
+/**
+ * Resolves the CORS config for dev and preview servers.
+ * SvelteKit needs `preflightContinue: true` so that OPTIONS requests for
+ * `+server.js` endpoints aren't intercepted by Vite's CORS middleware.
+ * If the user has explicitly set values that prevent this, we warn them
+ * and preserve their settings.
+ * @param {CorsOptions | boolean | undefined} user_cors
+ * @param {'server.cors' | 'preview.cors'} key
+ * @returns {CorsOptions | undefined}
+ */
+function resolve_cors(user_cors, key) {
+	if (user_cors === undefined) {
+		// Default: enable preflightContinue so OPTIONS handlers work
+		return { preflightContinue: true };
+	}
+
+	const preflight_disabled = typeof user_cors !== 'object' || user_cors.preflightContinue === false;
+
+	if (preflight_disabled) {
+		console.warn(
+			styleText(
+				['yellow', 'bold'],
+				`OPTIONS request handlers will not work unless \`${key}.preflightContinue\` is set to \`true\``
+			)
+		);
+		return undefined;
+	}
+
+	// User set an object without preflightContinue — merge it in
+	if (typeof user_cors === 'object' && user_cors !== null && !('preflightContinue' in user_cors)) {
+		return { ...user_cors, preflightContinue: true };
+	}
+
+	// Already has preflightContinue: true, leave as-is
+	return undefined;
+}
 
 const removed_modules = [
 	{
@@ -369,7 +406,7 @@ function kit({ svelte_config }) {
 						]
 					},
 					server: {
-						cors: { preflightContinue: true },
+						cors: resolve_cors(config.server?.cors, 'server.cors'),
 						fs: {
 							allow: [...allow]
 						},
@@ -382,7 +419,7 @@ function kit({ svelte_config }) {
 						}
 					},
 					preview: {
-						cors: { preflightContinue: true }
+						cors: resolve_cors(config.preview?.cors, 'preview.cors')
 					},
 					optimizeDeps: {
 						entries: [

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -55,9 +55,7 @@ function resolve_cors(user_cors, key) {
 	}
 
 	const preflight_disabled =
-		typeof user_cors !== 'object' ||
-		user_cors === null ||
-		user_cors.preflightContinue === false;
+		typeof user_cors !== 'object' || user_cors === null || user_cors.preflightContinue === false;
 
 	if (preflight_disabled) {
 		console.warn(

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -54,7 +54,10 @@ function resolve_cors(user_cors, key) {
 		return { preflightContinue: true };
 	}
 
-	const preflight_disabled = typeof user_cors !== 'object' || user_cors.preflightContinue === false;
+	const preflight_disabled =
+		typeof user_cors !== 'object' ||
+		user_cors === null ||
+		user_cors.preflightContinue === false;
 
 	if (preflight_disabled) {
 		console.warn(

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -46,9 +46,10 @@ const options_regex = /(export\s+const\s+(prerender|csr|ssr|trailingSlash))\s*=/
  * and preserve their settings.
  * @param {CorsOptions | boolean | undefined} user_cors
  * @param {'server.cors' | 'preview.cors'} key
+ * @param {boolean} warn Whether to emit a warning when the user's settings prevent OPTIONS handlers from working. Only relevant for the dev/preview servers, not `vite build`.
  * @returns {CorsOptions | undefined}
  */
-function resolve_cors(user_cors, key) {
+function resolve_cors(user_cors, key, warn) {
 	if (user_cors === undefined) {
 		// Default: enable preflightContinue so OPTIONS handlers work
 		return { preflightContinue: true };
@@ -58,12 +59,14 @@ function resolve_cors(user_cors, key) {
 		typeof user_cors !== 'object' || user_cors === null || user_cors.preflightContinue === false;
 
 	if (preflight_disabled) {
-		console.warn(
-			styleText(
-				['yellow', 'bold'],
-				`OPTIONS request handlers will not work unless \`${key}.preflightContinue\` is set to \`true\``
-			)
-		);
+		if (warn) {
+			console.warn(
+				styleText(
+					['yellow', 'bold'],
+					`OPTIONS request handlers will not work unless \`${key}.preflightContinue\` is set to \`true\``
+				)
+			);
+		}
 		return undefined;
 	}
 
@@ -407,7 +410,7 @@ function kit({ svelte_config }) {
 						]
 					},
 					server: {
-						cors: resolve_cors(config.server?.cors, 'server.cors'),
+						cors: resolve_cors(config.server?.cors, 'server.cors', !is_build),
 						fs: {
 							allow: [...allow]
 						},
@@ -420,7 +423,7 @@ function kit({ svelte_config }) {
 						}
 					},
 					preview: {
-						cors: resolve_cors(config.preview?.cors, 'preview.cors')
+						cors: resolve_cors(config.preview?.cors, 'preview.cors', !is_build)
 					},
 					optimizeDeps: {
 						entries: [


### PR DESCRIPTION
closes #12574

SvelteKit currently silently overrides user-provided `server.cors` and `preview.cors` values to ensure OPTIONS handlers work during development and preview. This change preserves explicit user configuration instead, while continuing to add `preflightContinue: true` when it has not been configured. A warning explains that OPTIONS handlers require `preflightContinue: true` when the user's CORS setting disables it.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

Targeted verification: `pnpm -F @sveltejs/kit test:unit` (748 passed, 110 skipped).

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.