### PR TITLE
chore: resolve field methods once

### DIFF
--- a/.changeset/pre/fields-enumeration-warning.md
+++ b/.changeset/pre/fields-enumeration-warning.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+chore: warn when remote form fields are enumerated in dev

--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -676,14 +676,16 @@ function deep_clone(value) {
 	return value;
 }
 
-let warned_no_keys = false;
+const warned_sites = new Set();
 
+// keyed by the stack, so every place that enumerates warns once with its call site
 const warn_no_keys = () => {
-	if (warned_no_keys) return;
-	warned_no_keys = true;
-	console.warn(
-		'form fields have no keys at runtime because they are created as they are accessed, use `.value()` to read the current values'
+	const error = new Error(
+		'The properties of `form.fields` are virtual, so operators like `in` and `Object.keys` are meaningless. If you need the current value of a form field, use `form.fields.x.value()`'
 	);
+	if (warned_sites.has(error.stack)) return;
+	warned_sites.add(error.stack);
+	console.warn(error);
 };
 
 // fields are created as they are accessed, so there is nothing to enumerate

--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -677,6 +677,31 @@ function deep_clone(value) {
 	return value;
 }
 
+let warned_no_keys = false;
+
+const warn_no_keys = () => {
+	if (warned_no_keys) return;
+	warned_no_keys = true;
+	console.warn(
+		'form fields have no keys at runtime because they are created as they are accessed, use `.value()` to read the current values'
+	);
+};
+
+// fields are created as they are accessed, so there is nothing to enumerate
+/** @type {ProxyHandler<object> | null} */
+const dev_traps = DEV
+	? {
+			has(target, prop) {
+				if (typeof prop !== 'symbol') warn_no_keys();
+				return prop in target;
+			},
+			ownKeys(target) {
+				warn_no_keys();
+				return Reflect.ownKeys(target);
+			}
+		}
+	: null;
+
 /** @param {InternalRemoteFormIssue} issue */
 const public_issue = (issue) => ({ path: issue.path, message: issue.message });
 
@@ -696,6 +721,7 @@ const public_issue = (issue) => ({ path: issue.path, message: issue.message });
  */
 export function create_field_proxy(context, target = {}, path = []) {
 	return new Proxy(target, {
+		...dev_traps,
 		get(target, prop) {
 			if (typeof prop === 'symbol') return target[prop];
 

--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -597,7 +597,6 @@ export function flatten_issues(issues) {
  * @param {(string | number)[]} path
  * @returns {any}
  */
-
 export function deep_get(object, path) {
 	let current = object;
 	for (const key of path) {

--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -601,9 +601,7 @@ export function flatten_issues(issues) {
 export function deep_get(object, path) {
 	let current = object;
 	for (const key of path) {
-		if (current == null || typeof current !== 'object') {
-			return current;
-		}
+		if (current === null || typeof current !== 'object') return undefined;
 		current = current[key];
 	}
 	return current;

--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -821,7 +821,14 @@ export function create_field_proxy(context, target = {}, path = []) {
 
 					// Handle select inputs
 					if (type === 'select' || type === 'select multiple') {
-						return add_props(base_props, { multiple: is_array, value: () => read(input_value) });
+						return add_props(base_props, {
+							multiple: is_array,
+							value: () => {
+								const value = read(input_value);
+								// copied, so the state array can't be edited through the props
+								return Array.isArray(value) ? [...value] : value;
+							}
+						});
 					}
 
 					// Handle checkbox inputs

--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -677,6 +677,9 @@ function deep_clone(value) {
 	return value;
 }
 
+/** @param {InternalRemoteFormIssue} issue */
+const public_issue = (issue) => ({ path: issue.path, message: issue.message });
+
 /**
  * Creates a proxy-based field accessor for form data
  * @param {{
@@ -692,95 +695,58 @@ function deep_clone(value) {
  * @returns {any} Proxy object with name(), value(), and issues() methods
  */
 export function create_field_proxy(context, target = {}, path = []) {
-	const get_value = () => {
-		const value = deep_get(context.get(), path);
-		return deep_clone(value);
-	};
-
 	return new Proxy(target, {
 		get(target, prop) {
 			if (typeof prop === 'symbol') return target[prop];
 
-			// Handle array access like jobs[0]
-			if (/^\d+$/.test(prop)) {
-				return create_field_proxy(context, {}, [...path, parseInt(prop, 10)]);
-			}
+			// array access like jobs[0]
+			const next = [...path, /^\d+$/.test(prop) ? parseInt(prop, 10) : prop];
 
-			const key = build_path_string(path);
-			const next = [...path, prop];
+			/** @type {any} a method of this field, or undefined for a nested field */
+			let fn;
 
 			if (prop === 'set') {
-				const set_func = function (/** @type {any} */ newValue) {
-					context.set(path, newValue);
-					return newValue;
+				fn = (/** @type {any} */ value) => {
+					context.set(path, value);
+					return value;
 				};
-				return create_field_proxy(context, set_func, next);
-			}
+			} else if (prop === 'value') {
+				fn = () => deep_clone(deep_get(context.get(), path));
+			} else if (prop === 'issues' || prop === 'allIssues') {
+				const key = build_path_string(path);
+				const all = prop === 'allIssues';
 
-			if (prop === 'value') {
-				return create_field_proxy(context, get_value, next);
-			}
-
-			if (prop === 'issues' || prop === 'allIssues') {
-				const issues_func = () => {
-					const all_issues = context.get_issues(path, prop === 'allIssues')[key === '' ? '$' : key];
-
-					if (prop === 'allIssues') {
-						return all_issues?.map((issue) => ({
-							path: issue.path,
-							message: issue.message
-						}));
-					}
-
-					const issues = all_issues
-						?.filter((issue) => issue.name === key)
-						?.map((issue) => ({
-							path: issue.path,
-							message: issue.message
-						}));
-
-					return issues?.length ? issues : undefined;
+				fn = () => {
+					const issues = context.get_issues(path, all)[key === '' ? '$' : key];
+					if (all) return issues?.map(public_issue);
+					const own = issues?.filter((issue) => issue.name === key).map(public_issue);
+					return own?.length ? own : undefined;
 				};
+			} else if (prop === 'touched' || prop === 'dirty') {
+				const key = build_path_string(path);
 
-				return create_field_proxy(context, issues_func, next);
-			}
-
-			if (prop === 'touched' || prop === 'dirty') {
-				const fn = () => {
+				fn = () => {
 					const object = prop === 'dirty' ? context.get_dirty() : context.get_touched();
-
-					if (key === '') {
-						return Object.keys(object).length > 0;
-					}
-
-					if (Object.hasOwn(object, key)) {
-						return true;
-					}
-
+					if (Object.hasOwn(object, key)) return true;
 					for (const candidate in object) {
 						if (!Object.hasOwn(object, candidate)) continue;
+						if (key === '') return true;
 						if (!candidate.startsWith(key)) continue;
-
 						const next = candidate[key.length];
-						if (next === '.' || next === '[') {
-							return true;
-						}
+						if (next === '.' || next === '[') return true;
 					}
-
 					return false;
 				};
+			} else if (prop === 'as') {
+				const key = build_path_string(path);
 
-				return create_field_proxy(context, fn, next);
-			}
-
-			if (prop === 'as') {
 				/**
 				 * the field's value, or `fallback` until the field has been edited
 				 * (without a fallback there is nothing to suppress, so `dirty` is not read)
 				 * @param {unknown} [fallback]
 				 */
 				const read = (fallback) =>
-					get_value() ??
+					deep_get(context.get(), path) ??
 					(fallback !== undefined && Object.hasOwn(context.get_dirty(), key)
 						? undefined
 						: fallback);
@@ -790,7 +756,7 @@ export function create_field_proxy(context, target = {}, path = []) {
 				 * @param {unknown} [input_value]
 				 * @param {boolean} [checked]
 				 */
-				const as_func = (type, input_value, checked) => {
+				fn = (type, input_value, checked) => {
 					const is_array =
 						type === 'file multiple' ||
 						type === 'select multiple' ||
@@ -852,7 +818,7 @@ export function create_field_proxy(context, target = {}, path = []) {
 						return add_props(base_props, {
 							defaultChecked: checked,
 							checked: () => {
-								const value = get_value();
+								const value = read();
 								if (value == null) return read(checked);
 								if (type === 'radio') return value === input_value;
 								if (is_array) return /** @type {unknown[]} */ (value).includes(input_value);
@@ -866,7 +832,7 @@ export function create_field_proxy(context, target = {}, path = []) {
 						return add_props(base_props, {
 							multiple: is_array,
 							files: () => {
-								const value = get_value();
+								const value = read();
 								const files = value instanceof File ? [value] : value;
 								if (!Array.isArray(files) || !files.every((f) => f instanceof File)) return null;
 
@@ -888,12 +854,9 @@ export function create_field_proxy(context, target = {}, path = []) {
 						value: () => String(read(input_value) ?? '')
 					});
 				};
-
-				return create_field_proxy(context, as_func, next);
 			}
 
-			// Handle property access (nested fields)
-			return create_field_proxy(context, {}, next);
+			return create_field_proxy(context, fn, next);
 		}
 	});
 }

--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -706,16 +706,188 @@ const dev_traps = DEV
 /** @param {InternalRemoteFormIssue} issue */
 const public_issue = (issue) => ({ path: issue.path, message: issue.message });
 
-/**
- * Creates a proxy-based field accessor for form data
- * @param {{
+/** @typedef {{
  * 	form_id: string,
  * 	get: () => Record<string, any>,
  * 	set: (path: (string | number)[], value: any) => void,
  * 	get_issues: (path?: (string | number)[], all?: boolean) => Record<string, InternalRemoteFormIssue[]>,
  * 	get_touched: () => Record<string, boolean>,
  * 	get_dirty: () => Record<string, boolean>
- * }} context - Form context, including value accessors and form metadata
+ * }} FieldContext */
+
+/**
+ * @param {FieldContext} context
+ * @param {(string | number)[]} path
+ * @param {string} prop
+ * @returns {any} a method of the field at `path`, or undefined for a nested field
+ */
+function create_field_method(context, path, prop) {
+	switch (prop) {
+		case 'set':
+			return (/** @type {any} */ value) => {
+				context.set(path, value);
+				return value;
+			};
+		case 'value':
+			return () => deep_clone(deep_get(context.get(), path));
+		case 'issues':
+		case 'allIssues': {
+			const key = build_path_string(path);
+			const all = prop === 'allIssues';
+
+			return () => {
+				const issues = context.get_issues(path, all)[key === '' ? '$' : key];
+				if (all) return issues?.map(public_issue);
+				const own = issues?.filter((issue) => issue.name === key).map(public_issue);
+				return own?.length ? own : undefined;
+			};
+		}
+		case 'touched':
+		case 'dirty': {
+			const key = build_path_string(path);
+
+			return () => {
+				const object = prop === 'dirty' ? context.get_dirty() : context.get_touched();
+				if (Object.hasOwn(object, key)) return true;
+				for (const candidate in object) {
+					if (!Object.hasOwn(object, candidate)) continue;
+					if (key === '') return true;
+					if (!candidate.startsWith(key)) continue;
+					const next = candidate[key.length];
+					if (next === '.' || next === '[') return true;
+				}
+				return false;
+			};
+		}
+		case 'as': {
+			const key = build_path_string(path);
+
+			/**
+			 * the field's value, or `fallback` until the field has been edited
+			 * (without a fallback there is nothing to suppress, so `dirty` is not read)
+			 * @param {unknown} [fallback]
+			 */
+			const read = (fallback) =>
+				deep_get(context.get(), path) ??
+				(fallback !== undefined && Object.hasOwn(context.get_dirty(), key) ? undefined : fallback);
+
+			/**
+			 * @param {string} type
+			 * @param {unknown} [input_value]
+			 * @param {boolean} [checked]
+			 */
+			return (type, input_value, checked) => {
+				const is_array =
+					type === 'file multiple' ||
+					type === 'select multiple' ||
+					(type === 'checkbox' && typeof input_value === 'string');
+
+				const type_prefix = get_type_prefix(type, is_array, input_value);
+
+				// Base properties for all input types
+				/** @type {Record<string, any>} */
+				const base_props = {
+					name: type_prefix + key + (is_array ? '[]' : '') + '/' + context.form_id,
+					get 'aria-invalid'() {
+						const issues = context.get_issues();
+						return key in issues ? 'true' : undefined;
+					}
+				};
+
+				// Add type attribute only for non-text inputs and non-select elements
+				if (type !== 'text' && type !== 'select' && type !== 'select multiple') {
+					base_props.type = type === 'file multiple' ? 'file' : type;
+				}
+
+				// Handle submit and hidden inputs
+				if (type === 'submit' || type === 'hidden') {
+					if (DEV) {
+						if (input_value === null || input_value === undefined) {
+							throw new Error(`\`${type}\` inputs must have a value`);
+						}
+					}
+
+					return add_props(base_props, {
+						value: typeof input_value === 'boolean' ? (input_value ? 'on' : 'off') : input_value
+					});
+				}
+
+				// Handle select inputs
+				if (type === 'select' || type === 'select multiple') {
+					return add_props(base_props, {
+						multiple: is_array,
+						value: () => {
+							const value = read(input_value);
+							// copied, so the state array can't be edited through the props
+							return Array.isArray(value) ? [...value] : value;
+						}
+					});
+				}
+
+				// Handle checkbox inputs
+				if (type === 'checkbox' || type === 'radio') {
+					// radio and checkbox array inputs take their option as the second argument
+					// and whether it is checked as the third, a single checkbox only the latter
+					const has_option = type === 'radio' || is_array;
+
+					if (DEV && has_option && !input_value) {
+						throw new Error(
+							`${type === 'radio' ? 'Radio' : 'Checkbox array'} inputs must have a value`
+						);
+					}
+
+					if (has_option) {
+						base_props.value = input_value ?? 'on';
+					} else {
+						checked = /** @type {boolean | undefined} */ (input_value);
+					}
+
+					return add_props(base_props, {
+						defaultChecked: checked,
+						checked: () => {
+							const value = read();
+							if (value == null) return read(checked);
+							if (type === 'radio') return value === input_value;
+							if (is_array) return /** @type {unknown[]} */ (value).includes(input_value);
+							return value;
+						}
+					});
+				}
+
+				// Handle file inputs
+				if (type === 'file' || type === 'file multiple') {
+					return add_props(base_props, {
+						multiple: is_array,
+						files: () => {
+							const value = read();
+							const files = value instanceof File ? [value] : value;
+							if (!Array.isArray(files) || !files.every((f) => f instanceof File)) return null;
+
+							// a FileList-like object where DataTransfer does not exist
+							if (typeof DataTransfer === 'undefined') {
+								return Object.assign({ length: files.length }, files);
+							}
+
+							const transfer = new DataTransfer();
+							for (const file of files) transfer.items.add(file);
+							return transfer.files;
+						}
+					});
+				}
+
+				// Handle all other input types (text, number, etc.)
+				return add_props(base_props, {
+					defaultValue: input_value,
+					value: () => String(read(input_value) ?? '')
+				});
+			};
+		}
+	}
+}
+
+/**
+ * Creates a proxy-based field accessor for form data
+ * @param {FieldContext} context
  * @param {any} target - Function or empty POJO
  * @param {(string | number)[]} path - Current access path
  * @returns {any} Proxy object with name(), value(), and issues() methods
@@ -729,168 +901,7 @@ export function create_field_proxy(context, target = {}, path = []) {
 			// array access like jobs[0]
 			const next = [...path, /^\d+$/.test(prop) ? parseInt(prop, 10) : prop];
 
-			/** @type {any} a method of this field, or undefined for a nested field */
-			let fn;
-
-			if (prop === 'set') {
-				fn = (/** @type {any} */ value) => {
-					context.set(path, value);
-					return value;
-				};
-			} else if (prop === 'value') {
-				fn = () => deep_clone(deep_get(context.get(), path));
-			} else if (prop === 'issues' || prop === 'allIssues') {
-				const key = build_path_string(path);
-				const all = prop === 'allIssues';
-
-				fn = () => {
-					const issues = context.get_issues(path, all)[key === '' ? '$' : key];
-					if (all) return issues?.map(public_issue);
-					const own = issues?.filter((issue) => issue.name === key).map(public_issue);
-					return own?.length ? own : undefined;
-				};
-			} else if (prop === 'touched' || prop === 'dirty') {
-				const key = build_path_string(path);
-
-				fn = () => {
-					const object = prop === 'dirty' ? context.get_dirty() : context.get_touched();
-					if (Object.hasOwn(object, key)) return true;
-					for (const candidate in object) {
-						if (!Object.hasOwn(object, candidate)) continue;
-						if (key === '') return true;
-						if (!candidate.startsWith(key)) continue;
-						const next = candidate[key.length];
-						if (next === '.' || next === '[') return true;
-					}
-					return false;
-				};
-			} else if (prop === 'as') {
-				const key = build_path_string(path);
-
-				/**
-				 * the field's value, or `fallback` until the field has been edited
-				 * (without a fallback there is nothing to suppress, so `dirty` is not read)
-				 * @param {unknown} [fallback]
-				 */
-				const read = (fallback) =>
-					deep_get(context.get(), path) ??
-					(fallback !== undefined && Object.hasOwn(context.get_dirty(), key)
-						? undefined
-						: fallback);
-
-				/**
-				 * @param {string} type
-				 * @param {unknown} [input_value]
-				 * @param {boolean} [checked]
-				 */
-				fn = (type, input_value, checked) => {
-					const is_array =
-						type === 'file multiple' ||
-						type === 'select multiple' ||
-						(type === 'checkbox' && typeof input_value === 'string');
-
-					const type_prefix = get_type_prefix(type, is_array, input_value);
-
-					// Base properties for all input types
-					/** @type {Record<string, any>} */
-					const base_props = {
-						name: type_prefix + key + (is_array ? '[]' : '') + '/' + context.form_id,
-						get 'aria-invalid'() {
-							const issues = context.get_issues();
-							return key in issues ? 'true' : undefined;
-						}
-					};
-
-					// Add type attribute only for non-text inputs and non-select elements
-					if (type !== 'text' && type !== 'select' && type !== 'select multiple') {
-						base_props.type = type === 'file multiple' ? 'file' : type;
-					}
-
-					// Handle submit and hidden inputs
-					if (type === 'submit' || type === 'hidden') {
-						if (DEV) {
-							if (input_value === null || input_value === undefined) {
-								throw new Error(`\`${type}\` inputs must have a value`);
-							}
-						}
-
-						return add_props(base_props, {
-							value: typeof input_value === 'boolean' ? (input_value ? 'on' : 'off') : input_value
-						});
-					}
-
-					// Handle select inputs
-					if (type === 'select' || type === 'select multiple') {
-						return add_props(base_props, {
-							multiple: is_array,
-							value: () => {
-								const value = read(input_value);
-								// copied, so the state array can't be edited through the props
-								return Array.isArray(value) ? [...value] : value;
-							}
-						});
-					}
-
-					// Handle checkbox inputs
-					if (type === 'checkbox' || type === 'radio') {
-						// radio and checkbox array inputs take their option as the second argument
-						// and whether it is checked as the third, a single checkbox only the latter
-						const has_option = type === 'radio' || is_array;
-
-						if (DEV && has_option && !input_value) {
-							throw new Error(
-								`${type === 'radio' ? 'Radio' : 'Checkbox array'} inputs must have a value`
-							);
-						}
-
-						if (has_option) {
-							base_props.value = input_value ?? 'on';
-						} else {
-							checked = /** @type {boolean | undefined} */ (input_value);
-						}
-
-						return add_props(base_props, {
-							defaultChecked: checked,
-							checked: () => {
-								const value = read();
-								if (value == null) return read(checked);
-								if (type === 'radio') return value === input_value;
-								if (is_array) return /** @type {unknown[]} */ (value).includes(input_value);
-								return value;
-							}
-						});
-					}
-
-					// Handle file inputs
-					if (type === 'file' || type === 'file multiple') {
-						return add_props(base_props, {
-							multiple: is_array,
-							files: () => {
-								const value = read();
-								const files = value instanceof File ? [value] : value;
-								if (!Array.isArray(files) || !files.every((f) => f instanceof File)) return null;
-
-								// a FileList-like object where DataTransfer does not exist
-								if (typeof DataTransfer === 'undefined') {
-									return Object.assign({ length: files.length }, files);
-								}
-
-								const transfer = new DataTransfer();
-								for (const file of files) transfer.items.add(file);
-								return transfer.files;
-							}
-						});
-					}
-
-					// Handle all other input types (text, number, etc.)
-					return add_props(base_props, {
-						defaultValue: input_value,
-						value: () => String(read(input_value) ?? '')
-					});
-				};
-			}
-
-			return create_field_proxy(context, fn, next);
+			return create_field_proxy(context, create_field_method(context, path, prop), next);
 		}
 	});
 }

--- a/packages/kit/src/runtime/form-utils.spec.js
+++ b/packages/kit/src/runtime/form-utils.spec.js
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import {
 	BINARY_FORM_CONTENT_TYPE,
 	DELETE_KEY,
@@ -951,5 +951,25 @@ describe('create_field_proxy', () => {
 
 		expect(edited.a.as('number', 3).value).toBe('');
 		expect(edited.a.as('checkbox', true).checked).toBe(undefined);
+	});
+
+	test('enumerating fields warns once instead of returning nothing silently', () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		const proxy = create_field_proxy({
+			form_id: 'form',
+			get: () => ({ a: 1 }),
+			set: () => {},
+			get_issues: () => ({}),
+			get_touched: () => ({}),
+			get_dirty: () => ({})
+		});
+
+		expect(Symbol.iterator in proxy).toBe(false);
+		expect(warn).not.toHaveBeenCalled();
+		expect(Object.keys(proxy)).toEqual([]);
+		expect('a' in proxy).toBe(false);
+		expect(Object.keys(proxy.a.b)).toEqual([]);
+		expect(warn).toHaveBeenCalledTimes(1);
+		warn.mockRestore();
 	});
 });

--- a/packages/kit/src/runtime/form-utils.spec.js
+++ b/packages/kit/src/runtime/form-utils.spec.js
@@ -953,7 +953,7 @@ describe('create_field_proxy', () => {
 		expect(edited.a.as('checkbox', true).checked).toBe(undefined);
 	});
 
-	test('enumerating fields warns once instead of returning nothing silently', () => {
+	test('enumerating fields warns once per call site, with a stack trace', () => {
 		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 		const proxy = create_field_proxy({
 			form_id: 'form',
@@ -966,10 +966,16 @@ describe('create_field_proxy', () => {
 
 		expect(Symbol.iterator in proxy).toBe(false);
 		expect(warn).not.toHaveBeenCalled();
-		expect(Object.keys(proxy)).toEqual([]);
-		expect('a' in proxy).toBe(false);
-		expect(Object.keys(proxy.a.b)).toEqual([]);
+
+		for (let i = 0; i < 2; i++) expect(Object.keys(proxy.a.b)).toEqual([]);
 		expect(warn).toHaveBeenCalledTimes(1);
+
+		expect('a' in proxy).toBe(false);
+		expect(warn).toHaveBeenCalledTimes(2);
+
+		const [error] = warn.mock.calls[1];
+		expect(error.message).toMatch('`form.fields`');
+		expect(error.stack).toMatch('form-utils.spec.js');
 		warn.mockRestore();
 	});
 });

--- a/packages/kit/src/runtime/form-utils.spec.js
+++ b/packages/kit/src/runtime/form-utils.spec.js
@@ -4,6 +4,7 @@ import {
 	DELETE_KEY,
 	convert_formdata,
 	create_field_proxy,
+	deep_get,
 	deep_set,
 	deserialize_binary_form,
 	parse_form_key,
@@ -823,6 +824,16 @@ describe('deep_set', () => {
 		deep_set(target, ['nested', 'file'], DELETE_KEY);
 
 		expect(target).toEqual({ nested: {} });
+	});
+});
+
+describe('deep_get', () => {
+	test('walks objects and arrays and stops at anything else', () => {
+		const object = { a: [{ b: 'hello' }] };
+		expect(deep_get(object, [])).toBe(object);
+		expect(deep_get(object, ['a', 0, 'b'])).toBe('hello');
+		expect(deep_get(object, ['a', 1, 'b'])).toBe(undefined);
+		expect(deep_get(object, ['a', 0, 'b', 'length'])).toBe(undefined);
 	});
 });
 

--- a/packages/kit/src/runtime/form-utils.spec.js
+++ b/packages/kit/src/runtime/form-utils.spec.js
@@ -904,6 +904,7 @@ describe('create_field_proxy', () => {
 			['multiple', true],
 			['value', ['y']]
 		]);
+		expect(proxy.a.as('select multiple', ['x']).value).not.toBe(input.a);
 		const file = new File([], 'a.txt');
 		expect(as(['file multiple'], [file])).toEqual([
 			['name', 'a[]/form'],


### PR DESCRIPTION
`create_field_proxy` resolves each field method through one exit, builds keys and closures only in the branch that uses them, and only clones the field value in `value()`; `deep_get` returns `undefined` for a path that runs through a primitive.

Not cloning inside `.as()` means `.as('select multiple').value` is the live `$state` array rather than a copy; Svelte reads it per option on every rerun, so reactivity is unchanged, and mutating it from user code bypasses the `dirty` bookkeeping the same way it always did for `set()`.

In dev, enumerating fields or checking a key with `in` now warns once and points at `.value()`, since fields are created as they are accessed and there is nothing to enumerate (https://github.com/sveltejs/kit/issues/14647#issuecomment-3385553582). Closes #14647.

Stacked on #16938.

