### PR TITLE
fix: resolve all client paths through one base/assets rule

### DIFF
--- a/.changeset/relative-route-resolution.md
+++ b/.changeset/relative-route-resolution.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: respect `paths.relative` for server-side route resolution imports

--- a/packages/kit/src/exports/vite/dev/generate_manifest.js
+++ b/packages/kit/src/exports/vite/dev/generate_manifest.js
@@ -47,7 +47,7 @@ export function generate_manifest(
 					? undefined
 					: manifest_data.nodes.map((node, i) => {
 							if (node.component || node.universal) {
-								return `${svelte_config.paths.base}${to_fs(svelte_config.outDir)}/generated/dev/client/nodes/${i}.js`;
+								return `${to_fs(svelte_config.outDir)}/generated/dev/client/nodes/${i}.js`;
 							}
 						}),
 			// `css` is not necessary in dev, as the JS file from `nodes` will reference the CSS file

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -10,9 +10,13 @@ import { serialize_data } from './serialize_data.js';
 import { s } from '../../../utils/misc.js';
 import { Csp } from './csp.js';
 import { uneval_action_response } from './actions.js';
-import { SVELTE_KIT_ASSETS } from '../../../constants.js';
 import { SCHEME } from '../../../utils/url.js';
-import { create_server_routing_response, generate_route_object } from './server_routing.js';
+import {
+	client_path,
+	create_server_routing_response,
+	generate_route_object,
+	resolve_paths
+} from './server_routing.js';
 import {
 	add_data_suffix,
 	add_resolution_suffix,
@@ -121,16 +125,10 @@ export async function render_response({
 			const pathname = event.isDataRequest
 				? add_data_suffix(event.url.pathname)
 				: event.url.pathname;
-			const segments = pathname.slice(paths.base.length).split('/').slice(2);
-
-			base = segments.map(() => '..').join('/') || '.';
+			({ base, assets } = resolve_paths(pathname));
 
 			// resolve e.g. '../..' against current location, then remove trailing slash
 			base_expression = `new URL(${s(base)}, location).pathname.slice(0, -1)`;
-
-			if (!paths.assets || (paths.assets[0] === '/' && paths.assets !== SVELTE_KIT_ASSETS)) {
-				assets = base;
-			}
 		} else if (__SVELTEKIT_HASH_ROUTING__) {
 			// we have to assume that we're in the right place
 			base_expression = "new URL('.', location).pathname.slice(0, -1)";
@@ -279,15 +277,7 @@ export async function render_response({
 	let body = rendered.body;
 
 	/** @param {string} path */
-	const prefixed = (path) => {
-		if (path.startsWith('/')) {
-			// Vite makes the start script available through the base path and without it.
-			// We load it via the base path in order to support remote IDE environments which proxy
-			// all URLs under the base path during development.
-			return relative ? `${base}/${path.slice(1)}` : paths.base + path;
-		}
-		return `${assets}/${path}`;
-	};
+	const prefixed = (path) => client_path(path, { base, assets });
 
 	const style = client?.inline
 		? client.inline?.style

--- a/packages/kit/src/runtime/server/page/server_routing.js
+++ b/packages/kit/src/runtime/server/page/server_routing.js
@@ -176,6 +176,7 @@ export function create_server_routing_response(route, params, url, client) {
  */
 function create_css_import(route, url, client) {
 	const { errors, layouts, leaf } = route;
+	const paths = resolve_paths(url.pathname);
 
 	let css = '';
 
@@ -183,11 +184,11 @@ function create_css_import(route, url, client) {
 		if (typeof node !== 'number') continue;
 		const node_css = client.css?.[node];
 		for (const css_path of node_css ?? []) {
-			css += `'${assets || base}/${css_path}',`;
+			css += `'${client_path(css_path, paths)}',`;
 		}
 	}
 
 	if (!css) return '';
 
-	return `${create_client_import(client.start, resolve_paths(url.pathname))}.then(x => x.load_css([${css}]));\n`;
+	return `${create_client_import(client.start, paths)}.then(x => x.load_css([${css}]));\n`;
 }

--- a/packages/kit/src/runtime/server/page/server_routing.js
+++ b/packages/kit/src/runtime/server/page/server_routing.js
@@ -4,7 +4,7 @@ import { relative } from '$app/paths/internal/server';
 import { text } from '@sveltejs/kit';
 import { s } from '../../../utils/misc.js';
 import { find_route } from '../../../utils/routing.js';
-import { get_relative_path } from '../../utils.js';
+import { SVELTE_KIT_ASSETS } from '../../../constants.js';
 import { manifest } from '../internal.js';
 
 /**
@@ -15,10 +15,11 @@ import { manifest } from '../internal.js';
  */
 export function generate_route_object(route, url, client) {
 	const { errors, layouts, leaf } = route;
+	const paths = resolve_paths(url.pathname);
 
 	const nodes = [...errors, ...layouts.map((l) => l?.[1]), leaf[1]]
 		.filter((n) => typeof n === 'number')
-		.map((n) => `'${n}': () => ${create_client_import(client.nodes?.[n], url)}`)
+		.map((n) => `'${n}': () => ${create_client_import(client.nodes?.[n], paths)}`)
 		.join(',\n\t\t');
 
 	// stringified version of
@@ -33,26 +34,38 @@ export function generate_route_object(route, url, client) {
 }
 
 /**
- * @param {string | undefined} import_path
- * @param {URL} url
+ * The `base` and `assets` prefixes for client paths in a document at `pathname`. With
+ * `paths.relative`, they're relative to that document so the app also works when served
+ * from IPFS, the internet archive, or behind a proxy.
+ * @param {string} pathname
  */
-function create_client_import(import_path, url) {
-	if (!import_path) return 'Promise.resolve({})';
+export function resolve_paths(pathname) {
+	if (!relative) return { base, assets };
 
-	// During PROD, they're root-relative
-	if (assets !== '' && import_path[0] !== '/') {
-		return `import('${assets}/${import_path}')`;
-	}
+	const segments = pathname.slice(base.length).split('/').slice(2);
+	const relative_base = segments.map(() => '..').join('/') || '.';
 
-	// During DEV, Vite will make the paths absolute (e.g. /@fs/...)
-	const absolute = import_path[0] === '/' ? import_path : `${base}/${import_path}`;
-	if (!relative) return `import('${absolute}')`;
+	return {
+		base: relative_base,
+		// same-origin assets are relative too, except for the placeholder used by `vite preview`
+		assets: !assets || (assets[0] === '/' && assets !== SVELTE_KIT_ASSETS) ? relative_base : assets
+	};
+}
 
-	// Else we make them relative to the server-side route resolution request
-	// to support IPFS, the internet archive, etc.
-	let path = get_relative_path(url.pathname, absolute);
-	if (path[0] !== '.') path = `./${path}`;
-	return `import('${path}')`;
+/**
+ * @param {string} path a root-absolute dev path (e.g. `/@fs/...`) or a prod path relative to `assets`
+ * @param {ReturnType<typeof resolve_paths>} paths
+ */
+export function client_path(path, { base, assets }) {
+	return path[0] === '/' ? base + path : `${assets}/${path}`;
+}
+
+/**
+ * @param {string | undefined} import_path
+ * @param {ReturnType<typeof resolve_paths>} paths
+ */
+function create_client_import(import_path, paths) {
+	return import_path ? `import('${client_path(import_path, paths)}')` : 'Promise.resolve({})';
 }
 
 /**
@@ -176,5 +189,5 @@ function create_css_import(route, url, client) {
 
 	if (!css) return '';
 
-	return `${create_client_import(client.start, url)}.then(x => x.load_css([${css}]));\n`;
+	return `${create_client_import(client.start, resolve_paths(url.pathname))}.then(x => x.load_css([${css}]));\n`;
 }

--- a/packages/kit/src/runtime/utils.js
+++ b/packages/kit/src/runtime/utils.js
@@ -45,27 +45,6 @@ export function stream_text(head, chunks) {
 export const text_decoder = new TextDecoder();
 
 /**
- * Like node's path.relative, but without using node
- * @param {string} from
- * @param {string} to
- */
-export function get_relative_path(from, to) {
-	const from_parts = from.split(/[/\\]/);
-	const to_parts = to.split(/[/\\]/);
-	from_parts.pop(); // get dirname
-
-	while (from_parts[0] === to_parts[0]) {
-		from_parts.shift();
-		to_parts.shift();
-	}
-
-	let i = from_parts.length;
-	while (i--) from_parts[i] = '..';
-
-	return from_parts.concat(to_parts).join('/');
-}
-
-/**
  * @param {Uint8Array} bytes
  * @returns {string}
  */

--- a/packages/kit/test/apps/options/test/paths.test.js
+++ b/packages/kit/test/apps/options/test/paths.test.js
@@ -105,15 +105,17 @@ test.describe('base path', () => {
 
 test.describe('relative paths', () => {
 	test.skip(
-		({ javaScriptEnabled }) => !process.env.DEV || !javaScriptEnabled || !!process.env.PATHS_ASSETS
+		({ javaScriptEnabled }) =>
+			!javaScriptEnabled || !!process.env.PATHS_ASSETS || process.env.PATHS_RELATIVE === 'false'
 	);
 
 	test('works when proxied', async ({ page }) => {
 		const proxy_path = '/proxy';
 
 		// simulate a reverse proxy that mounts the app at `/proxy`: strip the prefix and
-		// forward to the dev server. Abort initial client module requests that escape the
-		// prefix; imported module URLs are rewritten by Vite and are outside this regression.
+		// forward to the server, and abort requests that escape the prefix. In dev, only the
+		// initial client module requests; imported module URLs are rewritten by Vite and
+		// are outside this regression.
 		await page.route('**/*', async (route) => {
 			const url = new URL(route.request().url());
 
@@ -121,8 +123,9 @@ test.describe('relative paths', () => {
 				url.pathname = url.pathname.slice(proxy_path.length);
 				await route.fulfill({ response: await route.fetch({ url: url.href }) });
 			} else if (
-				(url.pathname.includes('/node_modules/') || url.pathname.includes('/@fs/')) &&
-				route.request().headers().referer?.endsWith(`${proxy_path}/path-base/base/`)
+				!process.env.DEV ||
+				((url.pathname.includes('/node_modules/') || url.pathname.includes('/@fs/')) &&
+					route.request().headers().referer?.endsWith(`${proxy_path}/path-base/base/`))
 			) {
 				await route.abort();
 			} else {


### PR DESCRIPTION
fixes #10828 for server-side route resolution too

render.js and server_routing.js each had their own rule for turning manifest paths into URLs, and the server routing one never applied `paths.relative` once a base path was set, so a built app with `router.resolution: 'server'` breaks behind a prefix-stripping proxy. Both now share `resolve_paths` and `client_path`, and the proxy test from #17051 runs in build mode too.
