### PR TITLE
chore: replace deprecated Vite dev server APIs

### DIFF
--- a/.changeset/quiet-hooks-update.md
+++ b/.changeset/quiet-hooks-update.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+chore: replace deprecated Vite dev server APIs

--- a/packages/kit/src/core/env.js
+++ b/packages/kit/src/core/env.js
@@ -22,7 +22,9 @@ import { posixify } from '../utils/os.js';
  * @returns {string | null}
  */
 export function resolve_env_entry(config, root) {
-	return resolve_entry(path.resolve(root, config.files.src, 'env'));
+	const entry = resolve_entry(path.resolve(root, config.files.src, 'env'));
+	// posix, like the paths Vite hands to `hotUpdate`
+	return entry && posixify(entry);
 }
 
 /**

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -86,6 +86,7 @@ export async function dev(
 	let manifest_error = null;
 
 	const runner = get_runner(vite, vite_dev_server);
+	const { hot } = vite_dev_server.environments.client;
 
 	/**
 	 * Log a response to the console, routed through Vite's logger so that it
@@ -121,7 +122,7 @@ export async function dev(
 			// and when it does appear it may immediately vanish. `hot.send` broadcasts
 			// to all connected clients, even ones that are unaffected by the error.
 			// we need a more considered approach
-			vite_dev_server.environments.client.hot.send({
+			hot.send({
 				type: 'error',
 				err: /** @type {ErrorPayload['err']} */ ({
 					...err,
@@ -163,13 +164,13 @@ export async function dev(
 
 			if (manifest_error) {
 				manifest_error = null;
-				vite_dev_server.environments.client.hot.send({ type: 'full-reload' });
+				hot.send({ type: 'full-reload' });
 			}
 		} catch (error) {
 			manifest_error = /** @type {Error} */ (error);
 
 			console.error(styleText(['bold', 'red'], manifest_error.message));
-			vite_dev_server.environments.client.hot.send({
+			hot.send({
 				type: 'error',
 				err: {
 					message: manifest_error.message ?? 'Invalid routes',
@@ -450,7 +451,7 @@ export async function dev(
 	if (appTemplate !== 'index.html') {
 		vite_dev_server.watcher.on('change', (file) => {
 			if (file === appTemplate) {
-				vite_dev_server.environments.client.hot.send({ type: 'full-reload' });
+				hot.send({ type: 'full-reload' });
 			}
 		});
 	}

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -118,10 +118,10 @@ export async function dev(
 			}
 
 			// TODO this is inadequate — it doesn't reliably show the overlay on every page load,
-			// and when it does appear it may immediately vanish. `vite.hot.send` broadcasts
+			// and when it does appear it may immediately vanish. `hot.send` broadcasts
 			// to all connected clients, even ones that are unaffected by the error.
 			// we need a more considered approach
-			vite_dev_server.hot.send({
+			vite_dev_server.environments.client.hot.send({
 				type: 'error',
 				err: /** @type {ErrorPayload['err']} */ ({
 					...err,
@@ -163,13 +163,13 @@ export async function dev(
 
 			if (manifest_error) {
 				manifest_error = null;
-				vite_dev_server.hot.send({ type: 'full-reload' });
+				vite_dev_server.environments.client.hot.send({ type: 'full-reload' });
 			}
 		} catch (error) {
 			manifest_error = /** @type {Error} */ (error);
 
 			console.error(styleText(['bold', 'red'], manifest_error.message));
-			vite_dev_server.hot.send({
+			vite_dev_server.environments.client.hot.send({
 				type: 'error',
 				err: {
 					message: manifest_error.message ?? 'Invalid routes',
@@ -450,7 +450,7 @@ export async function dev(
 	if (appTemplate !== 'index.html') {
 		vite_dev_server.watcher.on('change', (file) => {
 			if (file === appTemplate) {
-				vite_dev_server.hot.send({ type: 'full-reload' });
+				vite_dev_server.environments.client.hot.send({ type: 'full-reload' });
 			}
 		});
 	}

--- a/packages/kit/src/exports/vite/plugins/env-vars.js
+++ b/packages/kit/src/exports/vite/plugins/env-vars.js
@@ -27,9 +27,6 @@ export function plugin_env_vars(config, callback) {
 	/** @type {ResolvedConfig} */
 	let resolved_config;
 
-	/** @type {string | null} */
-	let resolved_entry = null;
-
 	/** @type {Set<string>} */
 	let deps = new Set();
 
@@ -39,12 +36,8 @@ export function plugin_env_vars(config, callback) {
 	let generated;
 
 	async function generate() {
-		const synced = await sync.env(
-			config,
-			resolved_entry,
-			resolved_config.root,
-			resolved_config.mode
-		);
+		const entry = resolve_env_entry(config, resolved_config.root);
+		const synced = await sync.env(config, entry, resolved_config.root, resolved_config.mode);
 
 		deps = synced.deps;
 
@@ -56,7 +49,7 @@ export function plugin_env_vars(config, callback) {
 			vars,
 			env,
 			dir,
-			resolved_entry && posixify(path.relative(dir, resolved_entry)),
+			entry && posixify(path.relative(dir, entry)),
 			!is_build
 		);
 
@@ -85,28 +78,18 @@ export function plugin_env_vars(config, callback) {
 			// runs once via the memo — per-process, whichever environment starts first
 			// (environment names vary by adapter), and never in the postbuild forks,
 			// which resolve the config without building
-			await (generated ??= (async () => {
-				resolved_entry = resolve_env_entry(config, resolved_config.root);
-				await generate();
-			})());
+			await (generated ??= generate());
 		},
 
 		async hotUpdate({ type, file }) {
 			// runs for every environment; the generated modules are shared, so do the work once
 			if (this.environment.name !== 'client') return;
 
-			if (type === 'update') {
-				if (deps.has(file)) await generate();
-				return;
-			}
+			const created = type === 'create' && file === resolve_env_entry(config, resolved_config.root);
+			if (!deps.has(file) && !created) return;
 
-			// the env entry was created or deleted: re-resolve it and reload
-			const resolved = resolve_env_entry(config, resolved_config.root);
-			if (file !== resolved_entry && file !== resolved) return;
-
-			resolved_entry = resolved;
 			await generate();
-			this.environment.hot.send({ type: 'full-reload' });
+			if (type !== 'update') this.environment.hot.send({ type: 'full-reload' });
 		}
 	};
 }

--- a/packages/kit/src/exports/vite/plugins/env-vars.js
+++ b/packages/kit/src/exports/vite/plugins/env-vars.js
@@ -91,28 +91,22 @@ export function plugin_env_vars(config, callback) {
 			})());
 		},
 
-		configureServer(server) {
-			// `handleHotUpdate` only fires for `change` events on files Vite already knows about,
-			// so it doesn't cover the env entry being created or deleted while the dev server is
-			// running. Watch for those events explicitly, re-resolve the entry, regenerate the
-			// modules and trigger a full reload (mirroring the previous behaviour).
-			const on_entry_add_unlink = async (/** @type {string} */ file) => {
-				const resolved = resolve_env_entry(config, resolved_config.root);
+		async hotUpdate({ type, file }) {
+			// runs for every environment; the generated modules are shared, so do the work once
+			if (this.environment.name !== 'client') return;
 
-				if (file === resolved_entry || file === resolved) {
-					resolved_entry = resolved;
-					await generate();
-					server.hot.send({ type: 'full-reload' });
-				}
-			};
+			if (type === 'update') {
+				if (deps.has(file)) await generate();
+				return;
+			}
 
-			server.watcher.on('add', on_entry_add_unlink);
-			server.watcher.on('unlink', on_entry_add_unlink);
-		},
+			// the env entry was created or deleted: re-resolve it and reload
+			const resolved = resolve_env_entry(config, resolved_config.root);
+			if (file !== resolved_entry && file !== resolved) return;
 
-		async handleHotUpdate(update) {
-			if (!deps.has(update.file)) return;
+			resolved_entry = resolved;
 			await generate();
+			this.environment.hot.send({ type: 'full-reload' });
 		}
 	};
 }

--- a/packages/kit/src/exports/vite/plugins/guard.js
+++ b/packages/kit/src/exports/vite/plugins/guard.js
@@ -78,7 +78,7 @@ export function plugin_guard(kit, get_config, get_manifest_data) {
 				// composable filters only work during build so we still need this guard for dev
 				// see https://github.com/vitejs/rolldown-vite/issues/605
 				if (importer && !importer.endsWith('index.html')) {
-					const resolved = await this.resolve(id, importer, { ...options, skipSelf: true });
+					const resolved = await this.resolve(id, importer, options);
 
 					if (resolved) {
 						const normalized = normalize_id(resolved.id, normalized_aliases, normalized_cwd);


### PR DESCRIPTION
Vite's `future` flags (`removePluginHookHandleHotUpdate`, `removeServerHot`, `removePluginHookSsrArgument`) flag three things kit's dev path still uses: the `handleHotUpdate` hook in the env-vars plugin, `server.hot.send` in `dev/index.js`, and spreading `resolveId` `options` in the guard plugin, which enumerates the deprecated `ssr` getter.

`hotUpdate` also fires for `create`/`delete`, so the manual `watcher.on('add'|'unlink')` block that existed because `handleHotUpdate` only covered `change` folds into it. `hot.send` moves to the client environment, and the guard passes `options` through unchanged since `skipSelf` already defaults to true.
