### PR TITLE
fix: copy `_redirects` when deploying edge functions

### DIFF
--- a/.changeset/legal-boxes-eat.md
+++ b/.changeset/legal-boxes-eat.md
@@ -1,0 +1,6 @@
+---
+"@sveltejs/adapter-netlify": patch
+---
+
+fix: copy `_redirects` when deploying edge function
+  

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -85,16 +85,16 @@ export default function ({ split = false, edge = edge_set_in_env_var } = {}) {
 			builder.writeClient(publish_dir);
 			builder.writePrerendered(publish_dir);
 
-			// Copy user's custom _headers file if it exists
+			// Copy user's _headers file if it exists
 			if (existsSync('_headers')) {
+				builder.log.minor('Copying user custom headers...');
 				builder.copy('_headers', join(publish, '_headers'));
 			}
 
-			// Copy user's custom _redirects file if it exists
+			// Copy user's _redirects file if it exists
 			if (existsSync('_redirects')) {
 				builder.log.minor('Copying user redirects...');
-				const redirects_file = join(publish, '_redirects');
-				builder.copy('_redirects', redirects_file);
+				builder.copy('_redirects', join(publish, '_redirects'));
 			}
 
 			builder.log.minor('Writing Netlify config...');

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -90,6 +90,13 @@ export default function ({ split = false, edge = edge_set_in_env_var } = {}) {
 				builder.copy('_headers', join(publish, '_headers'));
 			}
 
+			// Copy user's custom _redirects file if it exists
+			if (existsSync('_redirects')) {
+				builder.log.minor('Copying user redirects...');
+				const redirects_file = join(publish, '_redirects');
+				builder.copy('_redirects', redirects_file);
+			}
+
 			builder.log.minor('Writing Netlify config...');
 			write_frameworks_config({ builder });
 
@@ -100,7 +107,7 @@ export default function ({ split = false, edge = edge_set_in_env_var } = {}) {
 
 				await generate_edge_functions({ builder });
 			} else {
-				generate_serverless_functions({ builder, split, publish });
+				generate_serverless_functions({ builder, split });
 			}
 		},
 
@@ -114,20 +121,15 @@ export default function ({ split = false, edge = edge_set_in_env_var } = {}) {
 /**
  * @param { object } params
  * @param {import('@sveltejs/kit').Builder} params.builder
- * @param { string } params.publish
  * @param { boolean } params.split
  */
-function generate_serverless_functions({ builder, publish, split }) {
+function generate_serverless_functions({ builder, split }) {
 	// https://docs.netlify.com/build/frameworks/frameworks-api/#netlifyv1functions
 	mkdirSync(netlify_framework_serverless_path, { recursive: true });
 
 	builder.writeServer('.netlify/v1/server');
 
-	const replace = {
-		'0SERVER': './server/index.js' // digit prefix prevents CJS build from using this as a variable name, which would also get replaced
-	};
-
-	builder.copy(files, '.netlify/v1', { replace, filter: (file) => !file.endsWith('edge.js') });
+	builder.copy(`${files}/serverless.js`, '.netlify/v1/serverless.js');
 
 	builder.log.minor('Generating serverless functions...');
 
@@ -205,13 +207,6 @@ function generate_serverless_functions({ builder, publish, split }) {
 			name: `${FUNCTION_PREFIX}render`,
 			type: 'singular'
 		});
-	}
-
-	// Copy user's custom _redirects file if it exists
-	if (existsSync('_redirects')) {
-		builder.log.minor('Copying user redirects...');
-		const redirects_file = join(publish, '_redirects');
-		builder.copy('_redirects', redirects_file);
 	}
 }
 

--- a/packages/adapter-netlify/test/apps/edge/build.test.js
+++ b/packages/adapter-netlify/test/apps/edge/build.test.js
@@ -6,3 +6,11 @@ test('_headers are copied to publish directory', () => {
 	const headers = fs.readFileSync(path.resolve(import.meta.dirname, './build/_headers'), 'utf-8');
 	expect(headers).toContain('X-Custom-Header: test-value');
 });
+
+test('_redirects are copied to publish directory', () => {
+	const redirects = fs.readFileSync(
+		path.resolve(import.meta.dirname, './build/_redirects'),
+		'utf-8'
+	);
+	expect(redirects).toContain('/redirect-me /greeting/redirected 301');
+});

--- a/packages/adapter-netlify/test/apps/edge/test/test.js
+++ b/packages/adapter-netlify/test/apps/edge/test/test.js
@@ -29,6 +29,14 @@ test('read from $app/server works', async ({ request }) => {
 	expect(await response.text()).toBe(content);
 });
 
+test('_redirects are copied to publish directory', () => {
+	const redirects = fs.readFileSync(
+		path.resolve(import.meta.dirname, '../build/_redirects'),
+		'utf-8'
+	);
+	expect(redirects).toContain('/redirect-me /greeting/redirected 301');
+});
+
 test('_headers are copied to publish directory', () => {
 	const headers = fs.readFileSync(path.resolve(import.meta.dirname, '../build/_headers'), 'utf-8');
 	expect(headers).toContain('X-Custom-Header: test-value');


### PR DESCRIPTION
Previously, `_redirects` was only copied when deploying serverless functions. This PR fixes it so it's also copied for edge builds

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
