### PR TITLE
fix: resolve static route ID unions

### DIFF
--- a/.changeset/fix-routeid-resolve.md
+++ b/.changeset/fix-routeid-resolve.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: preserve route parameters when resolving mixed route ID unions

--- a/packages/kit/src/runtime/app/paths/types.d.ts
+++ b/packages/kit/src/runtime/app/paths/types.d.ts
@@ -6,10 +6,24 @@ type StripSearchOrHash<T extends string> = T extends `${infer U}?${string}`
 		? U
 		: T;
 
-export type ResolveArgs<T> = T extends `/${string}`
+type ResolveRouteArgs<T extends string> = T extends unknown
 	? StripSearchOrHash<T> extends infer U extends RouteId
 		? RouteParams<U> extends Record<string, never>
 			? [route: T]
 			: [route: T, params: RouteParams<U>]
 		: [never]
+	: never;
+
+type HasRouteParams<T extends string> = T extends unknown
+	? StripSearchOrHash<T> extends infer U extends RouteId
+		? RouteParams<U> extends Record<string, never>
+			? never
+			: true
+		: never
+	: never;
+
+export type ResolveArgs<T extends string> = [T] extends [`/${string}`]
+	? [HasRouteParams<T>] extends [never]
+		? [route: T]
+		: ResolveRouteArgs<T>
 	: [pathname: T];

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2970,12 +2970,26 @@ declare module '$app/paths' {
 			? U
 			: T;
 
-	type ResolveArgs<T> = T extends `/${string}`
+	type ResolveRouteArgs<T extends string> = T extends unknown
 		? StripSearchOrHash<T> extends infer U extends RouteId
 			? RouteParams<U> extends Record<string, never>
 				? [route: T]
 				: [route: T, params: RouteParams<U>]
 			: [never]
+		: never;
+
+	type HasRouteParams<T extends string> = T extends unknown
+		? StripSearchOrHash<T> extends infer U extends RouteId
+			? RouteParams<U> extends Record<string, never>
+				? never
+				: true
+			: never
+		: never;
+
+	type ResolveArgs<T extends string> = [T] extends [`/${string}`]
+		? [HasRouteParams<T>] extends [never]
+			? [route: T]
+			: ResolveRouteArgs<T>
 		: [pathname: T];
 
 	export {};


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/15536

Stacked on #17024, which contains the regression test. Keeps static route-ID unions as a single resolve argument tuple while preserving correlated params for mixed unions.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the targeted write-types tests and lint the project with `pnpm lint` and `pnpm check`

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked.