### PR TITLE
fix: settle a query's pending request in place on set()

### DIFF
--- a/.changeset/quiet-queries-settle.md
+++ b/.changeset/quiet-queries-settle.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: settle a query's pending request in place when its value arrives through `set()`

--- a/packages/kit/src/runtime/client/remote-functions/instance.unhandled.svelte.spec.js
+++ b/packages/kit/src/runtime/client/remote-functions/instance.unhandled.svelte.spec.js
@@ -133,7 +133,7 @@ describe('Query errors', () => {
 });
 
 describe('Query.set', () => {
-	/** @param {Query<any>} query */
+	/** @param {import('./query/instance.svelte.js').Query<any>} query */
 	function count_invalidations(query) {
 		let runs = 0;
 		const destroy = $effect.root(() => {

--- a/packages/kit/src/runtime/client/remote-functions/instance.unhandled.svelte.spec.js
+++ b/packages/kit/src/runtime/client/remote-functions/instance.unhandled.svelte.spec.js
@@ -131,3 +131,44 @@ describe('Query errors', () => {
 		});
 	});
 });
+
+describe('Query.set', () => {
+	/** @param {Query<any>} query */
+	function count_invalidations(query) {
+		let runs = 0;
+		const destroy = $effect.root(() => {
+			$effect.pre(() => {
+				runs++;
+				void query.then;
+			});
+		});
+		return { runs: () => runs, destroy };
+	}
+
+	test('settles a pending request in place instead of replacing its promise', async () => {
+		const pending = Promise.withResolvers();
+		const query = new Query('set-pending', () => pending.promise);
+		const awaiter = count_invalidations(query);
+		await tick();
+		expect(awaiter.runs()).toBe(1);
+
+		query.set('b');
+		expect(await Promise.resolve(query)).toBe('b');
+		await tick();
+		expect(awaiter.runs()).toBe(1);
+		awaiter.destroy();
+	});
+
+	test('invalidates awaiters of a settled request', async () => {
+		const query = new Query('set-settled', () => Promise.resolve('a'));
+		const awaiter = count_invalidations(query);
+		expect(await Promise.resolve(query)).toBe('a');
+		expect(awaiter.runs()).toBe(1);
+
+		query.set('b');
+		await tick();
+		expect(awaiter.runs()).toBe(2);
+		expect(await Promise.resolve(query)).toBe('b');
+		awaiter.destroy();
+	});
+});

--- a/packages/kit/src/runtime/client/remote-functions/query/instance.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query/instance.svelte.js
@@ -127,14 +127,12 @@ export class Query {
 
 				// Untrack this to not trigger mutation validation errors which can occur if you do e.g. $derived({ a: await queryA(), b: await queryB() })
 				untrack(() => {
-					this.#latest.splice(0, idx).forEach((r) => r(undefined));
+					this.#latest.splice(0, idx + 1).forEach((r) => r(undefined));
 					this.#ready = true;
 					this.#loading = false;
 					this.#raw = value;
 					this.#error = undefined;
 				});
-
-				resolve(undefined);
 			})
 			.catch(async (e) => {
 				// TODO: Our behavior here could be better:
@@ -158,6 +156,7 @@ export class Query {
 
 				untrack(() => {
 					this.#latest.splice(0, idx).forEach((r) => r(undefined));
+					this.#latest.shift();
 					this.#error = error;
 					this.#loading = false;
 				});
@@ -242,12 +241,19 @@ export class Query {
 		// SSR record can never shadow the newly-set value
 		delete query_responses[this.#key];
 
+		// a pending request's promise is settled with the value below; replacing it
+		// too would make awaiting consumers settle a second time in a new batch
+		const in_flight = this.#latest.length > 0;
+
 		this.#clear_pending();
 		this.#ready = true;
 		this.#loading = false;
 		this.#error = undefined;
 		this.#raw = value;
-		this.#promise = Promise.resolve();
+
+		if (!in_flight) {
+			this.#promise = Promise.resolve();
+		}
 	}
 
 	/** @param {HttpError} error */

--- a/packages/kit/test/apps/async/src/app.d.ts
+++ b/packages/kit/test/apps/async/src/app.d.ts
@@ -1,0 +1,7 @@
+declare global {
+	interface Window {
+		__recomputations: number;
+	}
+}
+
+export {};

--- a/packages/kit/test/apps/async/src/routes/remote/query-derived-memoization/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/query-derived-memoization/+page.svelte
@@ -1,0 +1,14 @@
+<script>
+	import Graph from './Graph.svelte';
+	import { get_rows } from './data.remote.js';
+
+	// the argument changes on every bump, so each bump awaits a fresh query instance
+	let bucket = $state(0);
+</script>
+
+<button id="bump" onclick={() => (bucket += 1)}>bump</button>
+
+<svelte:boundary>
+	{#snippet pending()}<p>loading</p>{/snippet}
+	<Graph rows={await get_rows(bucket)} />
+</svelte:boundary>

--- a/packages/kit/test/apps/async/src/routes/remote/query-derived-memoization/Graph.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/query-derived-memoization/Graph.svelte
@@ -1,0 +1,38 @@
+<script>
+	/**
+	 * A graph of deriveds in the shape that makes lost memoization expensive: each
+	 * `constant_n` returns the same value every time, so it stays dirtier than the
+	 * `object_n` it reads, and every unmemoized read re-walks the levels below it.
+	 */
+	let { rows } = $props();
+
+	/**
+	 * @template T
+	 * @param {T} value
+	 * @returns {T}
+	 */
+	function counted(value) {
+		if (typeof window !== 'undefined') {
+			window.__recomputations = (window.__recomputations ?? 0) + 1;
+		}
+
+		return value;
+	}
+
+	const object_0 = $derived(counted({ n: rows.length }));
+	const constant_0 = $derived(counted(object_0.n >= 0 ? null : 1));
+	const object_1 = $derived(counted({ n: object_0.n + (constant_0 ?? 0) }));
+	const constant_1 = $derived(counted(object_1.n >= 0 ? null : 1));
+	const object_2 = $derived(counted({ n: object_1.n + (constant_1 ?? 0) }));
+	const constant_2 = $derived(counted(object_2.n >= 0 ? null : 1));
+	const object_3 = $derived(counted({ n: object_2.n + (constant_2 ?? 0) }));
+	const constant_3 = $derived(counted(object_3.n >= 0 ? null : 1));
+	const object_4 = $derived(counted({ n: object_3.n + (constant_3 ?? 0) }));
+	const constant_4 = $derived(counted(object_4.n >= 0 ? null : 1));
+	const object_5 = $derived(counted({ n: object_4.n + (constant_4 ?? 0) }));
+	const constant_5 = $derived(counted(object_5.n >= 0 ? null : 1));
+	const object_6 = $derived(counted({ n: object_5.n + (constant_5 ?? 0) }));
+	const constant_6 = $derived(counted(object_6.n >= 0 ? null : 1));
+</script>
+
+<p id="result">{object_6.n}{constant_6 ?? ''}</p>

--- a/packages/kit/test/apps/async/src/routes/remote/query-derived-memoization/data.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/query-derived-memoization/data.remote.js
@@ -1,0 +1,6 @@
+import { query } from '$app/server';
+import * as v from 'valibot';
+
+export const get_rows = query(v.number(), (bucket) => {
+	return Array.from({ length: 10 + bucket }, (_, i) => i);
+});

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -57,6 +57,19 @@ test.describe('remote functions', () => {
 		await page.goto('/plain-lib');
 		await expect(page.locator('p')).toHaveText('key set for https://example.com/jwks');
 	});
+
+	// https://github.com/sveltejs/kit/issues/16854
+	test('deriveds fed by an awaited query stay memoized', async ({ page }) => {
+		await page.goto('/remote/query-derived-memoization');
+		await expect(page.locator('#result')).toHaveText('10');
+
+		await page.evaluate(() => (window.__recomputations = 0));
+		await page.locator('#bump').click();
+		await expect(page.locator('#result')).toHaveText('11');
+
+		// fourteen when memoized, tens of thousands (and climbing with graph depth) when not
+		expect(await page.evaluate(() => window.__recomputations)).toBeLessThan(1000);
+	});
 });
 
 // have to run in serial because commands mutate in-memory data on the server (should fix this at some point)


### PR DESCRIPTION
`Query#run` settles a request by resolving the older resolvers in `#latest` and leaves its own behind, so `#latest` is never empty once a request has settled. `set()` resolves everything in `#latest` and then replaces `#promise` unconditionally. When a value arrives through `set()` while the request is pending, the normal path for single-flight responses (`remote_request` in `shared.svelte.js`), awaiting consumers settle twice: through the resolved promise, then again when the new `#promise` invalidates `#then`. The second settlement runs in a new batch while the first is still applying, deriveds lose memoization across the two, and a deep graph downstream of the query recomputes exponentially (#16854).

`#run()` now removes its own resolver when it settles, so `#latest` holds exactly the pending requests, and `set()` only replaces `#promise` when nothing was pending.

Fixes #16854
