### PR TITLE
fix: re-evaluate preloaded redirects before navigation

### DIFF
--- a/.changeset/fix-preloaded-redirect-cache.md
+++ b/.changeset/fix-preloaded-redirect-cache.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: do not reuse preloaded redirects after state changes

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1411,9 +1411,16 @@ function diff_search_params(old_url, new_url) {
  */
 async function load_route({ id, invalidating, url, params, route, preload, action_result }) {
 	if (!action_result && load_cache?.id === id) {
+		const cache = load_cache;
+
 		// the preload becomes the real navigation
-		preload_tokens.delete(load_cache.token);
-		return load_cache.promise;
+		preload_tokens.delete(cache.token);
+
+		const result = await cache.promise;
+		if (result.type !== 'redirect') return result;
+
+		// Redirects depend on transient state and must be reevaluated when navigating.
+		if (load_cache === cache) discard_load_cache();
 	}
 
 	const { errors, layouts, leaf } = route;

--- a/packages/kit/test/apps/basics/src/routes/routing/preloading/redirect/[step]/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/routing/preloading/redirect/[step]/+page.server.js
@@ -1,0 +1,17 @@
+import { redirect } from '@sveltejs/kit';
+
+/** @type {import('./$types').PageServerLoad} */
+export function load({ cookies, params }) {
+	if (params.step === 'resolve') {
+		cookies.set('preload-redirect-selected', 'true', {
+			path: '/routing/preloading/redirect',
+			secure: false
+		});
+
+		redirect(303, '/routing/preloading/redirect/target');
+	}
+
+	if (!cookies.get('preload-redirect-selected')) {
+		redirect(303, '/routing/preloading/redirect/resolve');
+	}
+}

--- a/packages/kit/test/apps/basics/src/routes/routing/preloading/redirect/[step]/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/routing/preloading/redirect/[step]/+page.svelte
@@ -1,0 +1,1 @@
+<h1>Redirect resolved</h1>

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -1022,6 +1022,50 @@ test.describe('Prefetching', () => {
 		);
 	});
 
+	test('does not reuse preloaded redirects after state changes', async ({ baseURL, page, app }) => {
+		const target = '/routing/preloading/redirect/target';
+		await page.goto('/routing/a');
+
+		expect(await app.preloadData(target)).toEqual({
+			type: 'redirect',
+			status: 303,
+			location: '/routing/preloading/redirect/resolve'
+		});
+
+		await page
+			.context()
+			.addCookies([{ name: 'preload-redirect-selected', value: 'true', url: baseURL }]);
+
+		/** @type {string[]} */
+		const requests = [];
+		page.on('request', (request) => requests.push(request.url()));
+
+		await app.goto(target);
+
+		await expect(page.locator('h1')).toHaveText('Redirect resolved');
+		expect(requests.some((url) => url.includes('/routing/preloading/redirect/resolve'))).toBe(
+			false
+		);
+	});
+
+	test('does not reuse preloaded redirects after a redirect changes state', async ({
+		page,
+		app
+	}) => {
+		const target = '/routing/preloading/redirect/target';
+		await page.goto('/routing/a');
+
+		expect(await app.preloadData(target)).toEqual({
+			type: 'redirect',
+			status: 303,
+			location: '/routing/preloading/redirect/resolve'
+		});
+
+		await app.goto(target);
+
+		await expect(page.locator('h1')).toHaveText('Redirect resolved');
+	});
+
 	test('chooses correct route when hash route is preloaded but regular route is clicked', async ({
 		app,
 		page


### PR DESCRIPTION
**Prevent stale preloaded redirects from causing incorrect navigation and redirect loops.**

- Reevaluate cached redirect decisions without changing successful preload caching.
- Cover state changes before navigation and during redirect chains.
- Verified with 750 unit tests, 100 browser tests, production builds, server-side routing, lint, and monorepo checks.

**Important files:**

- `packages/kit/src/runtime/client/client.js`
  - Discard only the matching cached redirect and reload its route against current state.
- `packages/kit/test/apps/basics/test/cross-platform/client.test.js`
  - Add browser regressions for stale redirect decisions and redirect-induced state changes.
- `packages/kit/test/apps/basics/src/routes/routing/preloading/redirect/[step]/+page.server.js`
  - Add a cookie-isolated redirect fixture used by both regression tests.

**Before and after:**

| Before: stale redirect causes a 500 error | After: redirect is reevaluated and the dashboard loads |
| --- | --- |
| ![Before: the stale preloaded redirect produces a 500 error](https://github.com/user-attachments/assets/bd100bb9-243d-42e4-bddf-0356dadae83e) | ![After: the fixed redirect successfully loads the dashboard](https://github.com/user-attachments/assets/3c0771d8-cc1c-4221-b7ac-a7fbfa573d3d) |

References sveltejs/kit#16484.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where preloaded redirects could be reused after application state changes.
  - Navigation now reevaluates redirects and reaches the updated destination correctly.

- **Tests**
  - Added coverage for redirect behavior after cookie changes and redirect-driven state changes.
  - Added a redirect resolution scenario displaying a “Redirect resolved” confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
