### PR TITLE
test: cover user-defined Vercel redirects

### DIFF
--- a/packages/adapter-vercel/test/apps/basic/test/test.ts
+++ b/packages/adapter-vercel/test/apps/basic/test/test.ts
@@ -5,6 +5,12 @@ test('basic page renders', async ({ page }) => {
 	await expect(page.locator('h1')).toContainText('Hello from SvelteKit on Vercel');
 });
 
+test('redirects from vercel.json work', async ({ request }) => {
+	const response = await request.get('/redirect', { maxRedirects: 0 });
+	expect(response.status()).toBe(307);
+	expect(response.headers()['location']).toBe('/');
+});
+
 test('server-side data loading works', async ({ page }) => {
 	await page.goto('/server-data');
 	await expect(page.locator('h1')).toContainText('loaded on server');

--- a/packages/adapter-vercel/test/apps/basic/vercel.json
+++ b/packages/adapter-vercel/test/apps/basic/vercel.json
@@ -1,0 +1,3 @@
+{
+	"redirects": [{ "source": "/redirect", "destination": "/", "permanent": false }]
+}


### PR DESCRIPTION
closes #12523

Add deployed platform coverage proving redirects defined in a user `vercel.json` remain active with adapter-vercel's Build Output API deployment.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

Targeted: `pnpm -F test-vercel-basic test:build` (12 passed); oxfmt check passed.

### Changesets

- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.