### PR TITLE
fix: widen remote form field types

### DIFF
--- a/.changeset/quick-forms-unite.md
+++ b/.changeset/quick-forms-unite.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: widen remote form fields for union schemas and string enums

--- a/packages/kit/src/runtime/app/server/public.d.ts
+++ b/packages/kit/src/runtime/app/server/public.d.ts
@@ -131,6 +131,8 @@ type AsArgs<Type extends keyof InputTypeMap, Value> = Type extends 'checkbox'
 				? [type: Type]
 				: [type: Type] | [type: Type, value: Value | undefined];
 
+type WidenLiteralString<T> = T extends string ? (string extends T ? T : string) : T;
+
 /**
  * Form field accessor type that provides name(), value(), and issues() methods
  */
@@ -145,7 +147,9 @@ export type RemoteFormField<Value extends RemoteFormFieldValue> = RemoteFormFiel
 	 * <input {...myForm.fields.myBoolean.as('checkbox')} />
 	 * ```
 	 */
-	as<T extends RemoteFormFieldType<Value>>(...args: AsArgs<T, Value>): InputElementProps<T>;
+	as<T extends RemoteFormFieldType<Value>>(
+		...args: AsArgs<T, Value>
+	): InputElementProps<T> & { value?: WidenLiteralString<Value> };
 };
 
 type RemoteFormFieldContainer<Value> = RemoteFormFieldMethods<Value> & {
@@ -273,7 +277,17 @@ export type RemoteFormEnhanceCallback<
 /**
  * The type of a remote `form` function. See [Remote functions](https://svelte.dev/docs/kit/remote-functions#form) for full documentation.
  */
-export type RemoteForm<Input extends RemoteFormInput | void, Output> = {
+export type RemoteForm<Input extends RemoteFormInput | void, Output> = RemoteForm_<
+	Input,
+	Output,
+	[Input]
+>;
+
+type RemoteForm_<
+	Input extends RemoteFormInput | void,
+	Output,
+	Original extends [RemoteFormInput | void]
+> = {
 	/** Attachment that sets up an event handler that intercepts the form submission on the client to prevent a full page reload */
 	[attachment: symbol]: (node: HTMLFormElement) => void;
 	method: 'POST';
@@ -327,7 +341,15 @@ export type RemoteForm<Input extends RemoteFormInput | void, Output> = {
 	/** True if the form has been submitted at least once, and hasn't been reset since */
 	get submitted(): boolean;
 	/** Access form fields using object notation */
-	fields: RemoteFormFieldsRoot<Input>;
+	fields: IsAny<Input> extends true
+		? RecursiveFormFields
+		: Input extends void
+			? RemoteFormFieldsRoot<Input>
+			: WillRecurseIndefinitely<Input> extends true
+				? RecursiveFormFields
+				: RemoteFormFieldContainer<Original[0]> & {
+						[K in KeysOfUnion<Original[0]>]-?: RemoteFormFields<ValueOfUnionKey<Original[0], K>>;
+					};
 };
 
 /**

--- a/packages/kit/src/runtime/app/server/public.d.ts
+++ b/packages/kit/src/runtime/app/server/public.d.ts
@@ -175,7 +175,10 @@ type UnknownField<Value> = RemoteFormFieldMethods<Value> & {
 	[key: string | number]: UnknownField<any>;
 };
 
-type RemoteFormFieldsRoot<Input extends RemoteFormInput | void> =
+type RemoteFormFieldsRoot<
+	Input extends RemoteFormInput | void,
+	Original extends [RemoteFormInput | void] = [Input]
+> =
 	IsAny<Input> extends true
 		? RecursiveFormFields
 		: Input extends void
@@ -185,7 +188,11 @@ type RemoteFormFieldsRoot<Input extends RemoteFormInput | void> =
 					/** Validation issues belonging to this or any of the fields that belong to it, if any */
 					allIssues(): RemoteFormIssue[] | undefined;
 				}
-			: RemoteFormFields<Input>;
+			: WillRecurseIndefinitely<Input> extends true
+				? RecursiveFormFields
+				: RemoteFormFieldContainer<Original[0]> & {
+						[K in KeysOfUnion<Original[0]>]-?: RemoteFormFields<ValueOfUnionKey<Original[0], K>>;
+					};
 
 /**
  * Recursive type to build form fields structure with proxy access
@@ -341,15 +348,7 @@ type RemoteForm_<
 	/** True if the form has been submitted at least once, and hasn't been reset since */
 	get submitted(): boolean;
 	/** Access form fields using object notation */
-	fields: IsAny<Input> extends true
-		? RecursiveFormFields
-		: Input extends void
-			? RemoteFormFieldsRoot<Input>
-			: WillRecurseIndefinitely<Input> extends true
-				? RecursiveFormFields
-				: RemoteFormFieldContainer<Original[0]> & {
-						[K in KeysOfUnion<Original[0]>]-?: RemoteFormFields<ValueOfUnionKey<Original[0], K>>;
-					};
+	fields: RemoteFormFieldsRoot<Input, Original>;
 };
 
 /**

--- a/packages/kit/src/runtime/app/server/public.d.ts
+++ b/packages/kit/src/runtime/app/server/public.d.ts
@@ -41,7 +41,7 @@ export type RemoteFormFieldType<T> = {
 }[keyof InputTypeMap];
 
 // Input element properties based on type
-type InputElementProps<T extends keyof InputTypeMap> = T extends 'checkbox' | 'radio'
+type InputElementProps<T extends keyof InputTypeMap, Value> = T extends 'checkbox' | 'radio'
 	? {
 			name: string;
 			type: T;
@@ -78,9 +78,9 @@ type InputElementProps<T extends keyof InputTypeMap> = T extends 'checkbox' | 'r
 					? {
 							name: string;
 							'aria-invalid': boolean | 'false' | 'true' | undefined;
-							get value(): string | number;
-							set value(v: string | number);
-							readonly defaultValue?: string | number;
+							get value(): Value extends string ? string : string | number;
+							set value(v: Value extends string ? string : string | number);
+							readonly defaultValue?: Value extends string ? string : string | number;
 						}
 					: {
 							name: string;
@@ -149,7 +149,7 @@ export type RemoteFormField<Value extends RemoteFormFieldValue> = RemoteFormFiel
 	 */
 	as<T extends RemoteFormFieldType<Value>>(
 		...args: AsArgs<T, Value>
-	): InputElementProps<T> & { value?: WidenLiteralString<Value> };
+	): InputElementProps<T, WidenLiteralString<Value>>;
 };
 
 type RemoteFormFieldContainer<Value> = RemoteFormFieldMethods<Value> & {
@@ -170,7 +170,7 @@ type UnknownField<Value> = RemoteFormFieldMethods<Value> & {
 	 * <input {...myForm.fields.myBoolean.as('checkbox')} />
 	 * ```
 	 */
