### PR TITLE
feat(adapter-auto): detect Lizard platform

### DIFF
--- a/.changeset/lizard-adapter-detect.md
+++ b/.changeset/lizard-adapter-detect.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-auto': minor
+---
+
+feat: detect the Lizard platform (`LIZARD_BUILD` env var) and use `@sveltejs/adapter-node`

--- a/packages/adapter-auto/adapters.js
+++ b/packages/adapter-auto/adapters.js
@@ -45,5 +45,11 @@ export const adapters = [
 		module: '@sveltejs/adapter-node',
 		// TODO replace with a stable version
 		version: 'next'
+	},
+	{
+		name: 'Lizard',
+		test: () => !!process.env.LIZARD_BUILD,
+		module: '@sveltejs/adapter-node',
+		version: '6'
 	}
 ];


### PR DESCRIPTION
## Summary

Adds Lizard (https://lizard.build) to `@sveltejs/adapter-auto`'s platform list, following the same pattern as the existing Google Cloud Run / Render entries — both resolve to `@sveltejs/adapter-node` since Lizard is a generic Node.js container host with no platform-specific adapter of its own.

Lizard's build pipeline now sets `LIZARD_BUILD=1` in the build environment for every SvelteKit app it builds (see the platform-side change: https://github.com/lizard-build/dragonlabs-platform/commit/5dbc0c31), so `adapter-auto` can detect it and auto-install a compatible `adapter-node` config — the same zero-config experience Vercel/Netlify/CF Pages users already get, instead of requiring a manual swap to an explicit `adapter-node` + custom Dockerfile.

## Changes

- `packages/adapter-auto/adapters.js`: new `Lizard` entry, `version: '6'` to match the current `packages/adapter-node` major (mirrors the Google Cloud Run entry).
- Changeset added.

## Test plan

- [x] `adapter versions are up to date` (existing `test/adapters.spec.js`) passes — `version: '6'` matches `packages/adapter-node`'s current major.
- [ ] Would appreciate a maintainer's steer on whether `LIZARD_BUILD` is an acceptable env var name/convention before I chase down anything further on our end.

Draft for visibility/discussion first — happy to adjust naming or add anything else you'd want (docs, additional tests) before marking ready for review.