### PR TITLE
chore: move build tests out of platform tests

### DIFF
--- a/packages/adapter-netlify/package.json
+++ b/packages/adapter-netlify/package.json
@@ -38,7 +38,7 @@
 		"lint": "oxfmt --check .",
 		"format": "oxfmt --write .",
 		"test:unit": "vitest run",
-		"test:build": "pnpm -r --workspace-concurrency 1 --filter=\"./test/**\" build",
+		"test:build": "pnpm -r --workspace-concurrency 1 --filter=\"./test/**\" test:build",
 		"test": "pnpm test:unit && pnpm test:build"
 	},
 	"dependencies": {

--- a/packages/adapter-netlify/test/apps/basic/build.test.js
+++ b/packages/adapter-netlify/test/apps/basic/build.test.js
@@ -1,0 +1,16 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { test, expect } from 'vitest';
+
+test('_redirects are copied to publish directory', () => {
+	const redirects = fs.readFileSync(
+		path.resolve(import.meta.dirname, './build/_redirects'),
+		'utf-8'
+	);
+	expect(redirects).toContain('/redirect-me /greeting/redirected 301');
+});
+
+test('_headers are copied to publish directory', () => {
+	const headers = fs.readFileSync(path.resolve(import.meta.dirname, './build/_headers'), 'utf-8');
+	expect(headers).toContain('X-Custom-Header: test-value');
+});

--- a/packages/adapter-netlify/test/apps/basic/package.json
+++ b/packages/adapter-netlify/test/apps/basic/package.json
@@ -6,13 +6,15 @@
 		"dev": "vite dev",
 		"build": "vite build",
 		"preview": "vite preview",
+		"test:build": "pnpm build && vitest run build.test.js",
 		"test:platform": "playwright test"
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:^",
 		"@sveltejs/vite-plugin-svelte": "catalog:",
 		"svelte": "catalog:",
-		"vite": "catalog:"
+		"vite": "catalog:",
+		"vitest": "catalog:"
 	},
 	"type": "module"
 }

--- a/packages/adapter-netlify/test/apps/basic/test/test.js
+++ b/packages/adapter-netlify/test/apps/basic/test/test.js
@@ -22,16 +22,3 @@ test('read from $app/server works', async ({ request }) => {
 	const response = await request.get('/read');
 	expect(await response.text()).toBe(content);
 });
-
-test('_redirects are copied to publish directory', () => {
-	const redirects = fs.readFileSync(
-		path.resolve(import.meta.dirname, '../build/_redirects'),
-		'utf-8'
-	);
-	expect(redirects).toContain('/redirect-me /greeting/redirected 301');
-});
-
-test('_headers are copied to publish directory', () => {
-	const headers = fs.readFileSync(path.resolve(import.meta.dirname, '../build/_headers'), 'utf-8');
-	expect(headers).toContain('X-Custom-Header: test-value');
-});

--- a/packages/adapter-netlify/test/apps/edge/build.test.js
+++ b/packages/adapter-netlify/test/apps/edge/build.test.js
@@ -1,0 +1,8 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { test, expect } from 'vitest';
+
+test('_headers are copied to publish directory', () => {
+	const headers = fs.readFileSync(path.resolve(import.meta.dirname, './build/_headers'), 'utf-8');
+	expect(headers).toContain('X-Custom-Header: test-value');
+});

--- a/packages/adapter-netlify/test/apps/edge/package.json
+++ b/packages/adapter-netlify/test/apps/edge/package.json
@@ -6,13 +6,15 @@
 		"dev": "vite dev",
 		"build": "vite build",
 		"preview": "vite preview",
+		"test:build": "pnpm build && vitest run build.test.js",
 		"test:platform": "playwright test"
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:^",
 		"@sveltejs/vite-plugin-svelte": "catalog:",
 		"svelte": "catalog:",
-		"vite": "catalog:"
+		"vite": "catalog:",
+		"vitest": "catalog:"
 	},
 	"type": "module"
 }

--- a/packages/adapter-netlify/test/apps/edge/test/test.js
+++ b/packages/adapter-netlify/test/apps/edge/test/test.js
@@ -29,11 +29,6 @@ test('read from $app/server works', async ({ request }) => {
 	expect(await response.text()).toBe(content);
 });
 
