### PR TITLE
chore: more CodeRabbit auto issue/pr labelling

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -143,7 +143,9 @@ issue_enrichment:
     auto_apply_labels: true
     labeling_instructions:
       - label: 'awaiting submitter'
-        instructions: 'Issue is a bug report but does not include a link to a minimal reproduction'
+        instructions: >-
+          Issue is a bug report and has a heading named "Reproduction" in the description
+          but does not include a link to a minimal reproduction
       - label: 'pkg:enhanced-img'
         instructions: 'Issue is related to static image optimisation the `@sveltejs/enhanced-img` package'
       - label: 'pkg:adapter-cloudflare'

--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -36,6 +36,8 @@ reviews:
       instructions: "PR contains a breaking change to public interfaces"
     - label: "documentation"
       instructions: "PR updates documentation or examples"
+    - label: "needs-platform-tests"
+      instructions: "PR adds/deletes/modifies files in an adapter package or has 'Version Packages' in the title"
 
   slop_detection:
     label: "🤖"
@@ -138,12 +140,12 @@ issue_enrichment:
     auto_apply_labels: true
     labeling_instructions:
       - label: "awaiting submitter"
-        instructions: "If the issue is a bug report but does not include a link to a minimal reproduction"
+        instructions: "Issue is a bug report but does not include a link to a minimal reproduction"
       - label: "pkg:enhanced-img"
-        instructions: "If the issue is related to static image optimisation the `@sveltejs/enhanced-img` package"
+        instructions: "Issue is related to static image optimisation the `@sveltejs/enhanced-img` package"
       - label: "pkg:adapter-cloudflare"
-        instructions: "If the issue is related to Cloudflare Workers/Pages or the `@sveltejs/adapter-cloudflare` package"
+        instructions: "Issue is related to Cloudflare Workers/Pages or the `@sveltejs/adapter-cloudflare` package"
       - label: "pkg:adapter-netlify"
-        instructions: "If the issue is related to the Netlify platform or the `@sveltejs/adapter-netlify` package"
+        instructions: "Issue is related to the Netlify platform or the `@sveltejs/adapter-netlify` package"
       - label: "pkg:adapter-vercel"
-        instructions: "If the issue is related to the Vercel platform or the `@sveltejs/adapter-vercel` package"
+        instructions: "Issue is related to the Vercel platform or the `@sveltejs/adapter-vercel` package"

--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -37,7 +37,7 @@ reviews:
     - label: "documentation"
       instructions: "PR updates documentation or examples"
     - label: "needs-platform-tests"
-      instructions: "PR adds/deletes/modifies files in an adapter package or has 'Version Packages' in the title"
+      instructions: "PR adds/deletes/modifies files in an adapter package (except adapter-static and adapter-auto) or has 'Version Packages' in the PR title"
 
   slop_detection:
     label: "🤖"

--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -26,24 +26,24 @@ reviews:
     auto_incremental_review: true
     # auto_pause_after_reviewed_commits: 5
     ignore_title_keywords:
-      - "Version Packages"
+      - 'Version Packages'
     # ignore_usernames: []
     # labels: []
 
   auto_apply_labels: true
   labeling_instructions:
-    - label: "breaking change"
-      instructions: "PR contains a breaking change to public interfaces"
-    - label: "documentation"
-      instructions: "PR updates documentation or examples"
-    - label: "needs-platform-tests"
+    - label: 'breaking change'
+      instructions: 'PR contains a breaking change to public interfaces'
+    - label: 'documentation'
+      instructions: 'PR updates documentation or examples'
+    - label: 'needs-platform-tests'
       instructions: >-
         PR adds/deletes/modifies files in an adapter package
         (except adapter-static and adapter-auto) or has 'Version Packages'
         in the PR title
 
   slop_detection:
-    label: "🤖"
+    label: '🤖'
 
   profile: quiet
 
@@ -70,7 +70,7 @@ reviews:
   pre_merge_checks:
     title:
       mode: warning
-      requirements: "Prefix PR titles with `breaking:`, `feat:`, `fix:`, or `chore:`"
+      requirements: 'Prefix PR titles with `breaking:`, `feat:`, `fix:`, or `chore:`'
     docstrings:
       mode: off
       threshold: 80
@@ -79,8 +79,8 @@ reviews:
     issue_assessment:
       mode: off
     custom_checks:
