### PR TITLE
fix: restore the `_app/immutable/workers` output path

### DIFF
--- a/.changeset/quiet-workers-return.md
+++ b/.changeset/quiet-workers-return.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: emit web workers under `_app/immutable/workers` again

--- a/packages/kit/src/exports/vite/build/index.js
+++ b/packages/kit/src/exports/vite/build/index.js
@@ -264,6 +264,16 @@ export function plugin_compile(
 						emptyOutDir: false,
 						ssrEmitAssets: true
 					},
+					worker: {
+						rolldownOptions: {
+							output: {
+								entryFileNames: `${app_immutable}/workers/[name]-[hash].js`,
+								chunkFileNames: `${app_immutable}/workers/chunks/[hash].js`,
+								assetFileNames: `${app_immutable}/workers/assets/[name]-[hash][extname]`,
+								hoistTransitiveImports: false
+							}
+						}
+					},
 					builder: {
 						sharedConfigBuild: true,
 						sharedPlugins: true


### PR DESCRIPTION
`packages/kit/src/exports/vite/build/index.js` no longer sets `worker.rolldownOptions.output`. #15532 moved the build config into the shared `new_config` and left that block out, so `?worker` and `?worker&url` imports fall back to Vite's default and are emitted to `assets/[name]-[hash].js` at the root of the output directory instead of `_app/immutable/workers/`. Adapters only send immutable cache headers for `_app/immutable/`, and `collect_immutable` only lists files under that prefix, so worker files lose both.

This restores the block with the same paths `main` uses. #16870 adds a test that asserts the path.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
