### PR TITLE
chore: stop stat'ing assets whose sizes nothing reads

### DIFF
--- a/.changeset/idle-stats-rest.md
+++ b/.changeset/idle-stats-rest.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+chore: stop stat'ing static and server assets whose sizes nothing reads

--- a/.changeset/idle-stats-rest.md
+++ b/.changeset/idle-stats-rest.md
@@ -1,5 +1,0 @@
----
-'@sveltejs/kit': patch
----
-
-chore: stop stat'ing static and server assets whose sizes nothing reads

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -131,11 +131,7 @@ export function create_builder({
 				route_data.filter((route) => prerender_map.get(route.id) !== true),
 				vite_config.root
 			);
-			/** @type {Record<string, number>} */
-			const files = {};
 			for (const file of server_assets) {
-				files[file] = statSync(path.resolve(build_data.out_dir, 'server', file)).size;
-
 				const ext = path.extname(file);
 				mime_types[ext] ??= mime_lookup(ext) || '';
 			}

--- a/packages/kit/src/core/sync/create_manifest_data/index.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.js
@@ -82,7 +82,6 @@ export function create_assets(config) {
 
 	return [...walk(config.files.assets)].map((file) => ({
 		file,
-		size: fs.statSync(path.resolve(config.files.assets, file)).size,
 		type: lookup(file) || null
 	}));
 }

--- a/packages/kit/src/core/sync/create_manifest_data/index.spec.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.spec.js
@@ -731,12 +731,10 @@ test('lists static assets', () => {
 	expect(assets).toEqual([
 		{
 			file: 'bar/baz.txt',
-			size: 14,
 			type: 'text/plain'
 		},
 		{
 			file: 'foo.txt',
-			size: 9,
 			type: 'text/plain'
 		}
 	]);

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -55,7 +55,6 @@ export interface ServerInternalModule {
 
 export interface Asset {
 	file: string;
-	size: number;
 	type: string | null;
 }
 


### PR DESCRIPTION
`builder.mimeTypes` stats every server asset for a size it never returns, and `create_assets` stats every file in `static/` for a `size` field nothing reads. Both calls are removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced unnecessary filesystem checks when processing static and server assets, improving build efficiency.

* **Bug Fixes**
  * Simplified asset metadata by removing file-size information that was not needed.
  * Asset records now retain relevant file paths and MIME types without exposing size values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->