### PR TITLE
chore: read manifest from one module instead of threading it through the server runtime

### DIFF
--- a/.changeset/quiet-manifest-single.md
+++ b/.changeset/quiet-manifest-single.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+chore: read `manifest` from a single module instead of passing it through the server runtime

--- a/.changeset/quiet-manifest-single.md
+++ b/.changeset/quiet-manifest-single.md
@@ -1,5 +1,0 @@
----
-'@sveltejs/kit': patch
----
-
-chore: read `manifest` from a single module instead of passing it through the server runtime

--- a/packages/kit/src/runtime/server/data/index.js
+++ b/packages/kit/src/runtime/server/data/index.js
@@ -8,24 +8,17 @@ import { handle_error_and_jsonify } from '../errors.js';
 import { normalize_path } from '../../../utils/url.js';
 import { stream_text } from '../../utils.js';
 import { with_version_header } from '../utils.js';
+import { manifest } from '../internal.js';
 
 /**
  * @param {import('@sveltejs/kit').RequestEvent} event
  * @param {import('types').RequestState} state
  * @param {{ page: Pick<import('types').PageNodeIndexes, 'layouts' | 'leaf'> | null }} route
- * @param {import('types').SSRManifest} manifest
  * @param {boolean[] | undefined} invalidated_data_nodes
  * @param {import('types').TrailingSlash} trailing_slash
  * @returns {Promise<Response>}
  */
