### PR TITLE
test: verify Vercel route max duration

### DIFF
--- a/packages/adapter-vercel/test/apps/basic/src/routes/max-duration/+server.ts
+++ b/packages/adapter-vercel/test/apps/basic/src/routes/max-duration/+server.ts
@@ -1,0 +1,8 @@
+export const config = {
+	maxDuration: 1
+};
+
+export async function GET() {
+	await new Promise((resolve) => setTimeout(resolve, 3_000));
+	return new Response('completed');
+}

--- a/packages/adapter-vercel/test/apps/basic/test/test.ts
+++ b/packages/adapter-vercel/test/apps/basic/test/test.ts
@@ -19,6 +19,12 @@ test('API routes work', async ({ request }) => {
 	expect(data.ok).toBe(true);
 });
 
+test('route-level maxDuration is applied', async ({ request }) => {
+	const response = await request.get('/max-duration');
+	expect(response.status()).toBe(504);
+	expect(response.headers()['x-vercel-error']).toBe('FUNCTION_INVOCATION_TIMEOUT');
+});
+
 test('dynamic env is available in instrumentation', async ({ request }) => {
 	const response = await request.get('/instrumentation-env');
 	expect(response.ok()).toBe(true);


### PR DESCRIPTION
closes #12023

Adds a deployed Vercel platform test to determine whether route-level `maxDuration` overrides work. The fixture exports `maxDuration: 1` from a route that runs for 3 seconds, then asserts Vercel returns `504` with `FUNCTION_INVOCATION_TIMEOUT`.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets

- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.