-      - name: "Backward Compatibility Impact Disclosure"
-        mode: "warning"
+      - name: 'Backward Compatibility Impact Disclosure'
+        mode: 'warning'
         instructions: >-
           Detect breaking changes to public interfaces: removed or renamed
           exports, new required request/response fields, changed defaults, or
@@ -92,12 +92,12 @@ reviews:
   #     prompt: ""
 
   path_filters:
-    - "!.well-known/**"
-    - "!playgrounds/**"
-    - "!packages/kit/types/**"
-    - "!FUNDING.json"
+    - '!.well-known/**'
+    - '!playgrounds/**'
+    - '!packages/kit/types/**'
+    - '!FUNDING.json'
   path_instructions:
-    - path: "documentation/docs/**.md"
+    - path: 'documentation/docs/**.md'
       instructions: |
         Check for clarity, accuracy, and completeness.
         Flag any references to deprecated APIs or outdated behavior.
@@ -105,15 +105,15 @@ reviews:
 knowledge_base:
   code_guidelines:
     filePatterns:
-      - "AGENTS.md"
-      - "CONTRIBUTING.md"
+      - 'AGENTS.md'
+      - 'CONTRIBUTING.md'
   linked_repositories:
-    - repository: "sveltejs/svelte"
-      instructions: "The Svelte compiler and runtime"
-    - repository: "sveltejs/vite-plugin-svelte"
-      instructions: "The Vite plugin that transforms Svelte modules during development and build"
-    - repository: "vitejs/vite"
-      instructions: "Powers the development server and build process"
+    - repository: 'sveltejs/svelte'
+      instructions: 'The Svelte compiler and runtime'
+    - repository: 'sveltejs/vite-plugin-svelte'
+      instructions: 'The Vite plugin that transforms Svelte modules during development and build'
+    - repository: 'vitejs/vite'
+      instructions: 'Powers the development server and build process'
   learnings:
     scope: global
   issues:
@@ -142,13 +142,13 @@ issue_enrichment:
   labeling:
     auto_apply_labels: true
     labeling_instructions:
-      - label: "awaiting submitter"
-        instructions: "Issue is a bug report but does not include a link to a minimal reproduction"
-      - label: "pkg:enhanced-img"
-        instructions: "Issue is related to static image optimisation the `@sveltejs/enhanced-img` package"
-      - label: "pkg:adapter-cloudflare"
-        instructions: "Issue is related to Cloudflare Workers/Pages or the `@sveltejs/adapter-cloudflare` package"
-      - label: "pkg:adapter-netlify"
-        instructions: "Issue is related to the Netlify platform or the `@sveltejs/adapter-netlify` package"
-      - label: "pkg:adapter-vercel"
-        instructions: "Issue is related to the Vercel platform or the `@sveltejs/adapter-vercel` package"
+      - label: 'awaiting submitter'
+        instructions: 'Issue is a bug report but does not include a link to a minimal reproduction'
+      - label: 'pkg:enhanced-img'
+        instructions: 'Issue is related to static image optimisation the `@sveltejs/enhanced-img` package'
+      - label: 'pkg:adapter-cloudflare'
+        instructions: 'Issue is related to Cloudflare Workers/Pages or the `@sveltejs/adapter-cloudflare` package'
+      - label: 'pkg:adapter-netlify'
+        instructions: 'Issue is related to the Netlify platform or the `@sveltejs/adapter-netlify` package'
+      - label: 'pkg:adapter-vercel'
+        instructions: 'Issue is related to the Vercel platform or the `@sveltejs/adapter-vercel` package'

--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -35,7 +35,7 @@ reviews:
     - label: 'breaking change'
       instructions: 'PR contains a breaking change to public interfaces'
     - label: 'documentation'
-      instructions: 'PR updates documentation or examples'
+      instructions: 'PR only contains changes to documentation files'
     - label: 'needs-platform-tests'
       instructions: >-
         PR adds/deletes/modifies files in an adapter package

--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -37,7 +37,10 @@ reviews:
     - label: "documentation"
       instructions: "PR updates documentation or examples"
     - label: "needs-platform-tests"
-      instructions: "PR adds/deletes/modifies files in an adapter package (except adapter-static and adapter-auto) or has 'Version Packages' in the PR title"
+      instructions: >-
+        PR adds/deletes/modifies files in an adapter package
+        (except adapter-static and adapter-auto) or has 'Version Packages'
+        in the PR title
 
   slop_detection:
     label: "🤖"


### PR DESCRIPTION
This one adds more automated package labeling for issues and `needs-platform-tests` for PRs which touch adapter code with platform tests