### PR TITLE
Add an ignore field to adapters that is passed through to nft to, to prevent build time only exports from getting included in the bundle

### DIFF
--- a/.changeset/witty-clouds-shave.md
+++ b/.changeset/witty-clouds-shave.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-vercel': minor
+---
+
+feat: add `ignore` option to exclude files from serverless function bundles

--- a/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
+++ b/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
@@ -55,6 +55,26 @@ Configuration set in a layout applies to all the routes beneath that layout, unl
 
 If your functions need to access data in a specific region, it's recommended that they be deployed in the same region (or close to it) for optimal performance.
 
+The `ignore` option can only be set at the adapter level, and is ignored if you set it in a route's `config`. It is called with the absolute path of every file traced into a serverless function bundle, and returning `true` leaves that file, and anything reachable only through it, out of the bundle:
+
+```js
+// @errors: 2554
+/// file: vite.config.js
+import adapter from '@sveltejs/adapter-vercel';
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+	plugins: [
+		sveltekit({
+			adapter: adapter({
+				ignore: (file) => file.includes('/node_modules/some-build-only-package/')
+			})
+		})
+	]
+});
+```
+
 ## Image Optimization
 
 You may set the `images` config to control how Vercel builds your images. See the [image configuration reference](https://vercel.com/docs/build-output-api/v3/configuration#images) for full details. As an example, you may set:

--- a/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
+++ b/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
@@ -55,7 +55,7 @@ Configuration set in a layout applies to all the routes beneath that layout, unl
 
 If your functions need to access data in a specific region, it's recommended that they be deployed in the same region (or close to it) for optimal performance.
 
-The `ignore` option can only be set at the adapter level, and is ignored if you set it in a route's `config`. It is called with the absolute path of every file traced into a serverless function bundle, and returning `true` leaves that file, and anything reachable only through it, out of the bundle:
+The `ignore` option can only be set at the adapter level, and is ignored if you set it in a route's `config`. It is called with the absolute path of every file traced into a serverless function bundle (always using `/` as the separator, including on Windows), and returning `true` leaves that file, and anything reachable only through it, out of the bundle:
 
 ```js
 // @errors: 2554

--- a/packages/adapter-vercel/index.d.ts
+++ b/packages/adapter-vercel/index.d.ts
@@ -76,4 +76,12 @@ export type Config = ServerlessConfig & {
 	 * https://vercel.com/docs/build-output-api/v3/configuration#images
 	 */
 	images?: ImagesConfig;
+	/**
+	 * Exclude files from the serverless function bundles. Called with the absolute path of every
+	 * file [`@vercel/nft`](https://github.com/vercel/nft) traces from the function entry point.
+	 * Return `true` to leave the file, and anything reachable only through it, out of the bundle.
+	 *
+	 * This option can only be set at the adapter level. It is ignored if set in a route's `config`.
+	 */
+	ignore?: (file: string) => boolean;
 };

--- a/packages/adapter-vercel/index.d.ts
+++ b/packages/adapter-vercel/index.d.ts
@@ -77,7 +77,8 @@ export type Config = ServerlessConfig & {
 	 */
 	images?: ImagesConfig;
 	/**
-	 * Exclude files from the serverless function bundles
+	 * Exclude files from the serverless function bundles. Called with the absolute path of each
+	 * traced file, using `/` as the separator on every platform.
 	 *
 	 * This option can only be set at the adapter level. It is ignored if set in a route's `config`.
 	 */

--- a/packages/adapter-vercel/index.d.ts
+++ b/packages/adapter-vercel/index.d.ts
@@ -77,9 +77,7 @@ export type Config = ServerlessConfig & {
 	 */
 	images?: ImagesConfig;
 	/**
-	 * Exclude files from the serverless function bundles. Called with the absolute path of every
-	 * file [`@vercel/nft`](https://github.com/vercel/nft) traces from the function entry point.
-	 * Return `true` to leave the file, and anything reachable only through it, out of the bundle.
+	 * Exclude files from the serverless function bundles
 	 *
 	 * This option can only be set at the adapter level. It is ignored if set in a route's `config`.
 	 */

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -4,7 +4,7 @@ import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 import { VERSION } from '@sveltejs/kit';
 import { nodeFileTrace } from '@vercel/nft';
-import { parse_isr_expiration, pattern_to_src, resolve_runtime } from './utils.js';
+import { parse_isr_expiration, pattern_to_src, resolve_runtime, trace_ignore } from './utils.js';
 
 const INTERNAL = '![-]'; // this name is guaranteed not to conflict with user routes
 
@@ -13,6 +13,10 @@ const plugin = function (defaults = {}) {
 	// @ts-ignore TODO remove this in a future version
 	if ('edge' in defaults || defaults.runtime === 'edge') {
 		throw new Error('The `edge` runtime is no longer supported');
+	}
+
+	if (defaults.ignore !== undefined && typeof defaults.ignore !== 'function') {
+		throw new Error('The `ignore` option must be a function');
 	}
 
 	return {
@@ -76,7 +80,7 @@ const plugin = function (defaults = {}) {
 				}
 				builder.generateServerInstance(`${tmp}/server.js`, { routes });
 
-				await create_function_bundle(builder, entrypoint, dir, config);
+				await create_function_bundle(builder, entrypoint, dir, config, defaults.ignore);
 
 				for (const asset of builder.findServerAssets(routes)) {
 					// TODO use symlinks, once Build Output API supports doing so
@@ -535,18 +539,21 @@ function static_vercel_config(builder, config, dir) {
  * @param {string} entry
  * @param {string} dir
  * @param {import('./index.js').ServerlessConfig} config
+ * @param {((file: string) => boolean) | undefined} ignore
  */
-async function create_function_bundle(builder, entry, dir, config) {
+async function create_function_bundle(builder, entry, dir, config, ignore) {
 	fs.rmSync(dir, { force: true, recursive: true });
 
 	let base = entry;
 	while (base !== (base = path.dirname(base)));
 
+	const user_ignore = trace_ignore(base, ignore);
+
 	const traced = await nodeFileTrace([entry], {
 		base,
 		processCwd: process.cwd(),
 		// a wildcard directly under `base` would glob the entire filesystem
-		ignore: (file) => file.startsWith('**')
+		ignore: (file) => file.startsWith('**') || user_ignore?.(file) === true
 	});
 
 	/** @type {Map<string, string[]>} */

--- a/packages/adapter-vercel/utils.js
+++ b/packages/adapter-vercel/utils.js
@@ -121,13 +121,14 @@ function assert_is_valid_runtime(key) {
 
 /**
  * Wrap a user `ignore` predicate for `@vercel/nft`, which reports paths relative to `base`.
+ * The predicate receives the absolute path with `/` separators on every platform.
  * @param {string} base
  * @param {((file: string) => boolean) | undefined} ignore
  * @returns {((file: string) => boolean) | undefined}
  */
 export function trace_ignore(base, ignore) {
 	if (!ignore) return undefined;
-	return (file) => ignore(path.join(base, file));
+	return (file) => ignore(path.join(base, file).split(path.sep).join('/'));
 }
 
 /** @typedef {typeof valid_runtimes[number]} RuntimeKey */

--- a/packages/adapter-vercel/utils.js
+++ b/packages/adapter-vercel/utils.js
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import process from 'node:process';
 
 /**
@@ -116,6 +117,17 @@ function assert_is_valid_runtime(key) {
 			`Unsupported runtime: ${key}. Supported runtimes are: ${valid_runtimes.join(', ')}. See the Node.js Version section in your Vercel project settings for info on the currently supported versions.`
 		);
 	}
+}
+
+/**
+ * Wrap a user `ignore` predicate for `@vercel/nft`, which reports paths relative to `base`.
+ * @param {string} base
+ * @param {((file: string) => boolean) | undefined} ignore
+ * @returns {((file: string) => boolean) | undefined}
+ */
+export function trace_ignore(base, ignore) {
+	if (!ignore) return undefined;
+	return (file) => ignore(path.join(base, file));
 }
 
 /** @typedef {typeof valid_runtimes[number]} RuntimeKey */

--- a/packages/adapter-vercel/utils.spec.js
+++ b/packages/adapter-vercel/utils.spec.js
@@ -113,13 +113,11 @@ describe('trace_ignore', () => {
 
 		ignore?.(path.join('Users', 'jane', 'app', 'node_modules', 'vite', 'index.js'));
 
-		assert.deepEqual(seen, [
-			path.join(path.sep, 'Users', 'jane', 'app', 'node_modules', 'vite', 'index.js')
-		]);
+		assert.deepEqual(seen, ['/Users/jane/app/node_modules/vite/index.js']);
 	});
 
 	test('forwards the result of the predicate', () => {
-		const ignore = trace_ignore(path.sep, (file) => file.includes('node_modules'));
+		const ignore = trace_ignore(path.sep, (file) => file.includes('/node_modules/vite/'));
 
 		assert.equal(ignore?.(path.join('app', 'node_modules', 'vite', 'index.js')), true);
 		assert.equal(ignore?.(path.join('app', 'src', 'index.js')), false);

--- a/packages/adapter-vercel/utils.spec.js
+++ b/packages/adapter-vercel/utils.spec.js
@@ -1,5 +1,6 @@
 import { assert, test, describe } from 'vitest';
-import { parse_isr_expiration, pattern_to_src, resolve_runtime } from './utils.js';
+import path from 'node:path';
+import { parse_isr_expiration, pattern_to_src, resolve_runtime, trace_ignore } from './utils.js';
 
 // workaround so that TypeScript doesn't follow that import which makes it pick up that file and then error on missing import aliases
 const { parse_route_id } = await import(
@@ -93,5 +94,34 @@ describe('resolve_runtime', () => {
 
 	test('throws an error when resolving to an invalid runtime', () => {
 		assert.throws(() => resolve_runtime('node18.x', undefined), /Unsupported runtime: node18.x/);
+	});
+});
+
+describe('trace_ignore', () => {
+	test('returns undefined when no predicate is given', () => {
+		assert.equal(trace_ignore('/', undefined), undefined);
+	});
+
+	test('calls the predicate with the absolute path', () => {
+		/** @type {string[]} */
+		const seen = [];
+
+		const ignore = trace_ignore(path.sep, (file) => {
+			seen.push(file);
+			return false;
+		});
+
+		ignore?.(path.join('Users', 'jane', 'app', 'node_modules', 'vite', 'index.js'));
+
+		assert.deepEqual(seen, [
+			path.join(path.sep, 'Users', 'jane', 'app', 'node_modules', 'vite', 'index.js')
+		]);
+	});
+
+	test('forwards the result of the predicate', () => {
+		const ignore = trace_ignore(path.sep, (file) => file.includes('node_modules'));
+
+		assert.equal(ignore?.(path.join('app', 'node_modules', 'vite', 'index.js')), true);
+		assert.equal(ignore?.(path.join('app', 'src', 'index.js')), false);
 	});
 });


### PR DESCRIPTION
## Preface:

I don't believe there is an open issue for this. I skimmed myself and couldn't find anything. When I asked my agent to look the closest thing it found was #13764 and that is already closed. Happy to make a new one if you'd like to.

I also want to add that the code in this PR should be interpretted as a bug report primarily, with code difff itself intended to demonstrate the bug and the fix/patch we are using in our codebase. I am not confident this is the *right* fix, but from my limited understanding of svelte internals it seems acceptable and I couldn't come up with a better one myself in the time I spent understanding the problem and the relevant svelte code and vercel code.

Finally I want to be upfront about my AI usage:
* I investigated this using AI, but I have read all the changes and have done my best to understand the nature of the problem as well as the fix.
* I am copying small snippets of text from my investigation/testing session with my AI, but any AI text copied into this PR will be block quoted so its easy to for you to identify it as such.


## The issue itself

> adapter-vercel packages each serverless function with `@vercel/nft`,

this statically pulls in a lot of unnecessary content, anything its dependencies re-export at build time. This leads to bloated bundle sizes and longer build times.  The root cause of this is...

> nft is a file tracer, not a bundler, so it cannot tree-shake, and it includes anything a dependency statically re-exports or `createRequire()`s even when that code only runs at build time. Until now the only way to prune was to patch the adapter.

On my app itself, we are seeing an increase in bundle size from 146MB to 56MB. We pay this cost for each edge function our Vercel container packages into it (which I'm currently in the process of reducing, so the bloat here is slightly overstated for my app as of today)

Here's an the example case that lead me to this.

> A concrete case: `@sentry/sveltekit` <= 10.x re-exports its Vite plugin from the server entry, and `@sentry/bundler-plugins` reaches `vite` and `rollup` through `createRequire()` inside try/catch. nft resolves those statically, so every function bundle carried `vite`, `rollup`, `esbuild` and all of esbuild's platform binaries.