### PR TITLE
fix: resolve every module entry point using kit.moduleExtensions

### DIFF
--- a/.changeset/hooks-module-extensions.md
+++ b/.changeset/hooks-module-extensions.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: resolve every module entry point using `kit.moduleExtensions`

--- a/packages/kit/src/core/config/index.js
+++ b/packages/kit/src/core/config/index.js
@@ -138,7 +138,7 @@ export function process_config(config, cwd) {
 	if (
 		config.csp?.directives?.['require-trusted-types-for']?.includes('script') &&
 		config.serviceWorker.register &&
-		resolve_entry(path.resolve(cwd, config.files.serviceWorker)) &&
+		resolve_entry(path.resolve(cwd, config.files.serviceWorker), config.moduleExtensions) &&
 		!config.csp?.directives?.['trusted-types']?.includes('sveltekit-trusted-url')
 	) {
 		throw new Error(

--- a/packages/kit/src/core/env.js
+++ b/packages/kit/src/core/env.js
@@ -23,7 +23,7 @@ import { posixify } from '../utils/os.js';
  * @returns {string | null}
  */
 export function resolve_env_entry(config, root) {
-	const entry = resolve_entry(path.resolve(root, config.files.src, 'env'));
+	const entry = resolve_entry(path.resolve(root, config.files.src, 'env'), config.moduleExtensions);
 	// posix, like the paths Vite hands to `hotUpdate`
 	return entry && posixify(entry);
 }

--- a/packages/kit/src/core/sync/create_manifest_data/index.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.js
@@ -91,9 +91,9 @@ export function create_assets(config) {
  * @param {string} cwd
  */
 function create_hooks(config, cwd) {
-	const client = resolve_entry(config.files.hooks.client);
-	const server = resolve_entry(config.files.hooks.server);
-	const universal = resolve_entry(config.files.hooks.universal);
+	const client = resolve_entry(config.files.hooks.client, config.moduleExtensions);
+	const server = resolve_entry(config.files.hooks.server, config.moduleExtensions);
+	const universal = resolve_entry(config.files.hooks.universal, config.moduleExtensions);
 
 	return {
 		client: client && posixify(path.relative(cwd, client)),
@@ -107,7 +107,7 @@ function create_hooks(config, cwd) {
  * @param {string} cwd
  */
 function resolve_params(config, cwd) {
-	const params_file = resolve_entry(config.files.params);
+	const params_file = resolve_entry(config.files.params, config.moduleExtensions);
 	return params_file ? posixify(path.relative(cwd, params_file)) : null;
 }
 

--- a/packages/kit/src/core/sync/utils.js
+++ b/packages/kit/src/core/sync/utils.js
@@ -74,9 +74,10 @@ export function dedent(strings, ...values) {
  * @param {string} original
  * @param {string} typo The common misspelling to check for
  * @param {string} description What was wrong with the filename
+ * @param {string[]} [extensions] the extensions a module may have
  */
-export function check_spelling(original, typo, description) {
-	const misspelled = resolve_entry(typo);
+export function check_spelling(original, typo, description, extensions) {
+	const misspelled = resolve_entry(typo, extensions);
 	if (!misspelled) return;
 
 	const corrected = path.basename(misspelled).replace(path.basename(typo), path.basename(original));

--- a/packages/kit/src/core/sync/write_app_types.js
+++ b/packages/kit/src/core/sync/write_app_types.js
@@ -116,7 +116,7 @@ function generate_app_types(manifest_data, config, dir) {
 		if (!type) {
 			const path_to_params = () => {
 				const params_file =
-					resolve_entry(config.files.params) ??
+					resolve_entry(config.files.params, config.moduleExtensions) ??
 					config.files.params.replace(/\.(js|ts)$/, '') + '.js';
 
 				return posixify(path.relative(dir, params_file));

--- a/packages/kit/src/core/sync/write_client_manifest.js
+++ b/packages/kit/src/core/sync/write_client_manifest.js
@@ -120,12 +120,17 @@ export function write_client_manifest(kit, manifest_data, output, root, metadata
 		if (root_layout) layouts_with_server_load.add(0);
 	}
 
-	const client_hooks_file = resolve_entry(kit.files.hooks.client);
-	const universal_hooks_file = resolve_entry(kit.files.hooks.universal);
+	const client_hooks_file = resolve_entry(kit.files.hooks.client, kit.moduleExtensions);
+	const universal_hooks_file = resolve_entry(kit.files.hooks.universal, kit.moduleExtensions);
 
 	if (!client_hooks_file) {
-		check_spelling('src/hooks.client', 'src/+hooks.client', 'Unexpected + prefix');
-		check_spelling('src/hooks.client', 'src/hook.client', 'Missing s suffix');
+		check_spelling(
+			'src/hooks.client',
+			'src/+hooks.client',
+			'Unexpected + prefix',
+			kit.moduleExtensions
+		);
+		check_spelling('src/hooks.client', 'src/hook.client', 'Missing s suffix', kit.moduleExtensions);
 	}
 
 	// Stringified version of

--- a/packages/kit/src/core/sync/write_server.js
+++ b/packages/kit/src/core/sync/write_server.js
@@ -79,17 +79,27 @@ export { set_assets, set_building, set_fix_stack_trace, set_manifest, set_preren
  * @param {string} root The project root directory
  */
 export function write_server(config, output, root) {
-	const server_hooks_file = resolve_entry(config.files.hooks.server);
-	const universal_hooks_file = resolve_entry(config.files.hooks.universal);
+	const server_hooks_file = resolve_entry(config.files.hooks.server, config.moduleExtensions);
+	const universal_hooks_file = resolve_entry(config.files.hooks.universal, config.moduleExtensions);
 
 	if (!server_hooks_file) {
-		check_spelling('src/hooks.server', 'src/+hooks.server', 'Unexpected + prefix');
-		check_spelling('src/hooks.server', 'src/hook.server', 'Missing s suffix');
+		check_spelling(
+			'src/hooks.server',
+			'src/+hooks.server',
+			'Unexpected + prefix',
+			config.moduleExtensions
+		);
+		check_spelling(
+			'src/hooks.server',
+			'src/hook.server',
+			'Missing s suffix',
+			config.moduleExtensions
+		);
 	}
 
 	if (!universal_hooks_file) {
-		check_spelling('src/hooks', 'src/+hooks', 'Unexpected + prefix');
-		check_spelling('src/hooks', 'src/hook', 'Missing s suffix');
+		check_spelling('src/hooks', 'src/+hooks', 'Unexpected + prefix', config.moduleExtensions);
+		check_spelling('src/hooks', 'src/hook', 'Missing s suffix', config.moduleExtensions);
 	}
 
 	/** @param {string} file */

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -603,7 +603,8 @@ function replace_ext_with_js(file_path) {
 function generate_params_type(params, outdir, config) {
 	const path_to_params = () => {
 		const params_file =
-			resolve_entry(config.files.params) ?? config.files.params.replace(/\.(js|ts)$/, '') + '.js';
+			resolve_entry(config.files.params, config.moduleExtensions) ??
+			config.files.params.replace(/\.(js|ts)$/, '') + '.js';
 
 		return posixify(path.relative(outdir, params_file));
 	};

--- a/packages/kit/src/exports/vite/build/index.js
+++ b/packages/kit/src/exports/vite/build/index.js
@@ -183,7 +183,8 @@ export function plugin_compile(
 
 				// ...and the server instrumentation file
 				const server_instrumentation = resolve_entry(
-					path.join(kit.files.src, 'instrumentation.server')
+					path.join(kit.files.src, 'instrumentation.server'),
+					kit.moduleExtensions
 				);
 				if (server_instrumentation) {
 					if (kit.adapter && !kit.adapter.supports?.instrumentation?.()) {

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -184,7 +184,7 @@ export async function dev(
 		return (error.stack = prelude + lines.join('\n'));
 	}
 
-	const params_file = resolve_entry(svelte_config.files.params);
+	const params_file = resolve_entry(svelte_config.files.params, svelte_config.moduleExtensions);
 
 	/**
 	 * @param {string} event
@@ -343,7 +343,10 @@ export async function dev(
 				}
 
 				if (decoded === svelte_config.paths.base + '/service-worker.js') {
-					const resolved = resolve_entry(svelte_config.files.serviceWorker);
+					const resolved = resolve_entry(
+						svelte_config.files.serviceWorker,
+						svelte_config.moduleExtensions
+					);
 
 					if (resolved) {
 						res.writeHead(200, {
@@ -361,7 +364,8 @@ export async function dev(
 				// resolve the instrumentation file per request so that changes to it
 				// are picked up on new requests
 				const resolved_instrumentation = resolve_entry(
-					path.join(svelte_config.files.src, 'instrumentation.server')
+					path.join(svelte_config.files.src, 'instrumentation.server'),
+					svelte_config.moduleExtensions
 				);
 
 				if (resolved_instrumentation) {

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -339,7 +339,7 @@ function kit({ svelte_config }) {
 				global_name = get_global_name(kit.version.name, !is_build);
 				kit_global = `globalThis.${global_name}`;
 
-				service_worker_entry_file = resolve_entry(kit.files.serviceWorker);
+				service_worker_entry_file = resolve_entry(kit.files.serviceWorker, kit.moduleExtensions);
 				service_worker_entry_file &&= posixify(service_worker_entry_file);
 
 				normalized_aliases = get_import_aliases(root, vite.normalizePath.bind(vite));
@@ -376,7 +376,7 @@ function kit({ svelte_config }) {
 
 				// We can only add directories to the allow list, so we find out
 				// if there's a client hooks file and pass its directory
-				const client_hooks = resolve_entry(kit.files.hooks.client);
+				const client_hooks = resolve_entry(kit.files.hooks.client, kit.moduleExtensions);
 				if (client_hooks) allow.add(path.dirname(client_hooks));
 
 				// dev and preview config can be shared

--- a/packages/kit/src/exports/vite/public.d.ts
+++ b/packages/kit/src/exports/vite/public.d.ts
@@ -230,7 +230,7 @@ export interface Config extends VitePluginSvelteOptions {
 	 */
 	inlineStyleThreshold?: number;
 	/**
-	 * An array of file extensions that SvelteKit will treat as modules. Files with extensions that match neither `config.extensions` nor `config.moduleExtensions` will be ignored by the router.
+	 * An array of file extensions that SvelteKit will treat as modules. Files with extensions that match neither `config.extensions` nor `config.moduleExtensions` will be ignored.
 	 * @default [".js", ".ts"]
 	 */
 	moduleExtensions?: string[];

--- a/packages/kit/src/utils/filesystem.js
+++ b/packages/kit/src/utils/filesystem.js
@@ -119,9 +119,10 @@ export function relative_path(from, to) {
 /**
  * Given an entry point like [cwd]/src/hooks, returns a filename like [cwd]/src/hooks.js or [cwd]/src/hooks/index.js
  * @param {string} entry
+ * @param {string[]} [extensions] defaults to `['.js', '.ts']`; pass `config.kit.moduleExtensions` for entries that are modules
  * @returns {string | null}
  */
-export function resolve_entry(entry) {
+export function resolve_entry(entry, extensions = ['.js', '.ts']) {
 	if (fs.existsSync(entry)) {
 		const stats = fs.statSync(entry);
 		if (stats.isFile()) {
@@ -129,8 +130,8 @@ export function resolve_entry(entry) {
 		}
 
 		const index = path.join(entry, 'index');
-		if (fs.existsSync(index + '.js') || fs.existsSync(index + '.ts')) {
-			return resolve_entry(index);
+		if (extensions.some((extension) => fs.existsSync(index + extension))) {
+			return resolve_entry(index, extensions);
 		}
 	}
 
@@ -140,7 +141,8 @@ export function resolve_entry(entry) {
 		const base = path.basename(entry);
 		const files = fs.readdirSync(dir);
 		const found = files.find((file) => {
-			return file.replace(/\.(js|ts)$/, '') === base && fs.statSync(path.join(dir, file)).isFile();
+			const matches = file === base || extensions.some((extension) => file === base + extension);
+			return matches && fs.statSync(path.join(dir, file)).isFile();
 		});
 
 		if (found) return path.join(dir, found);

--- a/packages/kit/src/utils/filesystem.spec.js
+++ b/packages/kit/src/utils/filesystem.spec.js
@@ -114,6 +114,28 @@ test('resolves entries that have an extension', () => {
 	expect(resolve_entry(join(source_dir, 'hooks.js'))).toBe(join(source_dir, 'hooks.js'));
 });
 
+test('resolves entries with an extension from moduleExtensions', () => {
+	write('hooks.server.py', '');
+
+	expect(resolve_entry(join(source_dir, 'hooks.server'), ['.js', '.ts', '.py'])).toBe(
+		join(source_dir, 'hooks.server.py')
+	);
+});
+
+test('ignores extensions that are not listed', () => {
+	write('hooks.server.py', '');
+
+	expect(resolve_entry(join(source_dir, 'hooks.server'))).null;
+});
+
+test('resolves index files with an extension from moduleExtensions', () => {
+	write(join('params', 'index.py'), '');
+
+	expect(resolve_entry(source_dir + '/params', ['.js', '.ts', '.py'])).toBe(
+		join(source_dir, 'params', 'index.py')
+	);
+});
+
 test('resolves universal hooks file when hooks folder exists', () => {
 	write(join('hooks', 'not-index.js'), '');
 	write('hooks.js', '');

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1816,7 +1816,7 @@ declare module '@sveltejs/kit/vite' {
 		 */
 		inlineStyleThreshold?: number;
 		/**
-		 * An array of file extensions that SvelteKit will treat as modules. Files with extensions that match neither `config.extensions` nor `config.moduleExtensions` will be ignored by the router.
+		 * An array of file extensions that SvelteKit will treat as modules. Files with extensions that match neither `config.extensions` nor `config.moduleExtensions` will be ignored.
 		 * @default [".js", ".ts"]
 		 */
 		moduleExtensions?: string[];


### PR DESCRIPTION
`resolve_entry` matched `/\.(js|ts)$/`, so `kit.moduleExtensions` was honoured by the router but nowhere else. A project that compiles another language to JavaScript could have route modules in that language, yet had to keep `src/hooks.server.js` as a shim re-exporting from the real file — and the same went for the param matchers, the service worker, the instrumentation file and `src/env`.

`resolve_entry` now takes the list of extensions to accept, defaulting to `['.js', '.ts']` so nothing changes for anyone who does not set `moduleExtensions`, and every entry point that is a module passes `config.moduleExtensions`. `check_spelling` takes them too, so a misspelled `hooks.sever.py` is caught the same way `hooks.sever.js` is.
