### PR TITLE
fix: record a history traversal before resolving its route

### DIFF
--- a/.changeset/fast-cats-traverse.md
+++ b/.changeset/fast-cats-traverse.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: record a history traversal before resolving its route

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2113,12 +2113,15 @@ async function navigate({
 
 	updating = true;
 
-	capture_scroll(previous_history_index);
-	capture_snapshot(previous_navigation_index);
-	if (replace_state) {
-		delete_navigation_snapshot(previous_history_index);
-	} else {
-		capture_navigation_snapshot(previous_history_index);
+	if (!popped) {
+		// popstate captures the source entry synchronously, before the traversal is resolved
+		capture_scroll(previous_history_index);
+		capture_snapshot(previous_navigation_index);
+		if (replace_state) {
+			delete_navigation_snapshot(previous_history_index);
+		} else {
+			capture_navigation_snapshot(previous_history_index);
+		}
 	}
 
 	// ensure the url pathname matches the page's trailing slash option
@@ -3404,9 +3407,25 @@ function _start_router() {
 					(history_metadata.pageUrl === undefined || history_metadata.pageUrl === location.href)) ||
 					is_hash_change);
 			const shallow_url = history_metadata.pageUrl ? new URL(location.href) : null;
+
+			// the browser has already traversed, so record the source entry and move the
+			// indices before anything async: a navigation that starts while this one
+			// resolves must build on the entry we are actually on
+			const previous_history_index = current_history_index;
+			const previous_navigation_index = current_navigation_index;
+			const previous_reset_index = current_reset_index;
+			capture_scroll(previous_history_index);
+			if (!shallow) capture_snapshot(previous_navigation_index);
+			capture_navigation_snapshot(previous_history_index);
+			current_history_index = history_index;
+			current_navigation_index = navigation_index;
+			current_reset_index = reset_index;
+
+			const token = navigation_token;
 			const shallow_intent = shallow_url
 				? await get_navigation_intent(shallow_url, false)
 				: undefined;
+			if (navigation_token !== token) return;
 			const shallow_target = shallow_url
 				? {
 						params: shallow_intent?.params ?? null,
@@ -3430,10 +3449,6 @@ function _start_router() {
 
 				update_url(url);
 
-				capture_scroll(current_history_index);
-				capture_navigation_snapshot(current_history_index);
-				current_history_index = history_index;
-				current_reset_index = reset_index;
 				if (reset && scroll) scrollTo(scroll.x, scroll.y);
 				restore_navigation_snapshot(current_history_index, current_registrations());
 				return;
@@ -3449,15 +3464,13 @@ function _start_router() {
 					delta,
 					shallow: shallow_target
 				},
-				accept: () => {
-					current_history_index = history_index;
-					current_navigation_index = navigation_index;
-					current_reset_index = reset_index;
-				},
 				block: () => {
+					current_history_index = previous_history_index;
+					current_navigation_index = previous_navigation_index;
+					current_reset_index = previous_reset_index;
 					history.go(-delta);
 				},
-				nav_token: navigation_token,
+				nav_token: token,
 				event
 			});
 		} else {


### PR DESCRIPTION
Replaces #16954.

The `popstate` handler in `client.js` awaits route resolution (`get_navigation_intent`, and again inside `navigate` before `accept`) before recording that the browser has moved. Under server-side route resolution that is a network round-trip, during which `current_history_index` still points at the entry we left. A popstate arriving in that window is swallowed by the cancellation guard, and a `goto` pushes an entry with a duplicate `historyIndex`, so later scroll and snapshot restores read the wrong entry. This is the flake in https://github.com/sveltejs/kit/actions/runs/33085846048.

Record the traversal synchronously: capture the source entry's scroll and snapshots and move the indices before anything async, restore them in `block()` before `history.go(-delta)`, and capture the navigation token up front so a superseded popstate stops instead of taking over the newer navigation's token. `navigate` skips its own capture for popped navigations.

Repro: a 120 ms delay after the `get_navigation_intent` await in the handler fails `Preserves scroll and focus across popstate...` 4/4 in `test:server-side-route-resolution:dev` before this change and passes 4/4 after it.