-export async function render_data(
-	event,
-	state,
-	route,
-	manifest,
-	invalidated_data_nodes,
-	trailing_slash
-) {
+export async function render_data(event, state, route, invalidated_data_nodes, trailing_slash) {
 	if (!route.page) {
 		// requesting /__data.json should fail for a +server.js
 		return with_version_header(new Response(undefined, { status: 404 }));

--- a/packages/kit/src/runtime/server/fetch.js
+++ b/packages/kit/src/runtime/server/fetch.js
@@ -2,21 +2,20 @@ import { parseSetCookie } from 'cookie';
 import { noop } from '../../utils/functions.js';
 import { respond } from './respond.js';
 import * as paths from '#app/paths';
-import { hooks, read_implementation } from './internal.js';
+import { hooks, manifest, read_implementation } from './internal.js';
 import { has_prerendered_path } from './utils.js';
 import { fork_state_for_subrequest } from './state.js';
 
 /**
  * @param {{
  *   event: import('@sveltejs/kit').RequestEvent;
- *   manifest: import('types').SSRManifest;
  *   state: import('types').RequestState;
  *   get_cookie_header: (url: URL, header: string | null) => string;
  *   set_internal: (name: string, value: string, opts: import('./page/types.js').Cookie['options']) => void;
  * }} opts
  * @returns {typeof fetch}
  */
-export function create_fetch({ event, manifest, state, get_cookie_header, set_internal }) {
+export function create_fetch({ event, state, get_cookie_header, set_internal }) {
 	/**
 	 * @type {typeof fetch}
 	 */
@@ -117,7 +116,7 @@ export function create_fetch({ event, manifest, state, get_cookie_header, set_in
 					return await fetch(request);
 				}
 
-				if (has_prerendered_path(manifest, decoded)) {
+				if (has_prerendered_path(decoded)) {
 					// The path of something prerendered could match a different route
 					// that is still in the manifest, leading to the wrong route being loaded.
 					// We therefore bail early here. The prerendered logic is different for
@@ -147,7 +146,7 @@ export function create_fetch({ event, manifest, state, get_cookie_header, set_in
 					request.headers.set('accept-language', accept_language);
 				}
 
-				const response = await internal_fetch(request, manifest, state);
+				const response = await internal_fetch(request, state);
 
 				for (const str of response.headers.getSetCookie()) {
 					const { name, value, ...cookie_options } = parseSetCookie(str, { decode: (v) => v });
@@ -193,11 +192,10 @@ function normalize_fetch_input(info, init, url) {
 
 /**
  * @param {Request} request
- * @param {import('types').SSRManifest} manifest
  * @param {import('types').RequestState} state
  * @returns {Promise<Response>}
  */
-async function internal_fetch(request, manifest, state) {
+async function internal_fetch(request, state) {
 	if (request.signal?.aborted) {
 		throw new DOMException('The operation was aborted.', 'AbortError');
 	}
@@ -205,7 +203,7 @@ async function internal_fetch(request, manifest, state) {
 	const subrequest_state = fork_state_for_subrequest(state);
 
 	if (!request.signal) {
-		return await respond(request, manifest, subrequest_state);
+		return await respond(request, subrequest_state);
 	}
 
 	let remove_abort_listener = noop;
@@ -218,7 +216,7 @@ async function internal_fetch(request, manifest, state) {
 		remove_abort_listener = () => request.signal.removeEventListener('abort', on_abort);
 	});
 
-	return Promise.race([respond(request, manifest, subrequest_state), abort_promise]).finally(
+	return Promise.race([respond(request, subrequest_state), abort_promise]).finally(
 		remove_abort_listener
 	);
 }

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -58,13 +58,8 @@ if (DEV) {
 }
 
 export class Server {
-	/** @type {import('types').SSRManifest} */
-	#manifest;
-
 	/** @param {import('types').SSRManifest} manifest */
 	constructor(manifest) {
-		this.#manifest = manifest;
-
 		// Since AsyncLocalStorage is not working in webcontainers, we don't reset `sync_store`
 		// in `src/exports/internal/server/event.js` and handle only one request at a time.
 		if (IN_WEBCONTAINER) {
@@ -187,7 +182,7 @@ export class Server {
 	async respond(request, options) {
 		const request_state = create_request_state(options);
 
-		const response = await respond(request, this.#manifest, request_state);
+		const response = await respond(request, request_state);
 
 		if (DEV) {
 			const error = decoded_responses.get(response);

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -1,5 +1,5 @@
 /** @import { RequestEvent } from '@sveltejs/kit' */
-/** @import { PageNodeIndexes, RequestState, RequiredResolveOptions, ServerDataNode, SSRNode, SSRManifest } from 'types' */
+/** @import { PageNodeIndexes, RequestState, RequiredResolveOptions, ServerDataNode, SSRNode } from 'types' */
 import { text } from '@sveltejs/kit';
 import { Redirect } from '@sveltejs/kit/internal';
 import { compact } from '../../../utils/array.js';
@@ -8,6 +8,7 @@ import { noop } from '../../../utils/functions.js';
 import { add_data_suffix } from '../../pathname.js';
 import { build_error_chain, nearest_error_pages } from '../../error-chain.js';
 import { redirect_response } from '../utils.js';
+import { manifest } from '../internal.js';
 import { static_error_page, handle_error_and_jsonify } from '../errors.js';
 import {
 	handle_action_json_request,
@@ -32,12 +33,11 @@ const MAX_DEPTH = 10;
  * @param {RequestEvent} event
  * @param {RequestState} state
  * @param {PageNodeIndexes} page
- * @param {SSRManifest} manifest
  * @param {import('../../../utils/page_nodes.js').PageNodes} nodes
  * @param {RequiredResolveOptions} resolve_opts
  * @returns {Promise<Response>}
  */
-export async function render_page(event, state, page, manifest, nodes, resolve_opts) {
+export async function render_page(event, state, page, nodes, resolve_opts) {
 	if (state.depth > MAX_DEPTH) {
 		// infinite request cycle detected
 		return text(`Not found: ${event.url.pathname}`, {
@@ -61,7 +61,7 @@ export async function render_page(event, state, page, manifest, nodes, resolve_o
 		if (is_action_request(event)) {
 			const remote_id = get_remote_action(event.url);
 			if (remote_id) {
-				action_result = await handle_remote_form_post(event, state, manifest, remote_id);
+				action_result = await handle_remote_form_post(event, state, remote_id);
 			} else {
 				// for action requests, first call handler in +page.server.js
 				// (this also determines status code)
@@ -149,7 +149,6 @@ export async function render_page(event, state, page, manifest, nodes, resolve_o
 				error: null,
 				event,
 				state,
-				manifest,
 				resolve_opts,
 				data_serializer: server_data_serializer(event, state)
 			});
@@ -291,7 +290,6 @@ export async function render_page(event, state, page, manifest, nodes, resolve_o
 						return await render_response({
 							event,
 							state,
-							manifest,
 							resolve_opts,
 							page_config: {
 								ssr: nodes.ssr(),
@@ -299,7 +297,7 @@ export async function render_page(event, state, page, manifest, nodes, resolve_o
 							},
 							status,
 							error,
-							error_components: await load_error_components(ssr, error_branch, page, manifest),
+							error_components: await load_error_components(ssr, error_branch, page),
 							branch: error_branch,
 							fetched,
 							data_serializer
@@ -336,7 +334,6 @@ export async function render_page(event, state, page, manifest, nodes, resolve_o
 		return await render_response({
 			event,
 			state,
-			manifest,
 			resolve_opts,
 			page_config: {
 				csr,
@@ -348,7 +345,7 @@ export async function render_page(event, state, page, manifest, nodes, resolve_o
 			action_result,
 			fetched,
 			data_serializer: !ssr ? server_data_serializer(event, state) : data_serializer,
-			error_components: await load_error_components(ssr, branch, page, manifest)
+			error_components: await load_error_components(ssr, branch, page)
 		});
 	} catch (e) {
 		// a remote function could have thrown a redirect during render
@@ -361,7 +358,6 @@ export async function render_page(event, state, page, manifest, nodes, resolve_o
 		return await respond_with_error({
 			event,
 			state,
-			manifest,
 			error: e,
 			resolve_opts
 		});
@@ -372,9 +368,8 @@ export async function render_page(event, state, page, manifest, nodes, resolve_o
  * @param {boolean} ssr
  * @param {Array<import('./types.js').Loaded | null>} branch
  * @param {PageNodeIndexes} page
- * @param {SSRManifest} manifest
  */
-function load_error_components(ssr, branch, page, manifest) {
+function load_error_components(ssr, branch, page) {
 	if (!ssr) return undefined;
 
 	return build_error_chain(branch, page.errors, (idx) =>

--- a/packages/kit/src/runtime/server/page/load_data.spec.js
+++ b/packages/kit/src/runtime/server/page/load_data.spec.js
@@ -1,5 +1,8 @@
-import { assert, expect, test } from 'vitest';
-import { create_universal_fetch } from './load_data.js';
+import { assert, expect, test, vi } from 'vitest';
+
+vi.stubGlobal('__SVELTEKIT_DEV__', undefined);
+
+const { create_universal_fetch } = await import('./load_data.js');
 
 /**
  * @param {Partial<Pick<import('@sveltejs/kit').RequestEvent, 'fetch' | 'url' | 'request' | 'route'>>} event

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -27,7 +27,7 @@ import Root from '../../components/root.svelte';
 import { render } from 'svelte/server';
 import { Props, RenderNode } from '../../props.svelte.js';
 import { has_custom_transporters, uneval } from '#app/internal/transport';
-import { options } from '../internal.js';
+import { manifest, options } from '../internal.js';
 
 // TODO rename this function/module
 
@@ -36,7 +36,6 @@ import { options } from '../internal.js';
  * @param {{
  *   branch: Array<import('./types.js').Loaded>;
  *   fetched: Array<import('./types.js').Fetched>;
- *   manifest: import('types').SSRManifest;
  *   page_config: { ssr: boolean; csr: boolean };
  *   status: number;
  *   error: App.Error | null;
@@ -51,7 +50,6 @@ import { options } from '../internal.js';
 export async function render_response({
 	branch,
 	fetched,
-	manifest,
 	page_config,
 	status,
 	error = null,

--- a/packages/kit/src/runtime/server/page/respond_with_error.js
+++ b/packages/kit/src/runtime/server/page/respond_with_error.js
@@ -5,6 +5,7 @@ import { redirect_response } from '../utils.js';
 import { handle_error_and_jsonify, static_error_page } from '../errors.js';
 import { PageNodes } from '../../../utils/page_nodes.js';
 import { server_data_serializer } from './data_serializer.js';
+import { manifest } from '../internal.js';
 
 /**
  * @typedef {import('./types.js').Loaded} Loaded
@@ -14,12 +15,11 @@ import { server_data_serializer } from './data_serializer.js';
  * @param {{
  *   event: import('@sveltejs/kit').RequestEvent;
  *   state: import('types').RequestState;
- *   manifest: import('types').SSRManifest;
  *   error: unknown;
  *   resolve_opts: import('types').RequiredResolveOptions;
  * }} opts
  */
-export async function respond_with_error({ event, state, manifest, error, resolve_opts }) {
+export async function respond_with_error({ event, state, error, resolve_opts }) {
 	// reroute to the fallback page to prevent an infinite chain of requests.
 	if (event.request.headers.get('x-sveltekit-error')) {
 		const transformed = await handle_error_and_jsonify(event, state, error);
@@ -79,7 +79,6 @@ export async function respond_with_error({ event, state, manifest, error, resolv
 		}
 
 		return await render_response({
-			manifest,
 			page_config: {
 				ssr,
 				csr

--- a/packages/kit/src/runtime/server/page/server_routing.js
+++ b/packages/kit/src/runtime/server/page/server_routing.js
@@ -5,6 +5,7 @@ import { text } from '@sveltejs/kit';
 import { s } from '../../../utils/misc.js';
 import { find_route } from '../../../utils/routing.js';
 import { get_relative_path } from '../../utils.js';
+import { manifest } from '../internal.js';
 
 /**
  * @param {import('types').SSRClientRoute} route
@@ -62,10 +63,9 @@ function create_client_import(import_path, url) {
 /**
  * @param {string} resolved_path
  * @param {URL} url
- * @param {SSRManifest} manifest
  * @returns {Promise<Response>}
  */
-export async function resolve_route(resolved_path, url, manifest) {
+export async function resolve_route(resolved_path, url) {
 	if (!manifest.client?.routes) {
 		return text('Server-side route resolution disabled', { status: 400 });
 	}
@@ -99,10 +99,9 @@ export async function resolve_route(resolved_path, url, manifest) {
  *
  * @param {string} route_id
  * @param {URL} url
- * @param {SSRManifest} manifest
  * @returns {Response}
  */
-export function resolve_route_by_id(route_id, url, manifest) {
+export function resolve_route_by_id(route_id, url) {
 	if (!manifest.client?.routes) {
 		return text('Server-side route resolution disabled', { status: 400 });
 	}

--- a/packages/kit/src/runtime/server/remote-functions.js
+++ b/packages/kit/src/runtime/server/remote-functions.js
@@ -1,6 +1,6 @@
 /** @import { RequestEvent } from '@sveltejs/kit' */
 /** @import { RemoteForm } from '$app/server' */
-/** @import { RemoteFormInternals, RemoteFunctionData, RemoteFunctionResponse, RemoteInternals, RequestState, ServerActionResult, SSRManifest } from 'types' */
+/** @import { RemoteFormInternals, RemoteFunctionData, RemoteFunctionResponse, RemoteInternals, RequestState, ServerActionResult } from 'types' */
 
 import { error } from '@sveltejs/kit';
 import { Redirect, SvelteKitError } from '@sveltejs/kit/internal';
@@ -18,6 +18,7 @@ import {
 import { deserialize_binary_form } from '../form-utils.js';
 import { text_encoder } from '../utils.js';
 import { with_version_header } from './utils.js';
+import { manifest } from './internal.js';
 
 /**
  * How long (in milliseconds) to wait after the last message was sent before
@@ -140,7 +141,7 @@ export function create_live_query_response(event, state, internals, arg) {
 }
 
 /** @type {typeof handle_remote_call_internal} */
-export async function handle_remote_call(event, state, manifest, id) {
+export async function handle_remote_call(event, state, id) {
 	return record_span({
 		name: 'sveltekit.remote.call',
 		attributes: {
@@ -149,7 +150,7 @@ export async function handle_remote_call(event, state, manifest, id) {
 		fn: async (current) => {
 			const traced_event = merge_tracing(event, current);
 			const response = await with_request_store({ event: traced_event, state }, () =>
-				handle_remote_call_internal(traced_event, state, manifest, id)
+				handle_remote_call_internal(traced_event, state, id)
 			);
 			return with_version_header(response);
 		}
@@ -159,10 +160,9 @@ export async function handle_remote_call(event, state, manifest, id) {
 /**
  * @param {RequestEvent} event
  * @param {RequestState} state
- * @param {SSRManifest} manifest
  * @param {string} id
  */
-async function handle_remote_call_internal(event, state, manifest, id) {
+async function handle_remote_call_internal(event, state, id) {
 	const [hash, name, additional_args] = id.split('/');
 	const remotes = manifest.remotes;
 
@@ -513,7 +513,7 @@ function create_requested_map(refreshes) {
 }
 
 /** @type {typeof handle_remote_form_post_internal} */
-export async function handle_remote_form_post(event, state, manifest, id) {
+export async function handle_remote_form_post(event, state, id) {
 	return record_span({
 		name: 'sveltekit.remote.form.post',
 		attributes: {
@@ -522,7 +522,7 @@ export async function handle_remote_form_post(event, state, manifest, id) {
 		fn: (current) => {
 			const traced_event = merge_tracing(event, current);
 			return with_request_store({ event: traced_event, state }, () =>
-				handle_remote_form_post_internal(traced_event, state, manifest, id)
+				handle_remote_form_post_internal(traced_event, state, id)
 			);
 		}
 	});
@@ -531,11 +531,10 @@ export async function handle_remote_form_post(event, state, manifest, id) {
 /**
  * @param {RequestEvent} event
  * @param {RequestState} state
- * @param {SSRManifest} manifest
  * @param {string} id
  * @returns {Promise<ServerActionResult>}
  */
-async function handle_remote_form_post_internal(event, state, manifest, id) {
+async function handle_remote_form_post_internal(event, state, id) {
 	const location = get_action_location(event.url);
 	// `hash` and `name` can never contain a `/`, but the JSON-stringified key of a
 	// keyed (`form.for(key)`) instance can — rejoin the remaining segments

--- a/packages/kit/src/runtime/server/remote-functions.spec.js
+++ b/packages/kit/src/runtime/server/remote-functions.spec.js
@@ -10,12 +10,14 @@ let create_live_query_response;
 let handle_remote_call;
 /** @type {typeof import('./internal.js').set_hooks} */
 let set_hooks;
+/** @type {typeof import('./internal.js').set_manifest} */
+let set_manifest;
 
 beforeAll(async () => {
 	vi.stubGlobal('__SVELTEKIT_DEV__', false);
 	init_transport({});
 	({ create_live_query_response, handle_remote_call } = await import('./remote-functions.js'));
-	({ set_hooks } = await import('./internal.js'));
+	({ set_hooks, set_manifest } = await import('./internal.js'));
 });
 
 /**
@@ -105,6 +107,13 @@ test('serializes explicitly ignored requested updates', async () => {
 		return null;
 	};
 	Object.assign(command, { __: { type: 'command', name: 'command', fn: command } });
+	set_manifest(
+		/** @type {any} */ ({
+			remotes: {
+				hash: () => Promise.resolve({ default: { command } })
+			}
+		})
+	);
 
 	const response = await handle_remote_call(
 		/** @type {any} */ ({
@@ -115,11 +124,6 @@ test('serializes explicitly ignored requested updates', async () => {
 			tracing: { current: { setAttributes: vi.fn() } }
 		}),
 		/** @type {any} */ ({ remote: { requested: null, ignored: null } }),
-		/** @type {any} */ ({
-			remotes: {
-				hash: () => Promise.resolve({ default: { command } })
-			}
-		}),
 		'hash/command'
 	);
 

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -45,7 +45,7 @@ import {
 } from '../pathname.js';
 import { server_data_serializer } from './page/data_serializer.js';
 import { get_remote_id, handle_remote_call } from './remote-functions.js';
-import { hooks, options } from './internal.js';
+import { hooks, manifest, options } from './internal.js';
 
 /** @type {import('types').RequiredResolveOptions['transformPageChunk']} */
 const default_transform = ({ html }) => html;
@@ -86,11 +86,10 @@ export const respond = propagate_context(internal_respond);
 
 /**
  * @param {Request} request
- * @param {import('types').SSRManifest} manifest
  * @param {import('types').RequestState} state
  * @returns {Promise<Response>}
  */
-export async function internal_respond(request, manifest, state) {
+export async function internal_respond(request, state) {
 	/** URL but stripped from the potential `/__data.json` suffix and its search param  */
 	const url = new URL(request.url);
 
@@ -243,7 +242,6 @@ export async function internal_respond(request, manifest, state) {
 	// @ts-expect-error this has to be assigned lazily
 	event.fetch = create_fetch({
 		event,
-		manifest,
 		state,
 		get_cookie_header,
 		set_internal
@@ -306,7 +304,7 @@ export async function internal_respond(request, manifest, state) {
 		// the resolved path has been decoded so it should be compared to the decoded url pathname
 		resolved_path !== decode_pathname(url.pathname) &&
 		!state.prerendering?.fallback &&
-		has_prerendered_path(manifest, resolved_path)
+		has_prerendered_path(resolved_path)
 	) {
 		const url = denormalise_url({
 			request_url: request.url,
@@ -347,10 +345,10 @@ export async function internal_respond(request, manifest, state) {
 
 	if (is_route_resolution_request) {
 		if (is_route_id_resolution_request) {
-			return resolve_route_by_id(extract_route_id(resolved_path), new URL(request.url), manifest);
+			return resolve_route_by_id(extract_route_id(resolved_path), new URL(request.url));
 		}
 
-		return resolve_route(resolved_path, new URL(request.url), manifest);
+		return resolve_route(resolved_path, new URL(request.url));
 	}
 
 	if (resolved_path === `/${app_dir}/env.js`) {
@@ -382,9 +380,7 @@ export async function internal_respond(request, manifest, state) {
 	}
 
 	try {
-		page_nodes = route?.page
-			? new PageNodes(await load_page_nodes(route.page, manifest))
-			: undefined;
+		page_nodes = route?.page ? new PageNodes(await load_page_nodes(route.page)) : undefined;
 
 		// determine whether we need to redirect to add/remove a trailing slash
 		if (route && !remote_id) {
@@ -600,7 +596,6 @@ export async function internal_respond(request, manifest, state) {
 				return await respond_with_error({
 					event,
 					state,
-					manifest,
 					error: new SvelteKitError(
 						400,
 						'Malformed URI',
@@ -614,7 +609,6 @@ export async function internal_respond(request, manifest, state) {
 				return await render_response({
 					event,
 					state,
-					manifest,
 					page_config: { ssr: false, csr: true },
 					status: 200,
 					error: null,
@@ -633,7 +627,7 @@ export async function internal_respond(request, manifest, state) {
 			}
 
 			if (remote_id) {
-				return await handle_remote_call(event, state, manifest, remote_id);
+				return await handle_remote_call(event, state, remote_id);
 			}
 
 			if (route) {
@@ -643,14 +637,7 @@ export async function internal_respond(request, manifest, state) {
 				let response;
 
 				if (is_data_request) {
-					response = await render_data(
-						event,
-						state,
-						route,
-						manifest,
-						invalidated_data_nodes,
-						trailing_slash
-					);
+					response = await render_data(event, state, route, invalidated_data_nodes, trailing_slash);
 				} else {
 					let endpoint;
 					if (
@@ -677,14 +664,7 @@ export async function internal_respond(request, manifest, state) {
 						if (!page_nodes) {
 							throw new Error('page_nodes not found. This should never happen');
 						} else if (page_methods.has(method)) {
-							response = await render_page(
-								event,
-								state,
-								route.page,
-								manifest,
-								page_nodes,
-								resolve_opts
-							);
+							response = await render_page(event, state, route.page, page_nodes, resolve_opts);
 						} else {
 							const allowed_methods = new Set(allowed_page_methods);
 							const node = await manifest.nodes[route.page.leaf]();
@@ -769,7 +749,6 @@ export async function internal_respond(request, manifest, state) {
 						event,
 						state,
 						{ page: { layouts: [], leaf: 0 } },
-						manifest,
 						invalidated_data_nodes,
 						// there is no route to take a trailing slash option from, and the
 						// SSR'd error page sees the pathname as-is
@@ -787,7 +766,6 @@ export async function internal_respond(request, manifest, state) {
 				return await respond_with_error({
 					event,
 					state,
-					manifest,
 					error: new SvelteKitError(404, 'Not Found', `Not found: ${event.url.pathname}`),
 					resolve_opts
 				});
@@ -824,9 +802,8 @@ export async function internal_respond(request, manifest, state) {
 
 /**
  * @param {import('types').PageNodeIndexes} page
- * @param {import('types').SSRManifest} manifest
  */
-export function load_page_nodes(page, manifest) {
+export function load_page_nodes(page) {
 	return Promise.all([
 		// we use == here rather than === because [undefined] serializes as "[null]"
 		...page.layouts.map((n) => (n == undefined ? n : manifest.nodes[n]())),

--- a/packages/kit/src/runtime/server/utils.js
+++ b/packages/kit/src/runtime/server/utils.js
@@ -1,5 +1,6 @@
 import { text } from '@sveltejs/kit';
 import { ENDPOINT_METHODS } from '../../constants.js';
+import { manifest } from './internal.js';
 
 /**
  * @param {Partial<Record<import('types').HttpMethod, any>>} mod
@@ -98,10 +99,9 @@ export function serialize_uses(node) {
 
 /**
  * Returns `true` if the given path was prerendered
- * @param {import('types').SSRManifest} manifest
  * @param {string} pathname Should include the base and be decoded
  */
-export function has_prerendered_path(manifest, pathname) {
+export function has_prerendered_path(pathname) {
 	return (
 		manifest.prerendered_routes.has(pathname) ||
 		(pathname.at(-1) === '/' && manifest.prerendered_routes.has(pathname.slice(0, -1)))


### PR DESCRIPTION
`Server` keeps the manifest in `#manifest` and passes it to `respond`, from where it travels through 16 parameter positions in `runtime/server`, down to `has_prerendered_path` and `load_error_components`. The same object is written to `runtime/server/internal.js` by `set_manifest` in the `Server` constructor, and `$app/server`'s `read`, `$app/paths`'s `resolve` and the `read_implementation` branch in `fetch.js` already read it from there, so `fetch.js` mixed the parameter and the module singleton in one function.

The parameter is gone and every reader imports `manifest` from `internal.js`, the same shape #16871 gave `options`. The `Server` constructor argument and its `set_manifest` call stay. In dev that call runs per request, so a request in flight during a manifest regeneration now sees the regenerated manifest, which `read` and `resolve` already did.

Closes #16519.
