### PR TITLE
chore: simplify .as() prop construction

### DIFF
--- a/.changeset/pre/field-name-error.md
+++ b/.changeset/pre/field-name-error.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+chore: say what a valid remote form field name looks like when rejecting one

--- a/packages/kit/src/runtime/app/server/public.d.ts
+++ b/packages/kit/src/runtime/app/server/public.d.ts
@@ -119,8 +119,8 @@ type AsArgs<Type extends keyof InputTypeMap, Value> = Type extends 'checkbox'
 	? Value extends string[]
 		? [type: Type, value: Value[number] | (string & {}), checked?: boolean]
 		: Value extends boolean
-			? [type: Type] | [type: Type, value: boolean | undefined]
-			: [type: Type] | [type: Type, value: Value]
+			? [type: Type, value?: boolean]
+			: [type: Type, value?: Value]
 	: Type extends 'submit' | 'hidden'
 		? Value extends string
 			? [type: Type, value: Value | (string & {})]
@@ -129,7 +129,7 @@ type AsArgs<Type extends keyof InputTypeMap, Value> = Type extends 'checkbox'
 			? [type: Type, value: Value | (string & {}), checked?: boolean]
 			: Type extends 'file' | 'file multiple'
 				? [type: Type]
-				: [type: Type] | [type: Type, value: Value | undefined];
+				: [type: Type, value?: Value];
 
 /**
  * Form field accessor type that provides name(), value(), and issues() methods

--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -789,6 +789,14 @@ export function create_field_proxy(context, target = {}, path = []) {
 						base_props.type = type === 'file multiple' ? 'file' : type;
 					}
 
+					/**
+					 * adds a prop that is computed each time it is read
+					 * @param {string} prop
+					 * @param {() => unknown} get
+					 */
+					const lazy = (prop, get) =>
+						Object.defineProperty(base_props, prop, { enumerable: true, get });
+
 					// Handle submit and hidden inputs
 					if (type === 'submit' || type === 'hidden') {
 						if (DEV) {
@@ -797,117 +805,72 @@ export function create_field_proxy(context, target = {}, path = []) {
 							}
 						}
 
-						const value =
+						base_props.value =
 							typeof input_value === 'boolean' ? (input_value ? 'on' : 'off') : input_value;
 
-						return Object.defineProperties(base_props, {
-							value: { value, enumerable: true }
-						});
+						return base_props;
 					}
 
 					// Handle select inputs
 					if (type === 'select' || type === 'select multiple') {
-						return Object.defineProperties(base_props, {
-							multiple: { value: is_array, enumerable: true },
-							value: {
-								enumerable: true,
-								get() {
-									return read(input_value);
-								}
-							}
-						});
+						base_props.multiple = is_array;
+
+						return lazy('value', () => read(input_value));
 					}
 
 					// Handle checkbox inputs
 					if (type === 'checkbox' || type === 'radio') {
-						if (DEV && (type === 'radio' || is_array) && !input_value) {
+						// radio and checkbox array inputs take their option as the second argument
+						// and whether it is checked as the third, a single checkbox only the latter
+						const has_option = type === 'radio' || is_array;
+
+						if (DEV && has_option && !input_value) {
 							throw new Error(
 								`${type === 'radio' ? 'Radio' : 'Checkbox array'} inputs must have a value`
 							);
 						}
 
-						/** @type {PropertyDescriptorMap} */
-						const props = {};
-
-						if (type === 'radio' || is_array) {
-							props.value = { value: input_value ?? 'on', enumerable: true };
+						if (has_option) {
+							base_props.value = input_value ?? 'on';
 						} else {
-							// a single checkbox takes its checked state as the second argument
 							checked = /** @type {boolean | undefined} */ (input_value);
 						}
 
-						props.defaultChecked = { value: checked, enumerable: true };
-						props.checked = {
-							enumerable: true,
-							get() {
-								const value = get_value();
-								if (value == null) return read(checked);
-								if (type === 'radio') return value === input_value;
-								if (is_array) return /** @type {unknown[]} */ (value).includes(input_value);
-								return value;
-							}
-						};
+						base_props.defaultChecked = checked;
 
-						return Object.defineProperties(base_props, props);
+						return lazy('checked', () => {
+							const value = get_value();
+							if (value == null) return read(checked);
+							if (type === 'radio') return value === input_value;
+							if (is_array) return /** @type {unknown[]} */ (value).includes(input_value);
+							return value;
+						});
 					}
 
 					// Handle file inputs
 					if (type === 'file' || type === 'file multiple') {
-						return Object.defineProperties(base_props, {
-							multiple: { value: is_array, enumerable: true },
-							files: {
-								enumerable: true,
-								get() {
-									const value = get_value();
+						base_props.multiple = is_array;
 
-									// Convert File/File[] to FileList-like object
-									if (value instanceof File) {
-										// In browsers, we can create a proper FileList using DataTransfer
-										if (typeof DataTransfer !== 'undefined') {
-											const fileList = new DataTransfer();
-											fileList.items.add(value);
-											return fileList.files;
-										}
-										// Fallback for environments without DataTransfer
-										return { 0: value, length: 1 };
-									}
+						return lazy('files', () => {
+							const value = get_value();
+							const files = value instanceof File ? [value] : value;
+							if (!Array.isArray(files) || !files.every((f) => f instanceof File)) return null;
 
-									if (Array.isArray(value) && value.every((f) => f instanceof File)) {
-										if (typeof DataTransfer !== 'undefined') {
-											const fileList = new DataTransfer();
-											value.forEach((file) => fileList.items.add(file));
-											return fileList.files;
-										}
-										// Fallback for environments without DataTransfer
-										/** @type {any} */
-										const fileListLike = { length: value.length };
-										value.forEach((file, index) => {
-											fileListLike[index] = file;
-										});
-										return fileListLike;
-									}
-
-									return null;
-								}
+							// a FileList-like object where DataTransfer does not exist
+							if (typeof DataTransfer === 'undefined') {
+								return Object.assign({ length: files.length }, files);
 							}
+
+							const transfer = new DataTransfer();
+							for (const file of files) transfer.items.add(file);
+							return transfer.files;
 						});
 					}
 
 					// Handle all other input types (text, number, etc.)
-					return Object.defineProperties(base_props, {
-						defaultValue: {
-							enumerable: true,
-							get() {
-								return input_value;
-							}
-						},
-						value: {
-							enumerable: true,
-							get() {
-								return String(read(input_value) ?? '');
-							}
-						}
-					});
+					base_props.defaultValue = input_value;
+
+					return lazy('value', () => String(read(input_value) ?? ''));
 				};
 
 				return create_field_proxy(context, as_func, next);

--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -604,20 +604,21 @@ export function deep_get(object, path) {
 	return current;
 }
 
+/** name prefixes that tell the server which type to coerce a submitted string to */
+const type_prefixes = /** @type {Record<string, string | undefined>} */ ({
+	number: 'n:',
+	boolean: 'b:'
+});
+
 /**
- *
- * @param {string} field_type
+ * @param {string} type
  * @param {boolean} is_array
  * @param {unknown} input_value
  */
-function get_type_prefix(field_type, is_array, input_value) {
-	if (field_type === 'number' || field_type === 'range') return 'n:';
-	if (field_type === 'checkbox' && !is_array) return 'b:';
-	if (field_type === 'hidden' || field_type === 'submit') {
-		const input_type = typeof input_value;
-		if (input_type === 'number') return 'n:';
-		if (input_type === 'boolean') return 'b:';
-	}
+function get_type_prefix(type, is_array, input_value) {
+	if (type === 'number' || type === 'range') return 'n:';
+	if (type === 'checkbox' && !is_array) return 'b:';
+	if (type === 'hidden' || type === 'submit') return type_prefixes[typeof input_value] ?? '';
 	return '';
 }
 

--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -465,7 +465,12 @@ const path_regex = /^[a-zA-Z_$]\w*(\.[a-zA-Z_$]\w*|\[\d+\])*$/;
  */
 export function split_path(path) {
 	if (!path_regex.test(path)) {
-		throw new Error(`Invalid path ${path}`);
+		throw new Error(
+			`Invalid field name ${path}` +
+				(DEV
+					? ': field names are written in JS object notation, so keys that would need quoting are not supported. See https://svelte.dev/docs/kit/remote-functions#form-Fields'
+					: '')
+		);
 	}
 
 	return path.split(/\.|\[|\]/).filter(Boolean);

--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -820,14 +820,10 @@ export function create_field_proxy(context, target = {}, path = []) {
 
 					// Handle checkbox inputs
 					if (type === 'checkbox' || type === 'radio') {
-						if (DEV) {
-							if (type === 'radio' && !input_value) {
-								throw new Error('Radio inputs must have a value');
-							}
-
-							if (type === 'checkbox' && is_array && !input_value) {
-								throw new Error('Checkbox array inputs must have a value');
-							}
+						if (DEV && (type === 'radio' || is_array) && !input_value) {
+							throw new Error(
+								`${type === 'radio' ? 'Radio' : 'Checkbox array'} inputs must have a value`
+							);
 						}
 
 						/** @type {PropertyDescriptorMap} */

--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -616,6 +616,26 @@ const type_prefixes = /** @type {Record<string, string | undefined>} */ ({
 });
 
 /**
+ * adds props; a function becomes a getter that is computed each time it is read
+ * @param {Record<string, any>} base_props
+ * @param {Record<string, unknown>} props
+ */
+function add_props(base_props, props) {
+	for (const prop in props) {
+		const value = props[prop];
+		if (typeof value === 'function') {
+			Object.defineProperty(base_props, prop, {
+				enumerable: true,
+				get: /** @type {() => unknown} */ (value)
+			});
+		} else {
+			base_props[prop] = value;
+		}
+	}
+	return base_props;
+}
+
+/**
  * @param {string} type
  * @param {boolean} is_array
  * @param {unknown} input_value
@@ -795,14 +815,6 @@ export function create_field_proxy(context, target = {}, path = []) {
 						base_props.type = type === 'file multiple' ? 'file' : type;
 					}
 
-					/**
-					 * adds a prop that is computed each time it is read
-					 * @param {string} prop
-					 * @param {() => unknown} get
-					 */
-					const lazy = (prop, get) =>
-						Object.defineProperty(base_props, prop, { enumerable: true, get });
-
 					// Handle submit and hidden inputs
 					if (type === 'submit' || type === 'hidden') {
 						if (DEV) {
@@ -811,17 +823,14 @@ export function create_field_proxy(context, target = {}, path = []) {
 							}
 						}
 
-						base_props.value =
-							typeof input_value === 'boolean' ? (input_value ? 'on' : 'off') : input_value;
-
-						return base_props;
+						return add_props(base_props, {
+							value: typeof input_value === 'boolean' ? (input_value ? 'on' : 'off') : input_value
+						});
 					}
 
 					// Handle select inputs
 					if (type === 'select' || type === 'select multiple') {
-						base_props.multiple = is_array;
-
-						return lazy('value', () => read(input_value));
+						return add_props(base_props, { multiple: is_array, value: () => read(input_value) });
 					}
 
 					// Handle checkbox inputs
@@ -842,41 +851,44 @@ export function create_field_proxy(context, target = {}, path = []) {
 							checked = /** @type {boolean | undefined} */ (input_value);
 						}
 
-						base_props.defaultChecked = checked;
-
-						return lazy('checked', () => {
-							const value = get_value();
-							if (value == null) return read(checked);
-							if (type === 'radio') return value === input_value;
-							if (is_array) return /** @type {unknown[]} */ (value).includes(input_value);
-							return value;
+						return add_props(base_props, {
+							defaultChecked: checked,
+							checked: () => {
+								const value = get_value();
+								if (value == null) return read(checked);
+								if (type === 'radio') return value === input_value;
+								if (is_array) return /** @type {unknown[]} */ (value).includes(input_value);
+								return value;
+							}
 						});
 					}
 
 					// Handle file inputs
 					if (type === 'file' || type === 'file multiple') {
-						base_props.multiple = is_array;
+						return add_props(base_props, {
+							multiple: is_array,
+							files: () => {
+								const value = get_value();
+								const files = value instanceof File ? [value] : value;
+								if (!Array.isArray(files) || !files.every((f) => f instanceof File)) return null;
 
-						return lazy('files', () => {
-							const value = get_value();
-							const files = value instanceof File ? [value] : value;
-							if (!Array.isArray(files) || !files.every((f) => f instanceof File)) return null;
+								// a FileList-like object where DataTransfer does not exist
+								if (typeof DataTransfer === 'undefined') {
+									return Object.assign({ length: files.length }, files);
+								}
 
-							// a FileList-like object where DataTransfer does not exist
-							if (typeof DataTransfer === 'undefined') {
-								return Object.assign({ length: files.length }, files);
+								const transfer = new DataTransfer();
+								for (const file of files) transfer.items.add(file);
+								return transfer.files;
 							}
-
-							const transfer = new DataTransfer();
-							for (const file of files) transfer.items.add(file);
-							return transfer.files;
 						});
 					}
 
 					// Handle all other input types (text, number, etc.)
-					base_props.defaultValue = input_value;
-
-					return lazy('value', () => String(read(input_value) ?? ''));
+					return add_props(base_props, {
+						defaultValue: input_value,
+						value: () => String(read(input_value) ?? '')
+					});
 				};
 
 				return create_field_proxy(context, as_func, next);

--- a/packages/kit/src/runtime/form-utils.spec.js
+++ b/packages/kit/src/runtime/form-utils.spec.js
@@ -893,13 +893,15 @@ describe('create_field_proxy', () => {
 			['multiple', true],
 			['value', ['y']]
 		]);
-		expect(as(['file multiple'])).toEqual([
+		const file = new File([], 'a.txt');
+		expect(as(['file multiple'], [file])).toEqual([
 			['name', 'a[]/form'],
 			invalid,
 			['type', 'file'],
 			['multiple', true],
-			['files', null]
+			['files', { 0: file, length: 1 }]
 		]);
+		expect(as(['file'], file)[4]).toEqual(['files', { 0: file, length: 1 }]);
 		expect(as(['checkbox', true], false)).toEqual([
 			['name', 'b:a/form'],
 			invalid,

--- a/packages/kit/src/runtime/form-utils.spec.js
+++ b/packages/kit/src/runtime/form-utils.spec.js
@@ -46,7 +46,7 @@ describe('split_path', () => {
 
 	for (const input of bad) {
 		test(input, () => {
-			expect(() => split_path(input)).toThrowError(`Invalid path ${input}`);
+			expect(() => split_path(input)).toThrowError(`Invalid field name ${input}`);
 		});
 	}
 });

--- a/packages/kit/src/runtime/form-utils.spec.js
+++ b/packages/kit/src/runtime/form-utils.spec.js
@@ -851,6 +851,81 @@ describe('create_field_proxy', () => {
 		expect(cloned).not.toBe(original);
 	});
 
+	test('as() returns the props of each input kind in spread order', () => {
+		/** @type {Record<string, unknown>} */
+		let input = {};
+
+		const proxy = create_field_proxy({
+			form_id: 'form',
+			get: () => input,
+			set: () => {},
+			get_issues: () => ({ bad: [] }),
+			get_touched: () => ({}),
+			get_dirty: () => ({})
+		});
+
+		/**
+		 * @param {unknown[]} args
+		 * @param {unknown} [value] the current form value of the field
+		 */
+		const as = (args, value) => {
+			input = value === undefined ? {} : { a: value };
+			return Object.entries(proxy.a.as(...args));
+		};
+
+		const invalid = ['aria-invalid', undefined];
+
+		expect(as(['text', 'x'], 'y')).toEqual([
+			['name', 'a/form'],
+			invalid,
+			['defaultValue', 'x'],
+			['value', 'y']
+		]);
+		expect(as(['hidden', true])).toEqual([
+			['name', 'b:a/form'],
+			invalid,
+			['type', 'hidden'],
+			['value', 'on']
+		]);
+		expect(as(['select multiple', ['x']], ['y'])).toEqual([
+			['name', 'a[]/form'],
+			invalid,
+			['multiple', true],
+			['value', ['y']]
+		]);
+		expect(as(['file multiple'])).toEqual([
+			['name', 'a[]/form'],
+			invalid,
+			['type', 'file'],
+			['multiple', true],
+			['files', null]
+		]);
+		expect(as(['checkbox', true], false)).toEqual([
+			['name', 'b:a/form'],
+			invalid,
+			['type', 'checkbox'],
+			['defaultChecked', true],
+			['checked', false]
+		]);
+		expect(as(['checkbox', 'red'])).toEqual([
+			['name', 'a[]/form'],
+			invalid,
+			['type', 'checkbox'],
+			['value', 'red'],
+			['defaultChecked', undefined],
+			['checked', undefined]
+		]);
+		expect(as(['radio', 'x', false], 'x')).toEqual([
+			['name', 'a/form'],
+			invalid,
+			['type', 'radio'],
+			['value', 'x'],
+			['defaultChecked', false],
+			['checked', true]
+		]);
+		expect(Object.entries(proxy.bad.as('text'))[1]).toEqual(['aria-invalid', 'true']);
+	});
+
 	test('the default given to as() only applies until the field is edited', () => {
 		const edited = create_field_proxy({
 			form_id: 'form',

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -3034,8 +3034,8 @@ declare module '$app/server' {
 		? Value extends string[]
 			? [type: Type, value: Value[number] | (string & {}), checked?: boolean]
 			: Value extends boolean
-				? [type: Type] | [type: Type, value: boolean | undefined]
-				: [type: Type] | [type: Type, value: Value]
+				? [type: Type, value?: boolean]
+				: [type: Type, value?: Value]
 		: Type extends 'submit' | 'hidden'
 			? Value extends string
 				? [type: Type, value: Value | (string & {})]
@@ -3044,7 +3044,7 @@ declare module '$app/server' {
 				? [type: Type, value: Value | (string & {}), checked?: boolean]
 				: Type extends 'file' | 'file multiple'
 					? [type: Type]
-					: [type: Type] | [type: Type, value: Value | undefined];
+					: [type: Type, value?: Value];
 
 	/**
 	 * Form field accessor type that provides name(), value(), and issues() methods


### PR DESCRIPTION
`.as()` in `packages/kit/src/runtime/form-utils.js` is restructured: data props are assigned directly with `Object.defineProperty` reserved for the accessors, the FileList is built from one array, the optional second argument is spelled as `[type, value?: X]` in `AsArgs`, and the two option guards are one.

The output of `.as()` is unchanged; the new unit test pins it per input kind including key order. `[type, value?: boolean]` still accepts `boolean | undefined`, since checkbox fields are optional in the schema, and `(string & {})` stays on the `string[]` and `radio` branches where a plain string option has to type-check against a literal union.

In dev, rejecting a field name that is not JS object notation now says what is expected and links the docs. Improves the error reported in #14801.

Stacked on #16939.
