### PR TITLE
fix: abort superseded preloads

### DIFF
--- a/.changeset/plenty-pears-tap.md
+++ b/.changeset/plenty-pears-tap.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: abort in-flight preload requests when a hover/tap preload is superseded by another

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -259,11 +259,15 @@ export const prerender_responses = {};
 /** @type {Array<((url: URL) => boolean)>} */
 const invalidated = [];
 
-/** @type {{id: string, token: {}, promise: Promise<import('./types.js').NavigationResult>, fork: Promise<import('svelte').Fork | null> | null} | null} */
+/** @type {{id: string, token: {}, controller: AbortController | null, promise: Promise<import('./types.js').NavigationResult>, fork: Promise<import('svelte').Fork | null> | null} | null} */
 let load_cache = null;
 
 function discard_load_cache() {
-	void load_cache?.fork?.then((f) => f?.discard());
+	if (load_cache?.controller && preload_tokens.has(load_cache.token)) {
+		load_cache.controller.abort();
+	}
+
+	void load_cache?.fork?.then((f) => f?.discard(), noop);
 	load_cache = null;
 	current_a = { element: undefined, href: undefined };
 }
@@ -770,8 +774,11 @@ export async function _goto(url, options = {}, redirect_count = 0, nav_token = {
 	}
 }
 