-	as<T extends RemoteFormFieldType<Value>>(...args: AsArgs<T, Value>): InputElementProps<T>;
+	as<T extends RemoteFormFieldType<Value>>(...args: AsArgs<T, Value>): InputElementProps<T, Value>;
 } & {
 	[key: string | number]: UnknownField<any>;
 };

--- a/packages/kit/test/types/remote.test.ts
+++ b/packages/kit/test/types/remote.test.ts
@@ -524,6 +524,16 @@ function form_tests() {
 	enum_text_props;
 	// @ts-expect-error
 	f5.fields.foo.as('text', 'c');
+	const optional_boolean_form = form(
+		null as any as StandardSchemaV1<{ enabled?: boolean }>,
+		() => {}
+	);
+	const boolean_checkbox_props: { value?: string; checked: boolean } =
+		optional_boolean_form.fields.enabled.as('checkbox');
+	boolean_checkbox_props;
+	const boolean_hidden_props: { value: string | number; type: 'hidden' } =
+		optional_boolean_form.fields.enabled.as('hidden', true);
+	boolean_hidden_props;
 	// @ts-expect-error
 	f5.fields.foo.value() === 'e';
 	// @ts-expect-error

--- a/packages/kit/test/types/remote.test.ts
+++ b/packages/kit/test/types/remote.test.ts
@@ -520,6 +520,10 @@ function form_tests() {
 	f5.fields.bar.issues();
 	f5.fields.foo.value();
 	f5.fields.bar.value() === 'c';
+	const enum_text_props: { value?: string } = f5.fields.foo.as('text', 'a');
+	enum_text_props;
+	// @ts-expect-error
+	f5.fields.foo.as('text', 'c');
 	// @ts-expect-error
 	f5.fields.foo.value() === 'e';
 	// @ts-expect-error
@@ -676,6 +680,12 @@ function form_tests() {
 	f11_field2.propA;
 	// @ts-expect-error
 	f11_field2.propB;
+
+	const f12 = form(null as any as StandardSchemaV1<{ a: string } | { b: string }>, () => {});
+	f12.fields.a.as('text', 'default');
+	f12.fields.b.as('text');
+	// @ts-expect-error
+	f12.fields.c.as('text');
 
 	// non-optional booleans
 	form(

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -3090,7 +3090,10 @@ declare module '$app/server' {
 		[key: string | number]: UnknownField<any>;
 	};
 
-	type RemoteFormFieldsRoot<Input extends RemoteFormInput | void> =
+	type RemoteFormFieldsRoot<
+		Input extends RemoteFormInput | void,
+		Original extends [RemoteFormInput | void] = [Input]
+	> =
 		IsAny<Input> extends true
 			? RecursiveFormFields
 			: Input extends void
@@ -3100,7 +3103,13 @@ declare module '$app/server' {
 						/** Validation issues belonging to this or any of the fields that belong to it, if any */
 						allIssues(): RemoteFormIssue[] | undefined;
 					}
-				: RemoteFormFields<Input>;
+				: WillRecurseIndefinitely<Input> extends true
+					? RecursiveFormFields
+					: RemoteFormFieldContainer<Original[0]> & {
+							[K in KeysOfUnion<Original[0]>]-?: RemoteFormFields<
+								ValueOfUnionKey<Original[0], K>
+							>;
+						};
 
 	/**
 	 * Recursive type to build form fields structure with proxy access
@@ -3256,17 +3265,7 @@ declare module '$app/server' {
 		/** True if the form has been submitted at least once, and hasn't been reset since */
 		get submitted(): boolean;
 		/** Access form fields using object notation */
-		fields: IsAny<Input> extends true
-			? RecursiveFormFields
-			: Input extends void
-				? RemoteFormFieldsRoot<Input>
-				: WillRecurseIndefinitely<Input> extends true
-					? RecursiveFormFields
-					: RemoteFormFieldContainer<Original[0]> & {
-							[K in KeysOfUnion<Original[0]>]-?: RemoteFormFields<
-								ValueOfUnionKey<Original[0], K>
-							>;
-						};
+		fields: RemoteFormFieldsRoot<Input, Original>;
 	};
 
 	/**

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2956,7 +2956,7 @@ declare module '$app/server' {
 	}[keyof InputTypeMap];
 
 	// Input element properties based on type
-	type InputElementProps<T extends keyof InputTypeMap> = T extends 'checkbox' | 'radio'
+	type InputElementProps<T extends keyof InputTypeMap, Value> = T extends 'checkbox' | 'radio'
 		? {
 				name: string;
 				type: T;
@@ -2993,9 +2993,9 @@ declare module '$app/server' {
 						? {
 								name: string;
 								'aria-invalid': boolean | 'false' | 'true' | undefined;
-								get value(): string | number;
-								set value(v: string | number);
-								readonly defaultValue?: string | number;
+								get value(): Value extends string ? string : string | number;
+								set value(v: Value extends string ? string : string | number);
+								readonly defaultValue?: Value extends string ? string : string | number;
 							}
 						: {
 								name: string;
@@ -3064,7 +3064,7 @@ declare module '$app/server' {
 		 */
 		as<T extends RemoteFormFieldType<Value>>(
 			...args: AsArgs<T, Value>
-		): InputElementProps<T> & { value?: WidenLiteralString<Value> };
+		): InputElementProps<T, WidenLiteralString<Value>>;
 	};
 
 	type RemoteFormFieldContainer<Value> = RemoteFormFieldMethods<Value> & {
@@ -3085,7 +3085,7 @@ declare module '$app/server' {
 		 * <input {...myForm.fields.myBoolean.as('checkbox')} />
 		 * ```
 		 */
-		as<T extends RemoteFormFieldType<Value>>(...args: AsArgs<T, Value>): InputElementProps<T>;
+		as<T extends RemoteFormFieldType<Value>>(...args: AsArgs<T, Value>): InputElementProps<T, Value>;
 	} & {
 		[key: string | number]: UnknownField<any>;
 	};

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -3106,9 +3106,7 @@ declare module '$app/server' {
 				: WillRecurseIndefinitely<Input> extends true
 					? RecursiveFormFields
 					: RemoteFormFieldContainer<Original[0]> & {
-							[K in KeysOfUnion<Original[0]>]-?: RemoteFormFields<
-								ValueOfUnionKey<Original[0], K>
-							>;
+							[K in KeysOfUnion<Original[0]>]-?: RemoteFormFields<ValueOfUnionKey<Original[0], K>>;
 						};
 
 	/**

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -3046,6 +3046,8 @@ declare module '$app/server' {
 					? [type: Type]
 					: [type: Type] | [type: Type, value: Value | undefined];
 
+	type WidenLiteralString<T> = T extends string ? (string extends T ? T : string) : T;
+
 	/**
 	 * Form field accessor type that provides name(), value(), and issues() methods
 	 */
@@ -3060,7 +3062,9 @@ declare module '$app/server' {
 		 * <input {...myForm.fields.myBoolean.as('checkbox')} />
 		 * ```
 		 */
-		as<T extends RemoteFormFieldType<Value>>(...args: AsArgs<T, Value>): InputElementProps<T>;
+		as<T extends RemoteFormFieldType<Value>>(
+			...args: AsArgs<T, Value>
+		): InputElementProps<T> & { value?: WidenLiteralString<Value> };
 	};
 
 	type RemoteFormFieldContainer<Value> = RemoteFormFieldMethods<Value> & {
@@ -3188,7 +3192,17 @@ declare module '$app/server' {
 	/**
 	 * The type of a remote `form` function. See [Remote functions](https://svelte.dev/docs/kit/remote-functions#form) for full documentation.
 	 */
-	export type RemoteForm<Input extends RemoteFormInput | void, Output> = {
+	export type RemoteForm<Input extends RemoteFormInput | void, Output> = RemoteForm_<
+		Input,
+		Output,
+		[Input]
+	>;
+
+	type RemoteForm_<
+		Input extends RemoteFormInput | void,
+		Output,
+		Original extends [RemoteFormInput | void]
+	> = {
 		/** Attachment that sets up an event handler that intercepts the form submission on the client to prevent a full page reload */
 		[attachment: symbol]: (node: HTMLFormElement) => void;
 		method: 'POST';
@@ -3242,7 +3256,17 @@ declare module '$app/server' {
 		/** True if the form has been submitted at least once, and hasn't been reset since */
 		get submitted(): boolean;
 		/** Access form fields using object notation */
-		fields: RemoteFormFieldsRoot<Input>;
+		fields: IsAny<Input> extends true
+			? RecursiveFormFields
+			: Input extends void
+				? RemoteFormFieldsRoot<Input>
+				: WillRecurseIndefinitely<Input> extends true
+					? RecursiveFormFields
+					: RemoteFormFieldContainer<Original[0]> & {
+							[K in KeysOfUnion<Original[0]>]-?: RemoteFormFields<
+								ValueOfUnionKey<Original[0], K>
+							>;
+						};
 	};
 
 	/**


### PR DESCRIPTION
closes #16931

### Union fields

Given a schema like `{ a: string } | { b: string }`, `form.fields` was typed as `{ a: RemoteFormField<string> } | { b: RemoteFormField<string> }`. That meant neither `form.fields.a` nor `form.fields.b` could be accessed, even though both fields exist on the runtime proxy:

```ts
const f = form(schema, () => {});

f.fields.a.as('text'); // error
f.fields.b.as('text'); // error
```

This preserves the original input union in a tuple so the outer conditional does not distribute over it, then deliberately collects the keys from every union member for the form instance. The container methods still use the original union, while the instance exposes both `a` and `b`; unknown fields remain errors.

### Enum fields

A string enum field kept its literal union in the attributes returned by `.as(...)`, which made an otherwise valid spread fail type checking:

```svelte
<input {...form.fields.choice.as('text', 'one')} />
```

This widens literal strings to `string` only in the returned DOM-facing `value` property. The `.as(...)` arguments still use the original enum, so `choice.as('text', 'three')` remains an error for a `'one' | 'two'` field.

Both cases have focused type regression tests.