### PR TITLE
fix: stop adapter-vercel tracing from globbing the whole drive on Windows

### DIFF
--- a/.changeset/vercel-trace-cwd-root-glob.md
+++ b/.changeset/vercel-trace-cwd-root-glob.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-vercel': patch
+---
+
+fix: trace `process.cwd()`-relative files from the project directory and never glob from the filesystem root

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -540,7 +540,12 @@ async function create_function_bundle(builder, entry, dir, config) {
 	let base = entry;
 	while (base !== (base = path.dirname(base)));
 
-	const traced = await nodeFileTrace([entry], { base });
+	const traced = await nodeFileTrace([entry], {
+		base,
+		processCwd: process.cwd(),
+		// a wildcard directly under `base` would glob the entire filesystem
+		ignore: (file) => file.startsWith('**')
+	});
 
 	/** @type {Map<string, string[]>} */
 	const resolution_failures = new Map();

--- a/packages/adapter-vercel/test/apps/basic/asset.txt
+++ b/packages/adapter-vercel/test/apps/basic/asset.txt
@@ -1,0 +1,1 @@
+adapter trace fixture

--- a/packages/adapter-vercel/test/apps/basic/build.test.js
+++ b/packages/adapter-vercel/test/apps/basic/build.test.js
@@ -61,3 +61,8 @@ test('dynamic ISR routes are matched after the filesystem', () => {
 	const index = config.routes.findIndex((route) => route.src === '^(/isr/([^/]+?)/?)$');
 	assert.ok(index > filesystem);
 });
+
+test('process.cwd() is traced from the project directory', () => {
+	const function_dir = fs.realpathSync(`${output}/functions/process-cwd.func`);
+	assert.ok(fs.existsSync(`${function_dir}/adapter-vercel/test/apps/basic/asset.txt`));
+});

--- a/packages/adapter-vercel/test/apps/basic/src/routes/process-cwd/+server.js
+++ b/packages/adapter-vercel/test/apps/basic/src/routes/process-cwd/+server.js
@@ -1,0 +1,6 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export function GET() {
+	return new Response(fs.readFileSync(path.join(process.cwd(), 'asset.txt'), 'utf8'));
+}


### PR DESCRIPTION
`create_function_bundle` traces with `base` set to the filesystem root. nft treats any absolute-looking string with a dynamic segment as an asset glob, and the server output has URL strings like

```js
`/${app_dir}/routes${route_id}`   // runtime/pathname.js
```

On Linux this resolves to `/<*>/routes`, the parent directory is `''`, the stat fails and nothing happens. On Windows it resolves to `D:\<*>\routes`, the parent `D:` stats fine, and nft runs `glob('D:/**/*/routes')` over the whole drive, which never finishes once it hits `pagefile.sys`.

nft also evaluates `process.cwd()` as `base` unless told otherwise, so `path.join(process.cwd(), 'asset.txt')` was traced from `/` and never bundled.

nft calls `ignore` with the glob relative to `base` before walking, and a base-rooted glob is `**\*\routes`. The cwd case has a regression test; the root-glob case can't fire on Linux for the reason above.

Fixes #16963. Supersedes #16964. Related: vercel/nft#609.
