### PR TITLE
breaking: remove `Server` constructor from public type

### DIFF
--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -12,7 +12,7 @@ import {
 	RequestOptions,
 	RouteSegment
 } from '../types/private.js';
-import { SSRManifest, ValidatedConfig } from 'types';
+import { ValidatedConfig } from 'types';
 import { Plugin } from 'vite';
 import { RouteId as AppRouteId, LayoutParams as AppLayoutParams } from '$app/types';
 import { StandardSchemaV1 } from '@standard-schema/spec';
@@ -681,8 +681,7 @@ export interface RouteDefinition<Config = any> {
 	config: Config;
 }
 
-export class Server {
-	constructor(manifest: SSRManifest);
+export interface Server {
 	init(options: ServerInitOptions): Promise<void>;
 	respond(request: Request, options: RequestOptions): Promise<Response>;
 }

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -194,7 +194,8 @@ export interface InternalRequestOptions extends RequestOptions {
 	emulator?: Emulator;
 }
 
-export class InternalServer extends Server {
+export class InternalServer implements Server {
+	constructor(manifest: SSRManifest);
 	init(options: ServerInitOptions): Promise<void>;
 	respond(request: Request, options: InternalRequestOptions): Promise<Response>;
 }
@@ -461,48 +462,36 @@ export interface ServerNode {
 
 /**
  * Information required to instantiate a new `Server` instance.
- * This interface's fields are internal implementation details, and
- * changes may be made at any time without being considered breaking.
  */
 export interface SSRManifest {
 	/**
-	 * The directory where SvelteKit keeps its stuff, including static assets (such as JS and CSS) and internally-used routes.
-	 * @internal
+	 * The directory where SvelteKit keeps its stuff, including static assets
+	 * (such as JS and CSS) and internally-used routes.
 	 */
 	app_dir: string;
 	/**
 	 * The `base` and `appDir` settings combined without a leading slash.
-	 * @internal
 	 */
 	app_path: string;
 	/**
 	 * Static files from `config.files.assets` and the service worker (if any).
-	 * @internal
 	 */
 	assets: Set<string>;
 	/**
 	 * Map of file extensions to MIME types
-	 * @internal
 	 */
 	mime_types: Record<string, string>;
-	/** @internal */
 	client: BuildData['client'];
-	/** @internal */
 	nodes: SSRNodeLoader[];
 	/**
 	 * hashed filename -> import to that file
-	 * @internal
 	 */
 	remotes: Record<string, () => Promise<{ default: Record<string, any> }>>;
-	/** @internal */
 	routes: SSRRoute[];
-	/** @internal */
 	prerendered_routes: Set<string>;
-	/** @internal */
 	matchers: () => Promise<Record<string, ParamMatcher>>;
 	/**
 	 * A `[file]: size` map of all assets imported by server code.
-	 * @internal
 	 */
 	server_assets: Record<string, number>;
 }

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -665,8 +665,7 @@ declare module '@sveltejs/kit' {
 		config: Config;
 	}
 
-	export class Server {
-		constructor(manifest: SSRManifest);
+	export interface Server {
 		init(options: ServerInitOptions): Promise<void>;
 		respond(request: Request, options: RequestOptions): Promise<Response>;
 	}
@@ -916,14 +915,6 @@ declare module '@sveltejs/kit' {
 			? RecursiveRequired<T[K]> // recursively continue through.
 			: T[K]; // Use the exact type for everything else
 	};
-
-	/**
-	 * Information required to instantiate a new `Server` instance.
-	 * This interface's fields are internal implementation details, and
-	 * changes may be made at any time without being considered breaking.
-	 */
-	interface SSRManifest {
-	}
 
 	type ValidatedConfig = RecursiveRequired<Omit<Config, 'preprocess'>> & {
 		preprocess: Config['preprocess'];


### PR DESCRIPTION
Building on top of https://github.com/sveltejs/kit/pull/16878

Removing the constructor lets us remove the `SSRManifest` type completely from the public types. We still keep it for the internal `Server` class though