### PR TITLE
fix: only require svelte-trusted-html trusted-types policy when client code ships

### DIFF
--- a/.changeset/lazy-queens-refuse.md
+++ b/.changeset/lazy-queens-refuse.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: only require the `svelte-trusted-html` trusted-types policy when client-side code is shipped, allowing builds where all pages have `csr: false`

--- a/packages/kit/src/core/config/index.js
+++ b/packages/kit/src/core/config/index.js
@@ -200,15 +200,6 @@ export function validate_config(config) {
 			}
 		}
 
-		if (
-			validated.csp?.directives?.['require-trusted-types-for']?.includes('script') &&
-			!validated.csp?.directives?.['trusted-types']?.includes('svelte-trusted-html')
-		) {
-			throw new Error(
-				"The `csp.directives['trusted-types']` option must include 'svelte-trusted-html'"
-			);
-		}
-
 		return validated;
 	} catch (e) {
 		const error = /** @type {Error} */ (e);

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -264,6 +264,18 @@ test("fails if paths.base ends with '/'", () => {
 	}, /^config\.paths\.base option must either be the empty string or a root-relative path that starts but doesn't end with '\/'. See https:\/\/svelte\.dev\/docs\/kit\/configuration#paths$/);
 });
 
+test('does not require svelte-trusted-html when trusted types are enforced', () => {
+	assert.doesNotThrow(() => {
+		validate_config({
+			csp: {
+				directives: {
+					'require-trusted-types-for': ['script']
+				}
+			}
+		});
+	});
+});
+
 test('fails if paths.assets is relative', () => {
 	assert_logs_error_and_throws(() => {
 		validate_config({

--- a/packages/kit/src/exports/vite/build/index.js
+++ b/packages/kit/src/exports/vite/build/index.js
@@ -518,6 +518,16 @@ export function plugin_compile(
 					(node) => node.page_options?.csr === false
 				);
 
+				if (
+					!skip_client_build &&
+					kit.csp.directives['require-trusted-types-for']?.includes('script') &&
+					!kit.csp.directives['trusted-types']?.includes('svelte-trusted-html')
+				) {
+					throw new Error(
+						"The `csp.directives['trusted-types']` option must include 'svelte-trusted-html' unless all pages have `csr: false`"
+					);
+				}
+
 				if (skip_client_build) {
 					copy(server_assets, client_assets);
 					copy(kit.files.assets, `${out}/client`);

--- a/packages/kit/test/apps/no-csr/vite.config.js
+++ b/packages/kit/test/apps/no-csr/vite.config.js
@@ -7,7 +7,16 @@ const config = {
 		minify: false
 	},
 	clearScreen: false,
-	plugins: [sveltekit()],
+	plugins: [
+		sveltekit({
+			csp: {
+				directives: {
+					'script-src': ['self'],
+					'require-trusted-types-for': ['script']
+				}
+			}
+		})
+	],
 	server: {
 		fs: {
 			allow: [path.resolve('../../../src')]


### PR DESCRIPTION
> Clone of https://github.com/sveltejs/kit/pull/16866, but bases off version-3

Previously, setting csp.directives['require-trusted-types-for']: ['script'] without including 'svelte-trusted-html' in trusted-types threw during config validation. This blocked builds of apps where every page has csr: false — those apps ship no client-side code, so the policy is never used.

The check now runs at build time instead, reusing the same statically-analysed page options that decide skip_client_build. If any page ships client code (or its csr option can't be statically analysed), the original error still throws; if all pages have csr: false, the build proceeds.

Note: since the analysis only runs during build, vite dev no longer surfaces the missing policy at startup.

- packages/kit/src/core/config/index.js — removed the check from validate_config
- packages/kit/src/exports/vite/index.js — added the check after skip_client_build is computed

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
