### PR TITLE
chore: use correct Vite instance for runner checks

### DIFF
--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -328,7 +328,7 @@ function kit({ svelte_config }) {
 		 */
 		config: {
 			order: 'pre',
-			async handler(config, config_env) {
+			handler(config, config_env) {
 				initial_config = config;
 				is_build = config_env.command === 'build';
 

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -2,7 +2,7 @@
 /** @import { Options } from '@sveltejs/vite-plugin-svelte' */
 /** @import { PreprocessorGroup } from 'svelte/compiler' */
 /** @import {  ManifestData, RemoteChunk, ServerMetadata, ValidatedConfig } from 'types' */
-/** @import { CorsOptions, Plugin, ResolvedConfig, Rolldown, UserConfig } from 'vite' */
+/** @import { CorsOptions, ResolvedConfig, Rolldown, UserConfig } from 'vite' */
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
@@ -174,7 +174,7 @@ let vite_plugin_svelte;
  * > Prior to SvelteKit 3, config lived in a `svelte.config.js` file, which is no longer supported. The ability to configure SvelteKit via `vite.config.js` was added in version 2.62.
  *
  * @param {import('./public.js').Config} [config]
- * @returns {Promise<Plugin[]>}
+ * @returns {Promise<import('vite').Plugin[]>}
  */
 export async function sveltekit(config) {
 	const cwd = process.cwd();
@@ -274,7 +274,7 @@ function kit({ svelte_config }) {
 	/** @type {string} name for `globalThis.__sveltekit_xxx` */
 	let kit_global;
 
-	/** @type {Plugin} */
+	/** @type {import('vite').Plugin} */
 	const plugin_resolve_root = {
 		name: 'vite-plugin-sveltekit-resolve-root',
 		// make sure it runs first
@@ -295,7 +295,7 @@ function kit({ svelte_config }) {
 		}
 	};
 
-	/** @type {Plugin} */
+	/** @type {import('vite').Plugin} */
 	const plugin_setup = {
 		name: 'vite-plugin-sveltekit-setup',
 		api: {

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -7,6 +7,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 import { styleText } from 'node:util';
+import * as vite from 'vite';
 
 import { resolve_entry } from '../../utils/filesystem.js';
 import { posixify } from '../../utils/os.js';
@@ -237,9 +238,6 @@ function resolve_root(vite_config) {
  * @return {Plugin[]}
  */
 function kit({ svelte_config }) {
-	/** @type {typeof import('vite')} */
-	let vite;
-
 	/**
 	 * The posix-ified root of the project based on the Vite configuration.
 	 * @type {string}
@@ -343,8 +341,6 @@ function kit({ svelte_config }) {
 
 				service_worker_entry_file = resolve_entry(kit.files.serviceWorker);
 				service_worker_entry_file &&= posixify(service_worker_entry_file);
-
-				vite = await import_peer('vite', root);
 
 				normalized_aliases = get_import_aliases(root, vite.normalizePath.bind(vite));
 
@@ -645,10 +641,7 @@ function kit({ svelte_config }) {
 			plugin_remote_guard(svelte_config),
 			plugin_remote(
 				svelte_config,
-				() => ({
-					root,
-					vite
-				}),
+				() => ({ root, vite }),
 				() => build_metadata,
 				(metadata) => {
 					remote_metadata = metadata;

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -1,8 +1,8 @@
 /** @import { EnvVarConfig } from '@sveltejs/kit/env' */
 /** @import { Options } from '@sveltejs/vite-plugin-svelte' */
 /** @import { PreprocessorGroup } from 'svelte/compiler' */
-/** @import {  ManifestData, RemoteChunk, ServerMetadata, ValidatedConfig } from 'types' */
-/** @import { CorsOptions, ResolvedConfig, Rolldown, UserConfig } from 'vite' */
+/** @import { ManifestData, RemoteChunk, ServerMetadata, ValidatedConfig } from 'types' */
+/** @import { CorsOptions, Plugin, ResolvedConfig, Rolldown, UserConfig } from 'vite' */
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
@@ -174,7 +174,7 @@ let vite_plugin_svelte;
  * > Prior to SvelteKit 3, config lived in a `svelte.config.js` file, which is no longer supported. The ability to configure SvelteKit via `vite.config.js` was added in version 2.62.
  *
  * @param {import('./public.js').Config} [config]
- * @returns {Promise<import('vite').Plugin[]>}
+ * @returns {Promise<Plugin[]>}
  */
 export async function sveltekit(config) {
 	const cwd = process.cwd();
@@ -274,7 +274,7 @@ function kit({ svelte_config }) {
 	/** @type {string} name for `globalThis.__sveltekit_xxx` */
 	let kit_global;
 
-	/** @type {import('vite').Plugin} */
+	/** @type {Plugin} */
 	const plugin_resolve_root = {
 		name: 'vite-plugin-sveltekit-resolve-root',
 		// make sure it runs first
@@ -295,7 +295,7 @@ function kit({ svelte_config }) {
 		}
 	};
 
-	/** @type {import('vite').Plugin} */
+	/** @type {Plugin} */
 	const plugin_setup = {
 		name: 'vite-plugin-sveltekit-setup',
 		api: {

--- a/packages/kit/src/runner.js
+++ b/packages/kit/src/runner.js
@@ -1,7 +1,7 @@
 /** @import { ViteDevServer } from 'vite' */
 
 /**
- * @param {typeof import('vite')} vite the peer resolved vite module
+ * @param {typeof import('vite')} vite the vite module that created the server
  * @param {ViteDevServer} server
  */
 export function get_runner(vite, server) {

--- a/packages/kit/src/runner.js
+++ b/packages/kit/src/runner.js
@@ -1,8 +1,8 @@
-/** @import { ViteDevServer } from 'vite' */
+/** @import * as vite from 'vite' */
 
 /**
- * @param {typeof import('vite')} vite the vite module that created the server
- * @param {ViteDevServer} server
+ * @param {typeof vite} vite the vite module that created the server
+ * @param {vite.ViteDevServer} server
  */
 export function get_runner(vite, server) {
 	// `isRunnableDevEnvironment` does an `instanceof` check and will fail if

--- a/packages/kit/src/runner.js
+++ b/packages/kit/src/runner.js
@@ -2,7 +2,7 @@
 /** @import { ViteDevServer } from 'vite' */
 
 /**
- * @param {typeof vite} vite_mod the vite module that created the server
+ * @param {typeof vite} vite the vite module that created the server
  * @param {ViteDevServer} server
  */
 export function get_runner({ isRunnableDevEnvironment }, server) {

--- a/packages/kit/src/runner.js
+++ b/packages/kit/src/runner.js
@@ -1,8 +1,8 @@
-/** @import * as vite from 'vite' */
+/** @import * as vite_types from 'vite' */
 
 /**
- * @param {typeof vite} vite the vite module that created the server
- * @param {vite.ViteDevServer} server
+ * @param {typeof vite_types} vite the vite module that created the server
+ * @param {vite_types.ViteDevServer} server
  */
 export function get_runner(vite, server) {
 	// `isRunnableDevEnvironment` does an `instanceof` check and will fail if

--- a/packages/kit/src/runner.js
+++ b/packages/kit/src/runner.js
@@ -1,13 +1,14 @@
-/** @import * as vite_types from 'vite' */
+/** @import * as vite from 'vite' */
+/** @import { ViteDevServer } from 'vite' */
 
 /**
- * @param {typeof vite_types} vite the vite module that created the server
- * @param {vite_types.ViteDevServer} server
+ * @param {typeof vite} vite_mod the vite module that created the server
+ * @param {ViteDevServer} server
  */
-export function get_runner(vite, server) {
+export function get_runner({ isRunnableDevEnvironment }, server) {
 	// `isRunnableDevEnvironment` does an `instanceof` check and will fail if
 	// we're using different instances of Vite
-	if (!vite.isRunnableDevEnvironment(server.environments.ssr)) {
+	if (!isRunnableDevEnvironment(server.environments.ssr)) {
 		throw new Error('The configured Vite SSR environment must be a RunnableDevEnvironment');
 	}
 

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1556,7 +1556,6 @@ declare module '@sveltejs/kit/params' {
 declare module '@sveltejs/kit/vite' {
 	import type { Adapter } from '@sveltejs/kit';
 	import type { Options } from '@sveltejs/vite-plugin-svelte';
-	import * as vite from 'vite';
 	// this indirection helps make the docs look pretty
 	type VitePluginSvelteOptions = Omit<Options, 'experimental'>;
 	type VitePluginSvelteOptionsExperimental = Options['experimental'];
@@ -2166,7 +2165,7 @@ declare module '@sveltejs/kit/vite' {
 	 * > Prior to SvelteKit 3, config lived in a `svelte.config.js` file, which is no longer supported. The ability to configure SvelteKit via `vite.config.js` was added in version 2.62.
 	 *
 	 * */
-	export function sveltekit(config?: Config): Promise<Plugin[]>;
+	export function sveltekit(config?: Config): Promise<import("vite").Plugin[]>;
 	// Based on https://github.com/josh-hemphill/csp-typed-directives/blob/latest/src/csp.types.ts
 	//
 	// MIT License

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1556,6 +1556,7 @@ declare module '@sveltejs/kit/params' {
 declare module '@sveltejs/kit/vite' {
 	import type { Adapter } from '@sveltejs/kit';
 	import type { Options } from '@sveltejs/vite-plugin-svelte';
+	import * as vite from 'vite';
 	// this indirection helps make the docs look pretty
 	type VitePluginSvelteOptions = Omit<Options, 'experimental'>;
 	type VitePluginSvelteOptionsExperimental = Options['experimental'];
@@ -2165,7 +2166,7 @@ declare module '@sveltejs/kit/vite' {
 	 * > Prior to SvelteKit 3, config lived in a `svelte.config.js` file, which is no longer supported. The ability to configure SvelteKit via `vite.config.js` was added in version 2.62.
 	 *
 	 * */
-	export function sveltekit(config?: Config): Promise<import("vite").Plugin[]>;
+	export function sveltekit(config?: Config): Promise<Plugin[]>;
 	// Based on https://github.com/josh-hemphill/csp-typed-directives/blob/latest/src/csp.types.ts
 	//
 	// MIT License

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1556,7 +1556,7 @@ declare module '@sveltejs/kit/params' {
 declare module '@sveltejs/kit/vite' {
 	import type { Adapter } from '@sveltejs/kit';
 	import type { Options } from '@sveltejs/vite-plugin-svelte';
-	import type { Plugin } from 'vite';
+	import * as vite from 'vite';
 	// this indirection helps make the docs look pretty
 	type VitePluginSvelteOptions = Omit<Options, 'experimental'>;
 	type VitePluginSvelteOptionsExperimental = Options['experimental'];


### PR DESCRIPTION
fixes the vite ecosystem ci error https://github.com/vitejs/vite-ecosystem-ci/actions/runs/32693769091/job/97332021820#step:7:1811

There is no point to us calling `resolve_peer(...)` for a Vite instance in the `vite/index.js` file anymore since we don't use to run the client build during a server build (SvelteKit 2 behaviour). Removing this should avoid the vite-ecosystem-ci error where the Vite runner `instanceof` check fails from two differently resolved Vite instances (the one that started the build and the one from our `resolve_peer`).
