### PR TITLE
test: reproduce relative dev proxy failure

### DIFF
--- a/packages/kit/test/apps/options/test/paths.test.js
+++ b/packages/kit/test/apps/options/test/paths.test.js
@@ -125,8 +125,8 @@ test.describe('relative paths behind a proxy', () => {
 
 		await page.goto(`${proxy_path}/path-base/base/`);
 
-		await page.click('button');
-		expect(await page.innerHTML('h2')).toBe('button has been clicked 1 time');
+		await page.locator('button').click();
+		await expect(page.locator('h2')).toHaveText('button has been clicked 1 time');
 	});
 });
 

--- a/packages/kit/test/apps/options/test/paths.test.js
+++ b/packages/kit/test/apps/options/test/paths.test.js
@@ -118,11 +118,8 @@ test.describe('relative paths', () => {
 			if (url.pathname.startsWith(`${proxy_path}/`)) {
 				url.pathname = url.pathname.slice(proxy_path.length);
 				await route.fulfill({ response: await route.fetch({ url: url.href }) });
-			} else if (url.pathname.includes('/node_modules/') || url.pathname.includes('/@fs/')) {
-				// module requests escaping the proxy prefix — abort, hydration never completes
-				await route.abort();
 			} else {
-				await route.continue();
+				await route.abort();
 			}
 		});
 

