### PR TITLE
image input fixes for #16944

### DIFF
--- a/packages/kit/src/runtime/app/server/public.d.ts
+++ b/packages/kit/src/runtime/app/server/public.d.ts
@@ -45,13 +45,7 @@ type InputTypeMap = {
 
 // Valid input types for a given value type
 export type RemoteFormFieldType<T> = {
-	[K in keyof InputTypeMap]: K extends 'image'
-		? IsImageInputValue<T> extends true
-			? K
-			: never
-		: T extends InputTypeMap[K]
-			? K
-			: never;
+	[K in keyof InputTypeMap]: T extends InputTypeMap[K] ? K : never;
 }[keyof InputTypeMap];
 
 // Input element properties based on type

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -615,7 +615,7 @@ export function form(id) {
 					}
 
 					const default_submitter = /** @type {HTMLElement | undefined} */ (
-						element.querySelector('button:not([type]), [type="submit"]')
+						element.querySelector('button:not([type]), [type="submit"], [type="image"]')
 					);
 
 					const form_data = new FormData(element, default_submitter);
@@ -706,7 +706,7 @@ export function form(id) {
 					if (!element) return;
 
 					const default_submitter = /** @type {HTMLElement | undefined} */ (
-						element.querySelector('button:not([type]), [type="submit"]')
+						element.querySelector('button:not([type]), [type="submit"], [type="image"]')
 					);
 
 					const form_data = new FormData(element, default_submitter);

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -446,7 +446,7 @@ export function form(id) {
 					set_nested_value(input, previous_submitter, undefined);
 				}
 
-				if (event.submitter) {
+				if (event.submitter && /** @type {HTMLInputElement} */ (event.submitter).type !== 'image') {
 					const name = event.submitter.getAttribute('name');
 
 					/** @type {null | ReturnType<typeof parse_form_key>} */

--- a/packages/kit/test/apps/async/src/routes/remote/form/image-validate/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/image-validate/+page.svelte
@@ -1,0 +1,20 @@
+<script>
+	import { image_validate_form } from './form.remote.ts';
+</script>
+
+<form {...image_validate_form} oninput={() => image_validate_form.validate()}>
+	<input {...image_validate_form.fields.name.as('text')} />
+	<input
+		{...image_validate_form.fields.position.as('image')}
+		src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs="
+		alt="submit coordinates"
+		width="20"
+		height="20"
+	/>
+</form>
+
+<pre id="name-issues">{JSON.stringify(image_validate_form.fields.name.issues() ?? [])}</pre>
+<pre id="position-issues">{JSON.stringify(
+		image_validate_form.fields.position.allIssues() ?? []
+	)}</pre>
+<p id="result">{image_validate_form.result}</p>

--- a/packages/kit/test/apps/async/src/routes/remote/form/image-validate/form.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/form/image-validate/form.remote.ts
@@ -1,0 +1,13 @@
+import { form } from '$app/server';
+import * as v from 'valibot';
+
+export const image_validate_form = form(
+	v.object({
+		name: v.pipe(v.string(), v.minLength(1)),
+		position: v.object({
+			x: v.number(),
+			y: v.number()
+		})
+	}),
+	({ name, position }) => `${name}:${position.x},${position.y}`
+);

--- a/packages/kit/test/apps/async/src/routes/remote/form/submitter/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/submitter/+page.svelte
@@ -1,5 +1,18 @@
 <script>
+	import { onMount } from 'svelte';
 	import { image_form, my_form } from './form.remote.ts';
+
+	let position_on_submit = $state('');
+
+	onMount(() => {
+		image_form.fields.position.set({ x: 1, y: 2 });
+
+		const listener = () => {
+			position_on_submit = JSON.stringify(image_form.fields.position.value());
+		};
+		document.addEventListener('submit', listener);
+		return () => document.removeEventListener('submit', listener);
+	});
 </script>
 
 <form {...my_form}>
@@ -19,3 +32,4 @@
 </form>
 
 <p id="image-result">{image_form.result}</p>
+<p id="image-position">{position_on_submit}</p>

--- a/packages/kit/test/apps/async/test/test.js
+++ b/packages/kit/test/apps/async/test/test.js
@@ -297,6 +297,16 @@ test.describe('remote functions', () => {
 		await expect(page.locator('#image-result')).toHaveText('5,6');
 	});
 
+	test('image form submit keeps client field state', async ({ page, javaScriptEnabled }) => {
+		test.skip(!javaScriptEnabled, 'requires JavaScript to set field values');
+
+		await page.goto('/remote/form/submitter');
+		await page.locator('input[type="image"]').click({ position: { x: 5, y: 6 } });
+
+		await expect(page.locator('#image-position')).toHaveText('{"x":1,"y":2}');
+		await expect(page.locator('#image-result')).toHaveText('5,6');
+	});
+
 	test('form updates inputs live', async ({ page, javaScriptEnabled }) => {
 		await page.goto('/remote/form/live-update');
 

--- a/packages/kit/test/apps/async/test/test.js
+++ b/packages/kit/test/apps/async/test/test.js
@@ -307,6 +307,24 @@ test.describe('remote functions', () => {
 		await expect(page.locator('#image-result')).toHaveText('5,6');
 	});
 
+	test('image inputs do not fail validation as the default submitter', async ({
+		page,
+		javaScriptEnabled
+	}) => {
+		test.skip(!javaScriptEnabled, 'requires JavaScript to validate');
+
+		await page.goto('/remote/form/image-validate');
+		await page.locator('input[type="image"]').click({ position: { x: 5, y: 6 } });
+		await expect(page.locator('#name-issues')).not.toHaveText('[]');
+
+		await page.getByRole('textbox').fill('a');
+		await expect(page.locator('#name-issues')).toHaveText('[]');
+		await expect(page.locator('#position-issues')).toHaveText('[]');
+
+		await page.locator('input[type="image"]').click({ position: { x: 5, y: 6 } });
+		await expect(page.locator('#result')).toHaveText('a:5,6');
+	});
+
 	test('form updates inputs live', async ({ page, javaScriptEnabled }) => {
 		await page.goto('/remote/form/live-update');
 

--- a/packages/kit/test/types/remote.test.ts
+++ b/packages/kit/test/types/remote.test.ts
@@ -680,6 +680,9 @@ function form_tests() {
 	// @ts-expect-error image inputs only support objects with exactly x and y coordinates
 	f_3d_position.fields.position.as('image');
 
+	const f_any_image = form(null as any, () => ({ success: true }));
+	f_any_image.fields.position.as('image');
+
 	// doesn't use data
 	const f9 = form(() => Promise.resolve({ success: true }));
 	f9.result?.success === true;

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2960,13 +2960,7 @@ declare module '$app/server' {
 
 	// Valid input types for a given value type
 	export type RemoteFormFieldType<T> = {
-		[K in keyof InputTypeMap]: K extends 'image'
-			? IsImageInputValue<T> extends true
-				? K
-				: never
-			: T extends InputTypeMap[K]
-				? K
-				: never;
+		[K in keyof InputTypeMap]: T extends InputTypeMap[K] ? K : never;
 	}[keyof InputTypeMap];
 
 	// Input element properties based on type


### PR DESCRIPTION
Fixes for the three issues raised on #16944, each with a test.

- https://github.com/sveltejs/kit/pull/16944#issuecomment-5441090207 (`handle_submit` skips the mirror for image submitters)
- https://github.com/sveltejs/kit/pull/16944#discussion_r3873032815 (plain `T extends InputTypeMap[K]` check in `RemoteFormFieldType`)
- https://github.com/sveltejs/kit/pull/16944#issuecomment-5441463143 (`[type="image"]` in the default-submitter selector)
