### PR TITLE
chore: derive the fetch cache url in one place

### DIFF
--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -47,7 +47,8 @@ import {
 	TRAILING_SLASH_PARAM,
 	create_remote_key,
 	validate_depends,
-	validate_load_response
+	validate_load_response,
+	fetch_cache_url
 } from '../shared.js';
 
 import { page, updated, notify_version, update_page, set_navigation } from '#app/state/client';
@@ -1309,10 +1310,7 @@ function resolve_fetch_url(input, init, url) {
 	// we must fixup relative urls so they are resolved from the target page
 	const resolved = new URL(input instanceof Request ? input.url : input, url);
 
-	// match the server's serialization of `fetched.url` (see load_data.js): a path for same-origin
-	// urls, so prerendered pages can be served from any origin, the normalized href otherwise
-	const requested =
-		resolved.origin === url.origin ? resolved.href.slice(url.origin.length) : resolved.href;
+	const requested = fetch_cache_url(resolved, url);
 
 	const promise = started
 		? subsequent_fetch(requested, resolved.href, init)

--- a/packages/kit/src/runtime/client/fetcher.js
+++ b/packages/kit/src/runtime/client/fetcher.js
@@ -1,3 +1,4 @@
+import { fetch_cache_url } from '../shared.js';
 import { DEV } from 'esm-env';
 import { hash_request } from '../../utils/hash.js';
 import { base64_decode } from '../utils.js';
@@ -152,15 +153,14 @@ export function dev_fetch(resource, opts) {
 }
 
 /**
- * Mirror the url normalization in `resolve_fetch_url`, so that non-GET requests
- * evict the cache entry regardless of how the url is spelled
+ * The cache key of a request, so that non-GET requests evict the entry regardless of how the url is spelled
  * @param {RequestInfo | URL} input
  */
 function requested_url(input) {
-	const resolved = new URL(input instanceof Request ? input.url : input, location.href);
-	return resolved.origin === location.origin
-		? resolved.href.slice(location.origin.length)
-		: resolved.href;
+	return fetch_cache_url(
+		new URL(input instanceof Request ? input.url : input, location.href),
+		location
+	);
 }
 
 /**

--- a/packages/kit/src/runtime/client/fetcher.js
+++ b/packages/kit/src/runtime/client/fetcher.js
@@ -1,7 +1,7 @@
-import { fetch_cache_url } from '../shared.js';
 import { DEV } from 'esm-env';
 import { hash_request } from '../../utils/hash.js';
 import { base64_decode } from '../utils.js';
+import { fetch_cache_url } from '../shared.js';
 
 let loading = 0;
 
@@ -153,7 +153,7 @@ export function dev_fetch(resource, opts) {
 }
 
 /**
- * The cache key of a request, so that non-GET requests evict the entry regardless of how the url is spelled
+ * Non-GET requests must evict under the stored key, however the url is spelled
  * @param {RequestInfo | URL} input
  */
 function requested_url(input) {

--- a/packages/kit/src/runtime/server/page/load_data.js
+++ b/packages/kit/src/runtime/server/page/load_data.js
@@ -1,7 +1,7 @@
 import { DEV } from 'esm-env';
 import { noop } from '../../../utils/functions.js';
 import { disable_search, make_trackable } from '../../../utils/url.js';
-import { validate_depends, validate_load_response } from '../../shared.js';
+import { fetch_cache_url, validate_depends, validate_load_response } from '../../shared.js';
 import { with_request_store, merge_tracing, record_span } from '@sveltejs/kit/internal/server';
 import { base64_encode } from '../../utils.js';
 import { NULL_BODY_STATUS } from '../constants.js';
@@ -344,7 +344,7 @@ export function create_universal_fetch(event, prerendering, fetched, csr, resolv
 					}
 
 					fetched.push({
-						url: same_origin ? url.href.slice(event.url.origin.length) : url.href,
+						url: fetch_cache_url(url, event.url),
 						method: event.request.method,
 						request_body: /** @type {string | ArrayBufferView | null | undefined} */ (request_body),
 						request_headers: cloned_headers,

--- a/packages/kit/src/runtime/shared.js
+++ b/packages/kit/src/runtime/shared.js
@@ -16,8 +16,7 @@ export function validate_depends(route_id, dep) {
 }
 
 /**
- * The url a `load` `fetch` response is serialized under during SSR and looked up by on the client:
- * a path for same-origin urls, so prerendered pages can be served from any origin, the href otherwise
+ * Same-origin urls are keyed by path, so prerendered pages can be served from any origin
  * @param {URL} url
  * @param {{ origin: string }} page
  */

--- a/packages/kit/src/runtime/shared.js
+++ b/packages/kit/src/runtime/shared.js
@@ -15,6 +15,16 @@ export function validate_depends(route_id, dep) {
 	}
 }
 
+/**
+ * The url a `load` `fetch` response is serialized under during SSR and looked up by on the client:
+ * a path for same-origin urls, so prerendered pages can be served from any origin, the href otherwise
+ * @param {URL} url
+ * @param {{ origin: string }} page
+ */
+export function fetch_cache_url(url, page) {
+	return url.origin === page.origin ? url.href.slice(page.origin.length) : url.href;
+}
+
 export const INVALIDATED_PARAM = 'x-sveltekit-invalidated';
 
 export const TRAILING_SLASH_PARAM = 'x-sveltekit-trailing-slash';


### PR DESCRIPTION
The url a `load` `fetch` response is serialized under is spelled out in `load_data.js`, `client.js` and `fetcher.js`, with comments asking each other to stay in sync. #14781 was those copies drifting. `fetch_cache_url` in `runtime/shared.js` is now the one definition.

Supersedes #16792 without its hash changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request URL handling for same-origin and cross-origin fetches.
  * Standardized URL normalization across client-side and server-side data fetching.
  * Preserved absolute URLs for cross-origin requests while using relative paths for same-origin requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->