### PR TITLE
fix: coerce values typed into remote form fields, apply the .as() default only until edited

### DIFF
--- a/.changeset/pre/as-default-until-edited.md
+++ b/.changeset/pre/as-default-until-edited.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: coerce values typed into remote form fields, and only apply the default given to `.as()` until the field is edited

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -535,7 +535,7 @@ export function form(id) {
 						}
 					}
 
-					set_nested_value(input, field, value);
+					set_nested_value(input, field, is_file ? value : coerce_form_value(field.type, value));
 				} else if (is_file) {
 					if (DEV && element.multiple) {
 						throw new Error(
@@ -554,7 +554,10 @@ export function form(id) {
 					set_nested_value(
 						input,
 						field,
-						element.type === 'checkbox' && !element.checked ? null : element.value
+						coerce_form_value(
+							field.type,
+							element.type === 'checkbox' && !element.checked ? null : element.value
+						)
 					);
 				}
 

--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -751,6 +751,17 @@ export function create_field_proxy(context, target = {}, path = []) {
 
 			if (prop === 'as') {
 				/**
+				 * the field's value, or `fallback` until the field has been edited
+				 * (without a fallback there is nothing to suppress, so `dirty` is not read)
+				 * @param {unknown} [fallback]
+				 */
+				const read = (fallback) =>
+					get_value() ??
+					(fallback !== undefined && Object.hasOwn(context.get_dirty(), key)
+						? undefined
+						: fallback);
+
+				/**
 				 * @param {string} type
 				 * @param {unknown} [input_value]
 				 * @param {boolean} [checked]
@@ -801,7 +812,7 @@ export function create_field_proxy(context, target = {}, path = []) {
 							value: {
 								enumerable: true,
 								get() {
-									return get_value() ?? input_value;
+									return read(input_value);
 								}
 							}
 						});
@@ -834,7 +845,7 @@ export function create_field_proxy(context, target = {}, path = []) {
 							enumerable: true,
 							get() {
 								const value = get_value();
-								if (value == null) return checked;
+								if (value == null) return read(checked);
 								if (type === 'radio') return value === input_value;
 								if (is_array) return /** @type {unknown[]} */ (value).includes(input_value);
 								return value;
@@ -897,8 +908,7 @@ export function create_field_proxy(context, target = {}, path = []) {
 						value: {
 							enumerable: true,
 							get() {
-								const value = get_value() ?? input_value;
-								return value != null ? String(value) : '';
+								return String(read(input_value) ?? '');
 							}
 						}
 					});

--- a/packages/kit/src/runtime/form-utils.spec.js
+++ b/packages/kit/src/runtime/form-utils.spec.js
@@ -850,4 +850,18 @@ describe('create_field_proxy', () => {
 		expect(cloned.getTime()).toBe(original.getTime());
 		expect(cloned).not.toBe(original);
 	});
+
+	test('the default given to as() only applies until the field is edited', () => {
+		const edited = create_field_proxy({
+			form_id: 'form',
+			get: () => ({}),
+			set: () => {},
+			get_issues: () => ({}),
+			get_touched: () => ({}),
+			get_dirty: () => ({ a: true })
+		});
+
+		expect(edited.a.as('number', 3).value).toBe('');
+		expect(edited.a.as('checkbox', true).checked).toBe(undefined);
+	});
 });

--- a/packages/kit/test/apps/async/src/routes/remote/form/default-until-edited/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/default-until-edited/+page.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+	import { edit } from './form.remote.ts';
+</script>
+
+<form {...edit}>
+	<input id="amount" {...edit.fields.amount.as('number', 200)} />
+	<button id="reset" type="reset">reset</button>
+</form>
+<p id="value">{JSON.stringify(edit.fields.value())}</p>

--- a/packages/kit/test/apps/async/src/routes/remote/form/default-until-edited/form.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/form/default-until-edited/form.remote.ts
@@ -1,0 +1,4 @@
+import { form } from '$app/server';
+import * as v from 'valibot';
+
+export const edit = form(v.object({ amount: v.optional(v.number()) }), async () => {});

--- a/packages/kit/test/apps/async/test/test.js
+++ b/packages/kit/test/apps/async/test/test.js
@@ -259,6 +259,29 @@ test.describe('remote functions', () => {
 		});
 	});
 
+	test('the default given to .as() only applies until the field is edited', async ({
+		page,
+		javaScriptEnabled
+	}) => {
+		test.skip(!javaScriptEnabled);
+
+		await page.goto('/remote/form/default-until-edited');
+		const amount = page.locator('#amount');
+		const value = page.locator('#value');
+		await expect(amount).toHaveValue('200');
+
+		await amount.fill('20');
+		await expect(value).toHaveText('{"amount":20}');
+
+		await amount.press('Backspace');
+		await amount.press('Backspace');
+		await expect(amount).toHaveValue('');
+		await expect(value).toHaveText('{}');
+
+		await page.click('#reset');
+		await expect(amount).toHaveValue('200');
+	});
+
 	test('radio and checkbox inputs keep the current value when only another field changes', async ({
 		page,
 		javaScriptEnabled


### PR DESCRIPTION
Since #16331 moved coercion into `coerce_form_value`, `handle_input` has stored the raw string of every typed value: `fields.value()` reported `'20'` while typing and `200` after a reset, and an emptied number field held `''` instead of `undefined`. Typed values are coerced again, the same way the submitter path already is.

That re-exposes #15937: the default passed to `.as(type, default)` was re-applied whenever the field's value became `undefined` or `null`, so an emptied number input, or one cleared with `set()`, snapped back to its default. The default now only applies until the field is dirty. `defaultValue` and `defaultChecked` are unchanged, so reset still restores it. `dirty` is the modified signal from #16208; `touched` would drop the default on a tab-through. It is client-only, so SSR and a failed no-JS submission still render defaults. #16237 keys the same rule on key presence in the model instead. Fixes #15937.
