### PR TITLE
fix: externalise `@opentelemetry/api` during build

### DIFF
--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -448,7 +448,18 @@ function kit({ svelte_config }) {
 							// import, but it works with vite-node's externalization logic, which
 							// uses basic concatenation)
 							'@sveltejs/kit/src/runtime'
-						]
+						],
+						// Any CommonJS dependencies of Kit (of which there are currently none) must always be externalized.
+						// Without this, the tests will still pass but `pnpm dev` will fail in projects that link `@sveltejs/kit`.
+
+						// `@opentelemetry/api` must be externalized so that `instrumentation.server.js` and the
+						// SvelteKit runtime share a single instance of the module (the global tracer/propagation
+						// is set on that instance — two bundled copies would mean instrumentation hooks are
+						// invisible to the runtime). Externalizing also prevents the bundler from colocating
+						// `@opentelemetry/api` into a shared chunk that also contains application modules, which
+						// would cause those modules to be evaluated before `Server.init()` sets env vars — see
+						// https://github.com/sveltejs/kit/issues/16288
+						external: ['@opentelemetry/api']
 					},
 					publicDir: kit.files.assets
 				};
@@ -515,20 +526,6 @@ function kit({ svelte_config }) {
 						__SVELTEKIT_HAS_SERVER_LOAD__: 'true',
 						__SVELTEKIT_HAS_UNIVERSAL_LOAD__: 'true'
 					};
-
-					// Any CommonJS dependencies of Kit (of which there are currently none) must always be externalized.
-					// Without this, the tests will still pass but `pnpm dev` will fail in projects that link `@sveltejs/kit`.
-					//
-					// `@opentelemetry/api` must be externalized so that `instrumentation.server.js` and the
-					// SvelteKit runtime share a single instance of the module (the global tracer/propagation
-					// is set on that instance — two bundled copies would mean instrumentation hooks are
-					// invisible to the runtime). Externalizing also prevents the bundler from colocating
-					// `@opentelemetry/api` into a shared chunk that also contains application modules, which
-					// would cause those modules to be evaluated before `Server.init()` sets env vars — see
-					// https://github.com/sveltejs/kit/issues/16288
-					/** @type {NonNullable<UserConfig['ssr']>} */ (new_config.ssr).external = [
-						'@opentelemetry/api'
-					];
 
 					// we avoid setting base to paths.assets in dev so that we get the
 					// trailing slash redirect to paths.base if it is set


### PR DESCRIPTION
I think this was accidentally added such that it only affected `vite dev`. This PR moves it out of the dev-only conditional block.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets

- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