--- a/packages/kit/test/apps/options/test/paths.test.js
+++ b/packages/kit/test/apps/options/test/paths.test.js
@@ -109,6 +109,9 @@ test.describe('relative paths behind a proxy', () => {
 	test('loads javascript behind an unknown prefix', async ({ page }) => {
 		const proxy_path = '/proxy';
 
+		// simulate a reverse proxy that mounts the app at `/proxy`: strip the prefix and
+		// forward to the dev server; requests that escape the prefix (e.g. module URLs
+		// generated without it) are aborted so the test hangs instead of silently passing
 		await page.route('**/*', async (route) => {
 			const url = new URL(route.request().url());
 

--- a/packages/kit/test/apps/options/test/paths.test.js
+++ b/packages/kit/test/apps/options/test/paths.test.js
@@ -103,6 +103,43 @@ test.describe('base path', () => {
 	});
 });
 
+test.describe('relative paths behind a proxy', () => {
+	test.skip(({ javaScriptEnabled }) => !process.env.DEV || !javaScriptEnabled);
+
+	test('loads javascript behind an unknown prefix', async ({ page }) => {
+		const proxy_path = '/proxy';
+		let report_bypass = () => {};
+		const bypassed = new Promise((resolve) => {
+			report_bypass = () => resolve('bypassed');
+		});
+
+		await page.route('**/*', async (route) => {
+			const url = new URL(route.request().url());
+
+			if (url.pathname.startsWith(`${proxy_path}/`)) {
+				url.pathname = url.pathname.slice(proxy_path.length);
+				await route.fulfill({ response: await route.fetch({ url: url.href }) });
+			} else if (url.pathname.includes('/node_modules/') || url.pathname.includes('/@fs/')) {
+				report_bypass();
+				await route.abort();
+			} else {
+				await route.continue();
+			}
+		});
+
+		await page.goto(`${proxy_path}/path-base/base/`, { wait_for_started: false });
+
+		const hydrated = page
+			.locator('body.started')
+			.waitFor()
+			.then(() => 'hydrated');
+		expect(await Promise.race([hydrated, bypassed])).toBe('hydrated');
+
+		await page.click('button');
+		expect(await page.innerHTML('h2')).toBe('button has been clicked 1 time');
+	});
+});
+
 test.describe('assets path', () => {
 	test.skip(!process.env.PATHS_ASSETS);
 

--- a/packages/kit/test/apps/options/test/paths.test.js
+++ b/packages/kit/test/apps/options/test/paths.test.js
@@ -104,7 +104,9 @@ test.describe('base path', () => {
 });
 
 test.describe('relative paths', () => {
-	test.skip(!!process.env.PATHS_ASSETS);
+	test.skip(
+		({ javaScriptEnabled }) => !process.env.DEV || !javaScriptEnabled || !!process.env.PATHS_ASSETS
+	);
 
 	test('works when proxied', async ({ page }) => {
 		const proxy_path = '/proxy';

--- a/packages/kit/test/apps/options/test/paths.test.js
+++ b/packages/kit/test/apps/options/test/paths.test.js
@@ -112,16 +112,21 @@ test.describe('relative paths', () => {
 		const proxy_path = '/proxy';
 
 		// simulate a reverse proxy that mounts the app at `/proxy`: strip the prefix and
-		// forward to the dev server; requests that escape the prefix (e.g. module URLs
-		// generated without it) are aborted so the test hangs instead of silently passing
+		// forward to the dev server. Abort initial client module requests that escape the
+		// prefix; imported module URLs are rewritten by Vite and are outside this regression.
 		await page.route('**/*', async (route) => {
 			const url = new URL(route.request().url());
 
 			if (url.pathname.startsWith(`${proxy_path}/`)) {
 				url.pathname = url.pathname.slice(proxy_path.length);
 				await route.fulfill({ response: await route.fetch({ url: url.href }) });
-			} else {
+			} else if (
+				(url.pathname.includes('/node_modules/') || url.pathname.includes('/@fs/')) &&
+				route.request().headers().referer?.endsWith(`${proxy_path}/path-base/base/`)
+			) {
 				await route.abort();
+			} else {
+				await route.continue();
 			}
 		});
 

--- a/packages/kit/test/apps/options/test/paths.test.js
+++ b/packages/kit/test/apps/options/test/paths.test.js
@@ -104,9 +104,9 @@ test.describe('base path', () => {
 });
 
 test.describe('relative paths', () => {
-	test.skip(({ javaScriptEnabled }) => !process.env.DEV || !javaScriptEnabled);
+	test.skip(!!process.env.PATHS_ASSETS);
 
-	test('loads javascript behind an unknown prefix', async ({ page }) => {
+	test('works when proxied', async ({ page }) => {
 		const proxy_path = '/proxy';
 
 		// simulate a reverse proxy that mounts the app at `/proxy`: strip the prefix and

--- a/packages/kit/test/apps/options/test/paths.test.js
+++ b/packages/kit/test/apps/options/test/paths.test.js
@@ -103,7 +103,7 @@ test.describe('base path', () => {
 	});
 });
 
-test.describe('relative paths behind a proxy', () => {
+test.describe('relative paths', () => {
 	test.skip(({ javaScriptEnabled }) => !process.env.DEV || !javaScriptEnabled);
 
 	test('loads javascript behind an unknown prefix', async ({ page }) => {

--- a/packages/kit/test/apps/options/test/paths.test.js
+++ b/packages/kit/test/apps/options/test/paths.test.js
@@ -108,10 +108,6 @@ test.describe('relative paths behind a proxy', () => {
 
 	test('loads javascript behind an unknown prefix', async ({ page }) => {
 		const proxy_path = '/proxy';
-		let report_bypass = () => {};
-		const bypassed = new Promise((resolve) => {
-			report_bypass = () => resolve('bypassed');
-		});
 
 		await page.route('**/*', async (route) => {
 			const url = new URL(route.request().url());
@@ -120,7 +116,7 @@ test.describe('relative paths behind a proxy', () => {
 				url.pathname = url.pathname.slice(proxy_path.length);
 				await route.fulfill({ response: await route.fetch({ url: url.href }) });
 			} else if (url.pathname.includes('/node_modules/') || url.pathname.includes('/@fs/')) {
-				report_bypass();
+				// module requests escaping the proxy prefix — abort, hydration never completes
 				await route.abort();
 			} else {
 				await route.continue();
@@ -128,12 +124,7 @@ test.describe('relative paths behind a proxy', () => {
 		});
 
 		await page.goto(`${proxy_path}/path-base/base/`, { wait_for_started: false });
-
-		const hydrated = page
-			.locator('body.started')
-			.waitFor()
-			.then(() => 'hydrated');
-		expect(await Promise.race([hydrated, bypassed])).toBe('hydrated');
+		await page.locator('body.started').waitFor();
 
 		await page.click('button');
 		expect(await page.innerHTML('h2')).toBe('button has been clicked 1 time');

--- a/packages/kit/test/apps/options/test/paths.test.js
+++ b/packages/kit/test/apps/options/test/paths.test.js
@@ -123,8 +123,7 @@ test.describe('relative paths behind a proxy', () => {
 			}
 		});
 
-		await page.goto(`${proxy_path}/path-base/base/`, { wait_for_started: false });
-		await page.locator('body.started').waitFor();
+		await page.goto(`${proxy_path}/path-base/base/`);
 
 		await page.click('button');
 		expect(await page.innerHTML('h2')).toBe('button has been clicked 1 time');


### PR DESCRIPTION
related to #10828

Adds a regression test when `kit.paths.relative` is enabled and the app is mounted at `/proxy`.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets

- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.