### PR TITLE
fix: respond to HEAD requests without a body

### DIFF
--- a/.changeset/quiet-heads-rest.md
+++ b/.changeset/quiet-heads-rest.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: respond to `HEAD` requests without a body

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -193,6 +193,12 @@ export class Server {
 			response.headers.set(REROUTED_URL_HEADER, request_state.rerouted_url);
 		}
 
+		// the HTTP layer discards HEAD response bodies, but nothing does when the server is called directly
+		if (request.method === 'HEAD' && response.body !== null) {
+			response.body.cancel().catch(noop);
+			return new Response(null, response);
+		}
+
 		return response;
 	}
 }


### PR DESCRIPTION
`Server.respond` returns `HEAD` responses with a body. The HTTP layer in front of it has always discarded that body, so nothing noticed until `Server.respond` was called directly.

It now cancels the body and returns a bodiless copy of the response, after the dev-only error lookup keyed on the original response object. Headers, including `content-length`, are kept.
