### PR TITLE
fix: support optional params in Netlify split mode

### DIFF
--- a/.changeset/fresh-pandas-smile.md
+++ b/.changeset/fresh-pandas-smile.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-netlify': patch
+---
+
+fix: route requests with omitted optional parameters to split serverless functions

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -159,7 +159,7 @@ function generate_serverless_functions({ builder, publish, split }) {
 			const name_parts = paths.at(-1);
 			const name =
 				FUNCTION_PREFIX +
-				(name_parts?.join('-').replace(/[:.]/g, '_').replace('*', '__rest') || 'index');
+				(name_parts?.join('-').replace(/[:.]/g, '_').replace(/\*/g, '__rest') || 'index');
 
 			// Netlify handles trailing slashes for us, so we don't need to include them in the patterns
 			const patterns = paths

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -140,32 +140,37 @@ function generate_serverless_functions({ builder, publish, split }) {
 
 			const routes = [route];
 
-			/** @type {string[]} */
-			const parts = [];
+			/** @type {string[][]} */
+			let paths = [[]];
 
 			// The parts should conform to URLPattern syntax
 			// https://docs.netlify.com/build/functions/get-started/?fn-language=ts&data-tab=TypeScript#route-requests
-			for (const segment of route.segments) {
-				if (segment.rest) {
-					parts.push('*');
-				} else if (segment.dynamic) {
-					// URLPattern requires params to start with letters
-					parts.push(`:param${parts.length}`);
+			for (const [i, segment] of route.segments.entries()) {
+				const param = `:param${i}`;
+
+				if (/^\[\[.+\]\]$/.test(segment.content)) {
+					paths = paths.flatMap((parts) => [parts, [...parts, param]]);
 				} else {
-					parts.push(segment.content);
+					const part = segment.rest ? '*' : segment.dynamic ? param : segment.content;
+					paths.forEach((parts) => parts.push(part));
 				}
 			}
 
-			// Netlify handles trailing slashes for us, so we don't need to include them in the pattern
-			const pattern = `/${parts.join('/')}`;
+			const name_parts = paths.at(-1);
 			const name =
-				FUNCTION_PREFIX + (parts.join('-').replace(/[:.]/g, '_').replace('*', '__rest') || 'index');
+				FUNCTION_PREFIX +
+				(name_parts?.join('-').replace(/[:.]/g, '_').replace('*', '__rest') || 'index');
 
-			// skip routes with identical patterns, they were already folded into another function
-			if (seen.has(pattern)) continue;
+			// Netlify handles trailing slashes for us, so we don't need to include them in the patterns
+			const patterns = paths
+				.map((parts) => `/${parts.join('/')}`)
+				.flatMap((pattern) => [pattern, `${pattern === '/' ? '' : pattern}/__data.json`])
+				.filter((pattern) => !seen.has(pattern));
 
-			const patterns = [pattern, `${pattern === '/' ? '' : pattern}/__data.json`];
-			patterns.forEach((p) => seen.add(p));
+			// skip routes whose patterns were already folded into other functions
+			if (patterns.length === 0) continue;
+
+			patterns.forEach((pattern) => seen.add(pattern));
 
 			// figure out which lower priority routes should be considered fallbacks
 			for (let j = i + 1; j < builder.routes.length; j += 1) {

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -140,36 +140,34 @@ function generate_serverless_functions({ builder, publish, split }) {
 
 			const routes = [route];
 
-			/** @type {string[][]} */
-			let paths = [[]];
+			/** @type {string[]} */
+			const parts = [];
 
 			// The parts should conform to URLPattern syntax
 			// https://docs.netlify.com/build/functions/get-started/?fn-language=ts&data-tab=TypeScript#route-requests
 			for (const [i, segment] of route.segments.entries()) {
-				const param = `:param${i}`;
-
-				if (/^\[\[.+\]\]$/.test(segment.content)) {
-					paths = paths.flatMap((parts) => [parts, [...parts, param]]);
+				if (segment.rest) {
+					parts.push('*');
+				} else if (segment.dynamic) {
+					// URLPattern requires params to start with letters
+					const optional = /^\[\[.+\]\]$/.test(segment.content) ? '?' : '';
+					parts.push(`:param${i}${optional}`);
 				} else {
-					const part = segment.rest ? '*' : segment.dynamic ? param : segment.content;
-					paths.forEach((parts) => parts.push(part));
+					parts.push(segment.content);
 				}
 			}
 
-			const name_parts = paths.at(-1);
+			// Netlify handles trailing slashes for us, so we don't need to include them in the pattern
+			const pattern = `/${parts.join('/')}`;
 			const name =
 				FUNCTION_PREFIX +
-				(name_parts?.join('-').replace(/[:.]/g, '_').replace(/\*/g, '__rest') || 'index');
+				(parts.join('-').replace(/[:.]/g, '_').replace(/\?/g, '').replace(/\*/g, '__rest') ||
+					'index');
 
-			// Netlify handles trailing slashes for us, so we don't need to include them in the patterns
-			const patterns = paths
-				.map((parts) => `/${parts.join('/')}`)
-				.flatMap((pattern) => [pattern, `${pattern === '/' ? '' : pattern}/__data.json`])
-				.filter((pattern) => !seen.has(pattern));
+			// skip routes with identical patterns, they were already folded into another function
+			if (seen.has(pattern)) continue;
 
-			// skip routes whose patterns were already folded into other functions
-			if (patterns.length === 0) continue;
-
+			const patterns = [pattern, `${pattern === '/' ? '' : pattern}/__data.json`];
 			patterns.forEach((pattern) => seen.add(pattern));
 
 			// figure out which lower priority routes should be considered fallbacks

--- a/packages/adapter-netlify/test/apps/split/src/routes/collection/[[optional]]/article/+page.server.js
+++ b/packages/adapter-netlify/test/apps/split/src/routes/collection/[[optional]]/article/+page.server.js
@@ -1,0 +1,4 @@
+/** @type {import('./$types').PageServerLoad} */
+export function load({ params }) {
+	return { optional: params.optional ?? null };
+}

--- a/packages/adapter-netlify/test/apps/split/src/routes/collection/[[optional]]/article/+page.svelte
+++ b/packages/adapter-netlify/test/apps/split/src/routes/collection/[[optional]]/article/+page.svelte
@@ -1,0 +1,6 @@
+<script>
+	let { data } = $props();
+</script>
+
+<!-- Netlify uses URLPattern for routing; verify direct SSR works whether the optional param is present or omitted -->
+<p>optional: {data.optional ?? 'none'}</p>

--- a/packages/adapter-netlify/test/apps/split/test/test.js
+++ b/packages/adapter-netlify/test/apps/split/test/test.js
@@ -41,7 +41,7 @@ test('split generates multiple function files', () => {
 		'utf-8'
 	);
 	expect(optional_route).toContain(
-		'path: ["/collection/article", "/collection/article/__data.json", "/collection/:param1/article", "/collection/:param1/article/__data.json"]'
+		'path: ["/collection/:param1?/article", "/collection/:param1?/article/__data.json"]'
 	);
 });
 

--- a/packages/adapter-netlify/test/apps/split/test/test.js
+++ b/packages/adapter-netlify/test/apps/split/test/test.js
@@ -35,6 +35,14 @@ test('split generates multiple function files', () => {
 	const functions_dir = path.resolve(import.meta.dirname, '../.netlify/v1/functions');
 	const files = fs.readdirSync(functions_dir).filter((f) => f.startsWith('sveltekit-'));
 	expect(files.length).toBeGreaterThan(1);
+
+	const optional_route = fs.readFileSync(
+		path.join(functions_dir, 'sveltekit-collection-_param1-article.mjs'),
+		'utf-8'
+	);
+	expect(optional_route).toContain(
+		'path: ["/collection/article", "/collection/article/__data.json", "/collection/:param1/article", "/collection/:param1/article/__data.json"]'
+	);
 });
 
 test('_redirects are copied to publish directory', () => {

--- a/packages/adapter-netlify/test/apps/split/test/test.js
+++ b/packages/adapter-netlify/test/apps/split/test/test.js
@@ -2,9 +2,17 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { expect, test } from '@playwright/test';
 
-test('routes to routes with dynamic params', async ({ page }) => {
+test('routes with dynamic params', async ({ page }) => {
 	await page.goto('/dynamic/123');
 	await expect(page.locator('p')).toHaveText('id: 123');
+});
+
+test('routes with optional params', async ({ page }) => {
+	await page.goto('/collection/article');
+	await expect(page.locator('p')).toHaveText('optional: none');
+
+	await page.goto('/collection/value/article');
+	await expect(page.locator('p')).toHaveText('optional: value');
 });
 
 test('client-side navigation fetches server load function data', async ({ page }) => {


### PR DESCRIPTION
closes #9825

This maps `[[optional]]` segments to URLPattern's native optional named-parameter syntax (`:param?`). 

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Netlify split-function routing for requests where optional URL parameters are omitted.
  * Improved generated function names and route matching for optional and rest parameters.

* **Tests**
  * Added coverage for routes with optional parameters both present and absent.
  * Verified that generated functions include all expected route paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->