### PR TITLE
chore: run split edge platform tests

### DIFF
--- a/.github/actions/netlify-deploy/action.yml
+++ b/.github/actions/netlify-deploy/action.yml
@@ -11,6 +11,9 @@ inputs:
   netlify-token:
     description: 'Netlify authentication token'
     required: true
+  edge:
+    description: 'Used to enable edge functions for the split test app'
+    default: false
 outputs:
   deployment-url:
     description: 'URL of the deployed preview'
@@ -28,7 +31,7 @@ runs:
 
     - name: Install Netlify CLI
       shell: bash
-      run: pnpm i -g netlify-cli
+      run: pnpm i -g netlify-cli --allow-build=esbuild --allow-build=netlify-cli
 
     - name: Deploy to Netlify
       id: deploy
@@ -37,6 +40,24 @@ runs:
         TEST_APP_DIR: ${{ inputs.test-app-dir }}
         NETLIFY_AUTH_TOKEN: ${{ inputs.netlify-token }}
         NETLIFY_PROJECT_ID: ${{ inputs.netlify-project-id }}
+        EDGE: ${{ inputs.edge }}
       run: |
-        TEST_APP_NAME=$(cat "$TEST_APP_DIR/package.json" | jq -r '.name')
-        echo "url=$(netlify deploy --json --filter="$TEST_APP_NAME" --dir="$TEST_APP_DIR/build" --functions=".netlify/v1/functions" --auth="$NETLIFY_AUTH_TOKEN" --site="$NETLIFY_PROJECT_ID" | jq -r '.deploy_url')" >> "$GITHUB_OUTPUT"
+        set -euo pipefail
+
+        TEST_APP_NAME=$(jq -r '.name' "$TEST_APP_DIR/package.json")
+
+        if deploy_json=$(netlify deploy \
+          --json \
+          --filter="$TEST_APP_NAME" \
+          --dir="$TEST_APP_DIR/build" \
+          --functions=".netlify/v1/functions" \
+          --auth="$NETLIFY_AUTH_TOKEN" \
+          --site="$NETLIFY_PROJECT_ID"
+        ); then
+          deploy_url=$(jq -er '.deploy_url' <<< "$deploy_json")
+          echo "url=$deploy_url" >> "$GITHUB_OUTPUT"
+        else
+          echo "::error::Netlify deployment failed"
+          echo "$deploy_json" >&2
+          exit 1
+        fi

--- a/.github/actions/netlify-deploy/action.yml
+++ b/.github/actions/netlify-deploy/action.yml
@@ -40,7 +40,6 @@ runs:
         TEST_APP_DIR: ${{ inputs.test-app-dir }}
         NETLIFY_AUTH_TOKEN: ${{ inputs.netlify-token }}
         NETLIFY_PROJECT_ID: ${{ inputs.netlify-project-id }}
-        EDGE: ${{ inputs.edge }}
       run: |
         set -euo pipefail
 

--- a/.github/actions/netlify-deploy/action.yml
+++ b/.github/actions/netlify-deploy/action.yml
@@ -48,6 +48,7 @@ runs:
 
         if deploy_json=$(netlify deploy \
           --json \
+          --verbose \
           --filter="$TEST_APP_NAME" \
           --dir="$TEST_APP_DIR/build" \
           --functions=".netlify/v1/functions" \

--- a/.github/actions/netlify-deploy/action.yml
+++ b/.github/actions/netlify-deploy/action.yml
@@ -11,9 +11,6 @@ inputs:
   netlify-token:
     description: 'Netlify authentication token'
     required: true
-  edge:
-    description: 'Used to enable edge functions for the split test app'
-    default: false
 outputs:
   deployment-url:
     description: 'URL of the deployed preview'

--- a/.github/workflows/platform-tests-netlify.yml
+++ b/.github/workflows/platform-tests-netlify.yml
@@ -93,3 +93,29 @@ jobs:
         with:
           test-app-dir: ${{ env.TEST_APP_DIR }}
           deployment-url: ${{ steps.deploy.outputs.deployment-url }}
+
+  test-split-edge:
+    if: github.repository == 'sveltejs/kit'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: '@sveltejs/adapter-netlify platform tests'
+    env:
+      TEST_APP_DIR: packages/adapter-netlify/test/apps/split
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.sha || github.sha }}
+          persist-credentials: false
+
+      - uses: ./.github/actions/netlify-deploy
+        id: deploy
+        with:
+          test-app-dir: ${{ env.TEST_APP_DIR }}
+          netlify-project-id: ${{ secrets.NETLIFY_PROJECT_ID_SPLIT }}
+          netlify-token: ${{ secrets.NETLIFY_TOKEN }}
+          edge: true
+
+      - uses: ./.github/actions/platform-test
+        with:
+          test-app-dir: ${{ env.TEST_APP_DIR }}
+          deployment-url: ${{ steps.deploy.outputs.deployment-url }}

--- a/.github/workflows/platform-tests-netlify.yml
+++ b/.github/workflows/platform-tests-netlify.yml
@@ -111,7 +111,6 @@ jobs:
       - uses: ./.github/actions/netlify-deploy
         id: deploy
         with:
-        with:
           test-app-dir: ${{ env.TEST_APP_DIR }}
           netlify-project-id: ${{ secrets.NETLIFY_PROJECT_ID_SPLIT }}
           netlify-token: ${{ secrets.NETLIFY_TOKEN }}

--- a/.github/workflows/platform-tests-netlify.yml
+++ b/.github/workflows/platform-tests-netlify.yml
@@ -111,10 +111,10 @@ jobs:
       - uses: ./.github/actions/netlify-deploy
         id: deploy
         with:
+        with:
           test-app-dir: ${{ env.TEST_APP_DIR }}
           netlify-project-id: ${{ secrets.NETLIFY_PROJECT_ID_SPLIT }}
           netlify-token: ${{ secrets.NETLIFY_TOKEN }}
-          edge: true
 
       - uses: ./.github/actions/platform-test
         with:

--- a/.github/workflows/platform-tests-netlify.yml
+++ b/.github/workflows/platform-tests-netlify.yml
@@ -101,6 +101,7 @@ jobs:
     environment: '@sveltejs/adapter-netlify platform tests'
     env:
       TEST_APP_DIR: packages/adapter-netlify/test/apps/split
+      EDGE: 'true'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
Applies the GitHub Actions changes from #17045 to ensure split edge functions are deployed and exercised by Netlify platform tests.