### PR TITLE
chore: replace @iarna/toml with smol-toml

### DIFF
--- a/.changeset/tidy-tomls-parse.md
+++ b/.changeset/tidy-tomls-parse.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-netlify': patch
+---
+
+chore: replace `@iarna/toml` with `smol-toml`

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -3,7 +3,7 @@ import { join, posix } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { builtinModules } from 'node:module';
 import process from 'node:process';
-import toml from '@iarna/toml';
+import { parse } from 'smol-toml';
 import { build } from 'rolldown';
 import { matches, get_publish_directory, s } from './utils.js';
 
@@ -11,7 +11,7 @@ import { matches, get_publish_directory, s } from './utils.js';
  * @typedef {{
  *   build?: { publish?: string }
  *   functions?: { node_bundler?: 'zisi' | 'esbuild' }
- * } & toml.JsonMap} NetlifyConfig
+ * } & import('smol-toml').TomlTable} NetlifyConfig
  */
 
 const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf-8'));
@@ -218,7 +218,7 @@ function get_netlify_config() {
 	if (!existsSync('netlify.toml')) return null;
 
 	try {
-		return toml.parse(readFileSync('netlify.toml', 'utf-8'));
+		return parse(readFileSync('netlify.toml', 'utf-8'));
 	} catch (err) {
 		if (err instanceof Error) {
 			throw new Error(`Failed to parse netlify.toml: ${err.message}`, { cause: err });

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -1,3 +1,4 @@
+/** @import { TomlTable } from 'smol-toml' */
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join, posix } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -11,7 +12,7 @@ import { matches, get_publish_directory, s } from './utils.js';
  * @typedef {{
  *   build?: { publish?: string }
  *   functions?: { node_bundler?: 'zisi' | 'esbuild' }
- * } & import('smol-toml').TomlTable} NetlifyConfig
+ * } & TomlTable} NetlifyConfig
  */
 
 const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf-8'));

--- a/packages/adapter-netlify/package.json
+++ b/packages/adapter-netlify/package.json
@@ -42,9 +42,9 @@
 		"test": "pnpm test:unit && pnpm test:build"
 	},
 	"dependencies": {
-		"@iarna/toml": "^2.2.5",
 		"@netlify/types": "^2.8.0",
-		"rolldown": "^1.2.3"
+		"rolldown": "^1.2.3",
+		"smol-toml": "^1.8.0"
 	},
 	"devDependencies": {
 		"@netlify/edge-functions": "^3.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,15 +248,15 @@ importers:
 
   packages/adapter-netlify:
     dependencies:
-      '@iarna/toml':
-        specifier: ^2.2.5
-        version: 2.2.5
       '@netlify/types':
         specifier: ^2.8.0
         version: 2.8.0
       rolldown:
         specifier: ^1.2.3
         version: 1.2.3
+      smol-toml:
+        specifier: ^1.8.0
+        version: 1.8.0
     devDependencies:
       '@netlify/edge-functions':
         specifier: ^3.0.8
@@ -2155,9 +2155,6 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
-
-  '@iarna/toml@2.2.5':
-    resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -4205,6 +4202,10 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  smol-toml@1.8.0:
+    resolution: {integrity: sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==}
+    engines: {node: '>= 18'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -4979,8 +4980,6 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
-
-  '@iarna/toml@2.2.5': {}
 
   '@img/colour@1.1.0': {}
 
@@ -6869,6 +6868,8 @@ snapshots:
       totalist: 3.0.1
 
   sisteransi@1.0.5: {}
+
+  smol-toml@1.8.0: {}
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
`@iarna/toml` last shipped in 2020 and implements TOML 0.5. `smol-toml` is TOML 1.0, ESM, dependency-free, and is what `@netlify/config` itself parses `netlify.toml` with, so the adapter now accepts exactly what Netlify accepts (TOML 1.0 mixed-type arrays, for one, throw today).
