### PR TITLE
docs: expand Config types on vite reference page

### DIFF
--- a/documentation/docs/98-reference/15-@sveltejs-kit-vite.md
+++ b/documentation/docs/98-reference/15-@sveltejs-kit-vite.md
@@ -2,5 +2,10 @@
 title:  @sveltejs/kit/vite
 ---
 
-> MODULE: @sveltejs/kit/vite
+## sveltekit
+
+> EXPORT_SNIPPET: @sveltejs/kit/vite#sveltekit
+
+## Config
+
 > EXPANDED_TYPES: @sveltejs/kit/vite#Config

--- a/documentation/docs/98-reference/15-@sveltejs-kit-vite.md
+++ b/documentation/docs/98-reference/15-@sveltejs-kit-vite.md
@@ -3,3 +3,4 @@ title:  @sveltejs/kit/vite
 ---
 
 > MODULE: @sveltejs/kit/vite
+> EXPANDED_TYPES: @sveltejs/kit/vite#Config


### PR DESCRIPTION
closes #17028

2c4e73dee moved Config to @sveltejs/kit/vite and deleted the configuration page with it, so the docs lost the left-nav entry and the per-option On-this-page anchors (everything collapsed under a single #Config). This puts the page back, pointing EXPANDED_TYPES at @sveltejs/kit/vite#Config. The 31 existing (configuration#...) links in 18 files resolve again.

Heads up: svelte.dev sync-docs still looks for Config/KitConfig in @sveltejs/kit, so it'll need a companion tweak to read Config from @sveltejs/kit/vite (it throws before preprocess runs on version-3). Happy to follow up there.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the tests with \`pnpm test\` and lint the project with \`pnpm lint\` and \`pnpm check\`

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running \`pnpm changeset\` and following the prompts. Changesets that add features should be \`minor\` and those that fix bugs should be \`patch\`. Please prefix changeset messages with \`feat:\`, \`fix:\`, or \`chore:\`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.