### PR TITLE
fix: discard a consumed preloaded redirect before following it

### DIFF
--- a/.changeset/pre/quiet-preload-redirect.md
+++ b/.changeset/pre/quiet-preload-redirect.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: don't replay a preloaded redirect when a later hop of the navigation returns to the route

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2072,6 +2072,9 @@ async function navigate({
 	if (navigation_result.type === 'redirect') {
 		// whatwg fetch spec https://fetch.spec.whatwg.org/#http-redirect-fetch says to error after 20 redirects
 		if (redirect_count < 20) {
+			// a preloaded redirect has been consumed; a later hop back to this route must load afresh
+			if (load_cache?.id === intent?.id) discard_load_cache();
+
 			await navigate({
 				type,
 				url: new URL(navigation_result.location, url),

--- a/packages/kit/test/apps/basics/src/routes/routing/preloading/redirect/[step]/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/routing/preloading/redirect/[step]/+page.server.js
@@ -1,0 +1,13 @@
+import { redirect } from '@sveltejs/kit';
+
+/** @type {import('./$types').PageServerLoad} */
+export function load({ cookies, params }) {
+	if (params.step === 'resolve') {
+		cookies.set('preload-redirect-resolved', 'true', { path: '/routing/preloading/redirect' });
+		redirect(303, '/routing/preloading/redirect/target');
+	}
+
+	if (!cookies.get('preload-redirect-resolved')) {
+		redirect(303, '/routing/preloading/redirect/resolve');
+	}
+}

--- a/packages/kit/test/apps/basics/src/routes/routing/preloading/redirect/[step]/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/routing/preloading/redirect/[step]/+page.svelte
@@ -1,0 +1,1 @@
+<h1>Redirect resolved</h1>

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -1023,6 +1023,24 @@ test.describe('Prefetching', () => {
 		);
 	});
 
+	test('does not replay a preloaded redirect when a later hop returns to the route', async ({
+		page,
+		app
+	}) => {
+		await page.goto('/routing/a');
+
+		// the cookie is unset, so the preload resolves to a redirect to /resolve
+		const target = '/routing/preloading/redirect/target';
+		expect(await app.preloadData(target)).toMatchObject({
+			type: 'redirect',
+			location: '/routing/preloading/redirect/resolve'
+		});
+
+		// /resolve sets the cookie and redirects back to /target, which must now load afresh
+		await app.goto(target);
+		await expect(page.locator('h1')).toHaveText('Redirect resolved');
+	});
+
 	test('chooses correct route when hash route is preloaded but regular route is clicked', async ({
 		app,
 		page


### PR DESCRIPTION
In `runtime/client/client.js`, `_preload_data` stores every `load_route` result in `load_cache` and `load_route` hands the entry back whenever the intent id matches. `navigate` only clears `load_cache` on the commit path, after `history.pushState`; the redirect branch recurses into `navigate` for the redirect target and returns before that. So when a preloaded route redirects and a later hop of the same navigation comes back to it (a gate: `/dashboard` redirects to `/select` until a flag is set, `/select` sets it and redirects to `/dashboard`), the cached redirect is replayed without a fetch on every return until the 20-redirect limit renders the 500 page.

Discard the consumed entry in the redirect branch before recursing, keyed on `intent.id` so a preload of a different route (such as the redirect target) survives. The first hop is still served from the preload; anything after it loads fresh.

Fixes #16484.

Replaces #16930. Thank you for the attempt @bmdavis419, big fan of your content.
