### PR TITLE
docs: use correct import path

### DIFF
--- a/documentation/docs/40-best-practices/05-performance.md
+++ b/documentation/docs/40-best-practices/05-performance.md
@@ -53,7 +53,7 @@ SvelteKit automatically preloads critical `.js` and `.css` files when the user v
 
 ```js
 /// file: src/hooks.server.js
-/** @type {import('@sveltejs/kit').Handle} */
+/** @type {import('@sveltejs/kit/hooks').Handle} */
 export async function handle({ event, resolve }) {
 	return resolve(event, {
 		preload: (asset) => {


### PR DESCRIPTION
Corrects the import path in the docs snippet