-test('_headers are copied to publish directory', () => {
-	const headers = fs.readFileSync(path.resolve(import.meta.dirname, '../build/_headers'), 'utf-8');
-	expect(headers).toContain('X-Custom-Header: test-value');
-});
-
 test('treeshakes component from the server bundle if SSR is turned off', async ({ page }) => {
 	await page.goto('/treeshake-server');
 	const component_text = 'this should never appear in the server bundle';

--- a/packages/adapter-netlify/test/apps/split/build.test.js
+++ b/packages/adapter-netlify/test/apps/split/build.test.js
@@ -9,3 +9,17 @@ test('_redirects are copied to publish directory', () => {
 	);
 	expect(redirects).toContain('/redirect-me /greeting/redirected 301');
 });
+
+test('split generates multiple function files', () => {
+	const functions_dir = path.resolve(import.meta.dirname, './.netlify/v1/functions');
+	const files = fs.readdirSync(functions_dir).filter((f) => f.startsWith('sveltekit-'));
+	expect(files.length).toBeGreaterThan(1);
+
+	const optional_route = fs.readFileSync(
+		path.join(functions_dir, 'sveltekit-collection-_param1-article.mjs'),
+		'utf-8'
+	);
+	expect(optional_route).toContain(
+		'path: ["/collection/:param1?/article", "/collection/:param1?/article/__data.json"]'
+	);
+});

--- a/packages/adapter-netlify/test/apps/split/build.test.js
+++ b/packages/adapter-netlify/test/apps/split/build.test.js
@@ -1,0 +1,11 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { test, expect } from 'vitest';
+
+test('_redirects are copied to publish directory', () => {
+	const redirects = fs.readFileSync(
+		path.resolve(import.meta.dirname, './build/_redirects'),
+		'utf-8'
+	);
+	expect(redirects).toContain('/redirect-me /greeting/redirected 301');
+});

--- a/packages/adapter-netlify/test/apps/split/package.json
+++ b/packages/adapter-netlify/test/apps/split/package.json
@@ -6,13 +6,15 @@
 		"dev": "vite dev",
 		"build": "vite build",
 		"preview": "vite preview",
+		"test:build": "pnpm build && vitest run build.test.js",
 		"test:platform": "playwright test"
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:^",
 		"@sveltejs/vite-plugin-svelte": "catalog:",
 		"svelte": "catalog:",
-		"vite": "catalog:"
+		"vite": "catalog:",
+		"vitest": "catalog:"
 	},
 	"type": "module"
 }

--- a/packages/adapter-netlify/test/apps/split/test/test.js
+++ b/packages/adapter-netlify/test/apps/split/test/test.js
@@ -45,14 +45,6 @@ test('split generates multiple function files', () => {
 	);
 });
 
-test('_redirects are copied to publish directory', () => {
-	const redirects = fs.readFileSync(
-		path.resolve(import.meta.dirname, '../build/_redirects'),
-		'utf-8'
-	);
-	expect(redirects).toContain('/redirect-me /greeting/redirected 301');
-});
-
 test('reroute works', async ({ page }) => {
 	await page.goto('/reroute');
 	await expect(page.locator('p')).toContainText('/reroute');

--- a/packages/adapter-netlify/test/apps/split/test/test.js
+++ b/packages/adapter-netlify/test/apps/split/test/test.js
@@ -31,20 +31,6 @@ test('client-side fetch for query remote function data', async ({ page }) => {
 	await expect(page.locator('p')).toHaveText('a: 1');
 });
 
-test('split generates multiple function files', () => {
-	const functions_dir = path.resolve(import.meta.dirname, '../.netlify/v1/functions');
-	const files = fs.readdirSync(functions_dir).filter((f) => f.startsWith('sveltekit-'));
-	expect(files.length).toBeGreaterThan(1);
-
-	const optional_route = fs.readFileSync(
-		path.join(functions_dir, 'sveltekit-collection-_param1-article.mjs'),
-		'utf-8'
-	);
-	expect(optional_route).toContain(
-		'path: ["/collection/:param1?/article", "/collection/:param1?/article/__data.json"]'
-	);
-});
-
 test('reroute works', async ({ page }) => {
 	await page.goto('/reroute');
 	await expect(page.locator('p')).toContainText('/reroute');

--- a/packages/adapter-netlify/vitest.config.js
+++ b/packages/adapter-netlify/vitest.config.js
@@ -2,4 +2,8 @@
 
 import { defineConfig } from 'vitest/config';
 
-export default defineConfig({});
+export default defineConfig({
+	test: {
+		include: ['*.spec.{js,ts}'],
+	}
+});

--- a/packages/adapter-netlify/vitest.config.js
+++ b/packages/adapter-netlify/vitest.config.js
@@ -4,6 +4,6 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
-		include: ['*.spec.{js,ts}'],
+		include: ['*.spec.{js,ts}']
 	}
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -398,6 +398,9 @@ importers:
       vite:
         specifier: 'catalog:'
         version: 8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(jiti@2.4.2)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.10)(jsdom@30.0.1)(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(jiti@2.4.2)(yaml@2.9.0))
 
   packages/adapter-netlify/test/apps/edge:
     devDependencies:
@@ -413,6 +416,9 @@ importers:
       vite:
         specifier: 'catalog:'
         version: 8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(jiti@2.4.2)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.10)(jsdom@30.0.1)(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(jiti@2.4.2)(yaml@2.9.0))
 
   packages/adapter-netlify/test/apps/instrumentation:
     devDependencies:
@@ -443,6 +449,9 @@ importers:
       vite:
         specifier: 'catalog:'
         version: 8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(jiti@2.4.2)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.10)(jsdom@30.0.1)(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(jiti@2.4.2)(yaml@2.9.0))
 
   packages/adapter-node:
     dependencies:


### PR DESCRIPTION
This PR moves some Netlify tests which can be run without deploying the app. They only inspect the build output