-/** @param {import('./types.js').NavigationIntent} intent */
-async function _preload_data(intent) {
+/**
+ * @param {import('./types.js').NavigationIntent} intent
+ * @param {boolean} [cancellable] whether the preload should be aborted when another one supersedes it
+ */
+async function _preload_data(intent, cancellable) {
 	// Reuse the existing pending preload if it's for the same navigation.
 	// Prevents an edge case where same preload is triggered multiple times,
 	// then a later one is becoming the real navigation and the preload tokens
@@ -781,20 +788,26 @@ async function _preload_data(intent) {
 
 		const preload = {};
 		preload_tokens.add(preload);
+
+		const controller = cancellable ? new AbortController() : null;
+
 		load_cache = {
 			id: intent.id,
 			token: preload,
-			promise: load_route({ ...intent, preload }).finally(() => {
+			controller,
+			promise: load_route({ ...intent, preload, signal: controller?.signal }).finally(() => {
 				preload_tokens.delete(preload);
 			}),
 			fork: null
 		};
 
-		load_cache.promise.catch(discard_load_cache);
+		const lc = load_cache;
+
+		lc.promise.catch(() => {
+			if (lc === load_cache) discard_load_cache();
+		});
 
 		if (__SVELTEKIT_FORK_PRELOADS__) {
-			const lc = load_cache;
-
 			lc.fork = lc.promise.then((result) => {
 				// if load_cache was discarded before load_cache.promise could
 				// resolve, bail rather than creating an orphan fork
@@ -1098,10 +1111,11 @@ async function get_navigation_result_from_branch({
  *   params: Record<string, string>;
  *   route: { id: string | null };
  * 	 server_data_node: import('./types.js').DataNode | null;
+ *   signal?: AbortSignal;
  * }} options
  * @returns {Promise<import('./types.js').BranchNode>}
  */
-async function load_node({ loader, parent, url, params, route, server_data_node }) {
+async function load_node({ loader, parent, url, params, route, server_data_node, signal }) {
 	/** @type {Record<string, any> | null} */
 	let data = null;
 
@@ -1212,7 +1226,11 @@ async function load_node({ loader, parent, url, params, route, server_data_node 
 					};
 				}
 
-				const { resolved, promise } = resolve_fetch_url(resource, init, url);
+				const { resolved, promise } = resolve_fetch_url(
+					resource,
+					signal && !init?.signal ? { ...init, signal } : init,
+					url
+				);
 
 				if (is_tracking) {
 					depends(resolved.href);
@@ -1360,14 +1378,23 @@ function diff_search_params(old_url, new_url) {
  */
 /**
  * @overload
- * @param {import('./types.js').NavigationIntent & { preload: {} }} intent
+ * @param {import('./types.js').NavigationIntent & { preload: {}; signal?: AbortSignal }} intent
  * @returns {Promise<import('./types.js').NavigationResult>}
  */
 /**
- * @param {import('./types.js').NavigationIntent & { preload?: {}; action_result?: ActionResult }} intent
+ * @param {import('./types.js').NavigationIntent & { preload?: {}; action_result?: ActionResult; signal?: AbortSignal }} intent
  * @returns {Promise<import('./types.js').NavigationResult | undefined>}
  */
-async function load_route({ id, invalidating, url, params, route, preload, action_result }) {
+async function load_route({
+	id,
+	invalidating,
+	url,
+	params,
+	route,
+	preload,
+	action_result,
+	signal
+}) {
 	if (!action_result && load_cache?.id === id) {
 		// the preload becomes the real navigation
 		preload_tokens.delete(load_cache.token);
@@ -1423,8 +1450,10 @@ async function load_route({ id, invalidating, url, params, route, preload, actio
 
 		if (invalid_server_nodes.some(Boolean)) {
 			try {
-				server_data = await load_data(url, invalid_server_nodes);
+				server_data = await load_data(url, invalid_server_nodes, signal);
 			} catch (error) {
+				if (signal?.aborted) throw error;
+
 				const handled_error = await handle_error(error, { url, params, route: { id } });
 
 				if (preload && preload_tokens.has(preload)) {
@@ -1482,6 +1511,7 @@ async function load_route({ id, invalidating, url, params, route, preload, actio
 			url,
 			params,
 			route,
+			signal,
 			parent: async () => {
 				const data = {};
 				for (let j = 0; j < i; j += 1) {
@@ -1509,6 +1539,8 @@ async function load_route({ id, invalidating, url, params, route, preload, actio
 			try {
 				branch.push(await branch_promises[i]);
 			} catch (err) {
+				if (signal?.aborted) throw err;
+
 				if (err instanceof Redirect) {
 					return {
 						type: 'redirect',
@@ -2431,7 +2463,9 @@ function setup_preload() {
 			if (!intent) return;
 
 			if (DEV) {
-				void _preload_data(intent).catch((error) => {
+				void _preload_data(intent, true).catch((error) => {
+					if (error?.name === 'AbortError') return;
+
 					console.warn(
 						`Preloading data for ${intent.url.pathname} failed with the following error: ${error.message}\n` +
 							'If this error is transient, you can ignore it. Otherwise, consider disabling preloading for this route. ' +
@@ -2440,7 +2474,7 @@ function setup_preload() {
 					);
 				});
 			} else {
-				void _preload_data(intent);
+				void _preload_data(intent, true);
 			}
 		} else if (priority <= options.preload_code) {
 			current_a = { element: a, href: a.href };
@@ -3622,9 +3656,10 @@ async function _hydrate(
 /**
  * @param {URL} url
  * @param {boolean[]} invalid
+ * @param {AbortSignal} [signal]
  * @returns {Promise<import('types').ServerNodesResponse | import('types').ServerRedirectNode>}
  */
-async function load_data(url, invalid) {
+async function load_data(url, invalid, signal) {
 	const data_url = new URL(url);
 	data_url.pathname = add_data_suffix(url.pathname);
 	if (url.pathname.endsWith('/')) {
@@ -3637,7 +3672,7 @@ async function load_data(url, invalid) {
 
 	// use window.fetch directly to allow using a 3rd party-patched fetch implementation
 	const fetcher = DEV ? dev_fetch : window.fetch;
-	const res = await fetcher(data_url.href, {});
+	const res = await fetcher(data_url.href, { signal });
 
 	// detect new deployments from the response header
 	notify_version(res.headers.get('x-sveltekit-version'));

--- a/packages/kit/test/apps/basics/test/playwright/client.test.js
+++ b/packages/kit/test/apps/basics/test/playwright/client.test.js
@@ -1149,6 +1149,26 @@ test.describe('data-sveltekit attributes', () => {
 		await expect(page.getByText('slow navigation', { exact: true })).toBeVisible();
 	});
 
+	test('data-sveltekit-preload-data aborts a superseded preload', async ({ page }) => {
+		/** @type {string[]} */
+		const failed = [];
+		page.on('requestfailed', (req) => {
+			if (req.url().includes('__data.json')) {
+				failed.push(req.url());
+			}
+		});
+
+		await page.goto('/data-sveltekit/preload-data/offline');
+
+		await page.locator('#slow-navigation').hover();
+		await page.waitForTimeout(100); // wait for the slow preload to start
+
+		await page.locator('#one').hover();
+		await page.waitForTimeout(100); // wait for the superseding preload to start
+
+		expect(failed.some((url) => url.includes('/slow-navigation/__data.json'))).toBe(true);
+	});
+
 	test('data-sveltekit-preload repeatedly works on the same anchor element', async ({
 		page,
 		clicknav


### PR DESCRIPTION
<!-- Add the related issue number here. Repeat this line for each additional issue it closes -->

## Context

Hello guys,

I'm not sure if this is a specific edge case, but I have an Svelte app with many links where some preloads can take 1s+.

When hovering over multiple links, the previous preloads keep running even after they've been superseded. When the user clicks a link, this can make the navigation wait for those previous preloads to finish.

During the investigation, I noticed that preloads don't have an `AbortController`, so I couldn't find a way to cancel these requests.

## Proposed fix

This PR aborts in-flight requests when a speculative preload is superseded by a newer one.

The signal is propagated through `load_route` to both the `__data.json` request and the `fetch` available to `load` functions.

Once a preload is consumed by a real navigation, it is no longer aborted, so user-initiated navigation remains unaffected.

I also fixed two related issues around rejected preload promises/unhandled rejections that became apparent while implementing this.

I'm not sure whether this is a broader problem or just an edge case from my application, so **feel free to reject this PR if the behavior doesn't make sense for SvelteKit's preload model.**


---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

`data-sveltekit-preload-data aborts a superseded preload` was verified to fail on `version-3` and pass with this change. The full `test-basics` Playwright suite passes (693 passed, 0 failed), as do `oxfmt --check`, `eslint`, and `tsc` on `packages/kit` (the pre-existing `src/exports/vite/index.js` TS2321 is unrelated and also present on `version-3`).

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
