### PR TITLE
chore: replace acorn with Vite's parseSync

### DIFF
--- a/.changeset/wise-parsers-swim.md
+++ b/.changeset/wise-parsers-swim.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+chore: parse page options and remote modules with Vite's `parseSync` instead of `acorn`

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -20,8 +20,6 @@
 	"dependencies": {
 		"@rolldown/pluginutils": "^1.0.1",
 		"@standard-schema/spec": "^1.1.0",
-		"@sveltejs/acorn-typescript": "^1.0.12",
-		"acorn": "^8.18.0",
 		"cookie": "^2.0.1",
 		"devalue": "^5.9.0",
 		"esm-env": "^1.2.2",

--- a/packages/kit/src/exports/vite/build/remote.js
+++ b/packages/kit/src/exports/vite/build/remote.js
@@ -3,7 +3,6 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { Parser } from 'acorn';
 import MagicString from 'magic-string';
 import { posixify } from '../../../utils/os.js';
 
@@ -59,11 +58,12 @@ export async function treeshake_prerendered_remotes(
 		const chunk_path = posixify(path.relative(cwd, `${out}/server/${remote_chunk.fileName}`));
 
 		const code = fs.readFileSync(chunk_path, 'utf-8');
-		const parsed = Parser.parse(code, { sourceType: 'module', ecmaVersion: 'latest' });
+		const parsed = vite.parseSync(chunk_path, code);
+		if (parsed.errors.length) throw new Error(parsed.errors[0].message);
 		const modified_code = new MagicString(code);
 
 		for (const fn of prerendered) {
-			for (const node of parsed.body) {
+			for (const node of parsed.program.body) {
 				const declaration =
 					node.type === 'ExportNamedDeclaration'
 						? node.declaration
@@ -85,7 +85,7 @@ export async function treeshake_prerendered_remotes(
 			}
 		}
 
-		for (const node of parsed.body) {
+		for (const node of parsed.program.body) {
 			if (node.type === 'ExportDefaultDeclaration') {
 				modified_code.remove(node.start, node.end);
 			}

--- a/packages/kit/src/exports/vite/static_analysis/index.js
+++ b/packages/kit/src/exports/vite/static_analysis/index.js
@@ -1,4 +1,5 @@
 /** @import { PageOptions } from './types.js' */
+/** @import { ESTree } from 'vite' */
 import path from 'node:path';
 import { parseSync } from 'vite';
 import { read } from '../../../utils/filesystem.js';
@@ -39,7 +40,7 @@ export function statically_analyse_page_options(filename, input) {
 		const source = parseSync(filename, input, { sourceType: 'module' });
 		if (source.errors.length) throw new Error(source.errors[0].message);
 
-		/** @type {Map<string, Extract<import('vite').ESTree.Expression, { type: 'Literal' }>['value']>} */
+		/** @type {Map<string, Extract<ESTree.Expression, { type: 'Literal' }>['value']>} */
 		const page_options = new Map();
 
 		for (const statement of source.program.body) {
@@ -201,7 +202,7 @@ export function statically_analyse_page_options(filename, input) {
 }
 
 /**
- * @param {import('vite').ESTree.ModuleExportName} node
+ * @param {ESTree.ModuleExportName} node
  * @returns {string}
  */
 function get_name(node) {

--- a/packages/kit/src/exports/vite/static_analysis/index.js
+++ b/packages/kit/src/exports/vite/static_analysis/index.js
@@ -1,7 +1,6 @@
 /** @import { PageOptions } from './types.js' */
 import path from 'node:path';
-import { tsPlugin } from '@sveltejs/acorn-typescript';
-import { Parser } from 'acorn';
+import { parseSync } from 'vite';
 import { read } from '../../../utils/filesystem.js';
 
 export const valid_page_options_array = /** @type {const} */ ([
@@ -21,8 +20,6 @@ const skip_parsing_regex = new RegExp(
 	`${Array.from(valid_page_options).join('|')}|(?:export[\\s\\n]+\\*[\\s\\n]+from)`
 );
 
-const parser = Parser.extend(tsPlugin());
-
 /**
  * Collects page options from a +page.js/+layout.js file, ignoring reassignments
  * and using the declared value (except for load functions, for which the value is `true`).
@@ -39,15 +36,13 @@ export function statically_analyse_page_options(filename, input) {
 	}
 
 	try {
-		const source = parser.parse(input, {
-			sourceType: 'module',
-			ecmaVersion: 'latest'
-		});
+		const source = parseSync(filename, input, { sourceType: 'module' });
+		if (source.errors.length) throw new Error(source.errors[0].message);
 
-		/** @type {Map<string, import('acorn').Literal['value']>} */
+		/** @type {Map<string, Extract<import('vite').ESTree.Expression, { type: 'Literal' }>['value']>} */
 		const page_options = new Map();
 
-		for (const statement of source.body) {
+		for (const statement of source.program.body) {
 			// ignore export all declarations with aliases that are not page options
 			if (
 				statement.type === 'ExportAllDeclaration' &&
@@ -82,7 +77,7 @@ export function statically_analyse_page_options(filename, input) {
 					export_specifiers.set(get_name(specifier.local), exported_name);
 				}
 
-				for (const statement of source.body) {
+				for (const statement of source.program.body) {
 					switch (statement.type) {
 						case 'ImportDeclaration': {
 							for (const import_specifier of statement.specifiers) {
@@ -105,7 +100,10 @@ export function statically_analyse_page_options(filename, input) {
 
 							// class and function declarations
 							if (declaration.type !== 'VariableDeclaration') {
-								if (export_specifiers.has(declaration.id.name)) {
+								if (
+									declaration.id?.type === 'Identifier' &&
+									export_specifiers.has(declaration.id.name)
+								) {
 									return null;
 								}
 								break;
@@ -156,9 +154,10 @@ export function statically_analyse_page_options(filename, input) {
 
 			// class and function declarations
 			if (statement.declaration.type !== 'VariableDeclaration') {
-				if (valid_page_options.has(statement.declaration.id.name)) {
+				const { id } = statement.declaration;
+				if (id?.type === 'Identifier' && valid_page_options.has(id.name)) {
 					// Special case: We only want to know that 'load' is exported (in a way that doesn't cause truthy checks in other places to trigger)
-					if (statement.declaration.id.name === 'load') {
+					if (id.name === 'load') {
 						page_options.set('load', null);
 					} else {
 						return null;
@@ -202,7 +201,7 @@ export function statically_analyse_page_options(filename, input) {
 }
 
 /**
- * @param {import('acorn').Identifier | import('acorn').Literal} node
+ * @param {import('vite').ESTree.ModuleExportName} node
  * @returns {string}
  */
 function get_name(node) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -558,12 +558,6 @@ importers:
       '@standard-schema/spec':
         specifier: ^1.1.0
         version: 1.1.0
-      '@sveltejs/acorn-typescript':
-        specifier: ^1.0.12
-        version: 1.0.12(acorn@8.18.0)
-      acorn:
-        specifier: ^8.18.0
-        version: 8.18.0
       cookie:
         specifier: ^2.0.1
         version: 2.0.1


### PR DESCRIPTION
Vite 8 exports `parseSync` (oxc, bundled inside rolldown) and deprecates `parseAst` in its favour: https://vite.dev/guide/migration#advanced. It parses TS natively, so `@sveltejs/acorn-typescript` goes too.
