### PR TITLE
chore: stop externalizing `cookie` dependency during build

### DIFF
--- a/.changeset/petite-pens-love.md
+++ b/.changeset/petite-pens-love.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+chore: stop externalizing `cookie` dependency during build

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -520,7 +520,7 @@ function kit({ svelte_config }) {
 						__SVELTEKIT_HAS_UNIVERSAL_LOAD__: 'true'
 					};
 
-					// These Kit dependencies are packaged as CommonJS, which means they must always be externalized.
+					// Any CommonJS dependencies of Kit (of which there are currently none) must always be externalized.
 					// Without this, the tests will still pass but `pnpm dev` will fail in projects that link `@sveltejs/kit`.
 					//
 					// `@opentelemetry/api` must be externalized so that `instrumentation.server.js` and the
@@ -531,7 +531,6 @@ function kit({ svelte_config }) {
 					// would cause those modules to be evaluated before `Server.init()` sets env vars — see
 					// https://github.com/sveltejs/kit/issues/16288
 					/** @type {NonNullable<UserConfig['ssr']>} */ (new_config.ssr).external = [
-						'cookie',
 						'@opentelemetry/api'
 					];
 


### PR DESCRIPTION
I _think_ we don't need to externalize `cookie` anymore, now that it's in ESM. At least, according to the code comment, that was the reason it was getting externalized before. Hopefully, this is no longer necessary.