### PR TITLE
chore: add CodSpeed benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,43 @@
+name: Benchmarks
+
+on:
+  push:
+    branches:
+      - version-3
+    paths-ignore: &paths_ignore
+      - '.changeset/**'
+      - '.githooks/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/copilot-instructions.md'
+      - '.github/FUNDING.yml'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
+      - 'documentation/**'
+      - 'packages/*/CHANGELOG*.md'
+      - 'packages/kit/src/types/synthetic/**'
+      - 'AGENTS.md'
+      - 'CLAUDE.md'
+      - 'CONTRIBUTING.md'
+      - 'FUNDING.json'
+      - 'LICENSE'
+      - 'README.md'
+      - '.coderabbit.yml'
+  pull_request:
+    paths-ignore: *paths_ignore
+  workflow_dispatch:
+
+jobs:
+  benchmark:
+    runs-on: codspeed-macro
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/node-setup
+      - name: Run benchmarks
+        uses: CodSpeedHQ/action@373d6868929f444bc08d901fd0eb0ad52a8875ea # v5.2.1
+        with:
+          mode: walltime
+          run: pnpm bench

--- a/benchmark/fixtures/kit/package.json
+++ b/benchmark/fixtures/kit/package.json
@@ -1,0 +1,16 @@
+{
+	"name": "benchmark-fixture-kit",
+	"private": true,
+	"version": "0.0.0",
+	"type": "module",
+	"scripts": {
+		"build": "vite build",
+		"preview": "node build/index.js"
+	},
+	"devDependencies": {
+		"@sveltejs/adapter-node": "workspace:*",
+		"@sveltejs/kit": "workspace:*",
+		"svelte": "catalog:",
+		"vite": "catalog:"
+	}
+}

--- a/benchmark/fixtures/kit/src/app.html
+++ b/benchmark/fixtures/kit/src/app.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		%sveltekit.head%
+	</head>
+	<body>
+		<div>%sveltekit.body%</div>
+	</body>
+</html>

--- a/benchmark/fixtures/kit/src/hooks.server.js
+++ b/benchmark/fixtures/kit/src/hooks.server.js
@@ -1,0 +1,22 @@
+/** @type {import('@sveltejs/kit/hooks').Handle} */
+export async function handle({ event, resolve }) {
+	const cookie = event.cookies.get('benchmark') ?? 'seed';
+
+	if (!event.cookies.get('benchmark')) {
+		event.cookies.set('benchmark', cookie, {
+			httpOnly: true,
+			path: '/',
+			sameSite: 'lax'
+		});
+	}
+
+	event.locals.benchmark = {
+		cohort: 'seed',
+		cookie,
+		path: event.url.pathname
+	};
+
+	const response = await resolve(event);
+	response.headers.set('x-benchmark-cohort', event.locals.benchmark.cohort);
+	return response;
+}

--- a/benchmark/fixtures/kit/src/routes/+layout.svelte
+++ b/benchmark/fixtures/kit/src/routes/+layout.svelte
@@ -1,0 +1,48 @@
+<script>
+	const { children } = $props();
+</script>
+
+<svelte:head>
+	<title>SvelteKit benchmark</title>
+	<meta name="description" content="Deterministic fixture for SvelteKit benchmark seeds" />
+</svelte:head>
+
+<div class="shell">
+	<header class="hero">
+		<h1>SvelteKit benchmark</h1>
+		<p>Small, deterministic seed app for sync, build, and SSR measurements.</p>
+	</header>
+
+	<main>
+		{@render children?.()}
+	</main>
+</div>
+
+<style>
+	:global(body) {
+		margin: 0;
+		font-family: system-ui, sans-serif;
+		background: #f8fafc;
+		color: #0f172a;
+	}
+
+	.shell {
+		max-width: 72rem;
+		margin: 0 auto;
+		padding: 2rem;
+	}
+
+	.hero {
+		margin-bottom: 2rem;
+	}
+
+	h1,
+	p {
+		margin: 0;
+	}
+
+	.hero p {
+		margin-top: 0.5rem;
+		color: #475569;
+	}
+</style>

--- a/benchmark/fixtures/kit/src/routes/+page.svelte
+++ b/benchmark/fixtures/kit/src/routes/+page.svelte
@@ -1,0 +1,32 @@
+<script>
+	let { data } = $props();
+</script>
+
+<section>
+	<h2>Route seed</h2>
+	<p>
+		Current route:
+		<code>{data.route ?? 'home'}</code>
+	</p>
+	<p>This page is duplicated by the benchmark harness to create representative routes.</p>
+	<p>
+		<a href="/ssr">Open the data-heavy SSR route</a>
+	</p>
+</section>
+
+<style>
+	section {
+		padding: 1.5rem;
+		background: white;
+		border-radius: 0.75rem;
+		box-shadow: 0 1px 2px rgb(15 23 42 / 0.08);
+	}
+
+	h2 {
+		margin-top: 0;
+	}
+
+	code {
+		font-family: ui-monospace, monospace;
+	}
+</style>

--- a/benchmark/fixtures/kit/src/routes/ssr/+page.server.js
+++ b/benchmark/fixtures/kit/src/routes/ssr/+page.server.js
@@ -1,0 +1,29 @@
+const groups = ['alpha', 'beta', 'gamma', 'delta'];
+
+export function load({ locals }) {
+	const items = Array.from({ length: 200 }, (_, index) => ({
+		id: index,
+		slug: `benchmark-item-${index}`,
+		group: groups[index % groups.length],
+		stats: {
+			rank: index + 1,
+			score: (index * 13) % 97,
+			featured: index % 9 === 0
+		},
+		tags: ['benchmark', `group-${index % groups.length}`]
+	}));
+
+	return {
+		request: locals.benchmark ?? {
+			cohort: 'seed',
+			cookie: 'seed',
+			path: '/ssr'
+		},
+		summary: {
+			total: items.length,
+			first: items[0].slug,
+			last: items[items.length - 1].slug
+		},
+		items
+	};
+}

--- a/benchmark/fixtures/kit/src/routes/ssr/+page.svelte
+++ b/benchmark/fixtures/kit/src/routes/ssr/+page.svelte
@@ -1,0 +1,61 @@
+<script>
+	let { data } = $props();
+
+	let featured = $derived.by(() => data.items.filter((item) => item.stats.featured).length);
+</script>
+
+<section>
+	<h2>Data-heavy SSR route</h2>
+	<p>
+		Hook cohort:
+		<code>{data.request.cohort}</code>
+		· cookie:
+		<code>{data.request.cookie}</code>
+	</p>
+	<p>
+		Items: {data.summary.total}
+		· featured: {featured}
+		· last:
+		<code>{data.summary.last}</code>
+	</p>
+
+	<ol>
+		{#each data.items as item (item.id)}
+			<li>
+				<strong>{item.slug}</strong>
+				<span>{item.group}</span>
+				<span>{item.stats.rank}/{item.stats.score}</span>
+			</li>
+		{/each}
+	</ol>
+</section>
+
+<style>
+	section {
+		padding: 1.5rem;
+		background: white;
+		border-radius: 0.75rem;
+		box-shadow: 0 1px 2px rgb(15 23 42 / 0.08);
+	}
+
+	ol {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+		gap: 0.75rem;
+		padding: 0;
+		list-style: none;
+	}
+
+	li {
+		display: grid;
+		gap: 0.25rem;
+		padding: 0.75rem;
+		border: 1px solid #e2e8f0;
+		border-radius: 0.5rem;
+	}
+
+	code,
+	strong {
+		font-family: ui-monospace, monospace;
+	}
+</style>

--- a/benchmark/fixtures/kit/tsconfig.json
+++ b/benchmark/fixtures/kit/tsconfig.json
@@ -1,0 +1,5 @@
+{
+	"extends": "$app/tsconfig",
+	"include": ["src", "*"],
+	"exclude": []
+}

--- a/benchmark/fixtures/kit/vite.config.js
+++ b/benchmark/fixtures/kit/vite.config.js
@@ -1,0 +1,7 @@
+import adapter from '@sveltejs/adapter-node';
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+	plugins: [sveltekit({ adapter: adapter({ precompress: false }) })]
+});

--- a/benchmark/fixtures/package/package.json
+++ b/benchmark/fixtures/package/package.json
@@ -1,0 +1,25 @@
+{
+	"name": "benchmark-fixture-package",
+	"private": true,
+	"version": "0.0.0",
+	"description": "Benchmark seed package for @sveltejs/package",
+	"type": "module",
+	"files": [
+		"dist"
+	],
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"svelte": "./dist/index.js"
+		}
+	},
+	"svelte": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"peerDependencies": {
+		"svelte": "^5.0.0"
+	},
+	"imports": {
+		"#lib": "./src/lib/index.ts",
+		"#lib/*": "./src/lib/*"
+	}
+}

--- a/benchmark/fixtures/package/src/lib/Component.svelte
+++ b/benchmark/fixtures/package/src/lib/Component.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+	import { formatMetric, type BenchmarkTone } from '#lib';
+
+	interface Props {
+		label: string;
+		value: number;
+		tone?: BenchmarkTone;
+		tags?: string[];
+	}
+
+	let { label, value, tone = 'neutral', tags = ['seed', 'component'] }: Props = $props();
+
+	let expanded = $state(false);
+	let metric = $derived(formatMetric(value));
+	let badge = $derived(tone === 'positive' ? 'ready' : tone === 'caution' ? 'watch' : 'steady');
+</script>
+
+<article class:expanded data-tone={tone}>
+	<header>
+		<div>
+			<h2>{label}</h2>
+			<p>{metric}</p>
+		</div>
+
+		<span>{badge}</span>
+	</header>
+
+	<button type="button" onclick={() => (expanded = !expanded)}>
+		{expanded ? 'Hide details' : 'Show details'}
+	</button>
+
+	{#if expanded}
+		<ul>
+			{#each tags as tag (tag)}
+				<li>{tag}</li>
+			{/each}
+		</ul>
+	{/if}
+</article>
+
+<style>
+	article {
+		display: grid;
+		gap: 0.75rem;
+		padding: 1rem;
+		border: 1px solid #dbe4ff;
+		border-radius: 0.75rem;
+		background: #f8faff;
+	}
+
+	article.expanded {
+		border-color: #7c3aed;
+	}
+
+	header {
+		display: flex;
+		align-items: start;
+		justify-content: space-between;
+		gap: 1rem;
+	}
+
+	h2,
+	p,
+	ul {
+		margin: 0;
+	}
+
+	span {
+		padding: 0.25rem 0.5rem;
+		border-radius: 999px;
+		background: #e2e8f0;
+		font-size: 0.875rem;
+		text-transform: capitalize;
+	}
+
+	article[data-tone='positive'] span {
+		background: #dcfce7;
+		color: #166534;
+	}
+
+	article[data-tone='caution'] span {
+		background: #fef3c7;
+		color: #92400e;
+	}
+
+	button {
+		width: fit-content;
+		padding: 0.5rem 0.75rem;
+		border: 0;
+		border-radius: 0.5rem;
+		background: #1d4ed8;
+		color: white;
+		font: inherit;
+	}
+
+	ul {
+		padding-left: 1.25rem;
+		color: #475569;
+	}
+</style>

--- a/benchmark/fixtures/package/src/lib/index.ts
+++ b/benchmark/fixtures/package/src/lib/index.ts
@@ -1,0 +1,7 @@
+export type BenchmarkTone = 'neutral' | 'positive' | 'caution';
+
+export function formatMetric(value: number) {
+	return `${value.toFixed(1)}ms`;
+}
+
+export { default as Component } from '$benchmark/Component.svelte';

--- a/benchmark/fixtures/package/svelte.config.js
+++ b/benchmark/fixtures/package/svelte.config.js
@@ -1,0 +1,7 @@
+const config = {
+	alias: {
+		$benchmark: './src/lib'
+	}
+};
+
+export default config;

--- a/benchmark/fixtures/package/tsconfig.json
+++ b/benchmark/fixtures/package/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"compilerOptions": {
+		"target": "ESNext",
+		"module": "ESNext",
+		"declaration": true,
+		"allowImportingTsExtensions": true,
+		"rewriteRelativeImportExtensions": true
+	}
+}

--- a/benchmark/kit.bench.js
+++ b/benchmark/kit.bench.js
@@ -1,0 +1,139 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { bench, describe, expect } from 'vitest';
+import {
+	create_workspace,
+	generate_routes,
+	repo_root,
+	run,
+	start_server,
+	stop_server
+} from './utils.js';
+
+const kit_cli = path.join(repo_root, 'packages/kit/svelte-kit.js');
+const vite_cli = path.join(repo_root, 'packages/kit/node_modules/vite/bin/vite.js');
+const macro = {
+	iterations: 1,
+	time: 0,
+	warmupIterations: 0,
+	warmupTime: 0
+};
+
+let sync_app = '';
+let build_app = '';
+let simple_app = '';
+let data_app = '';
+/** @type {Awaited<ReturnType<typeof start_server>> | undefined} */
+let simple_server;
+/** @type {Awaited<ReturnType<typeof start_server>> | undefined} */
+let data_server;
+
+/** @param {string} workspace */
+function remove_workspace(workspace) {
+	fs.rmSync(workspace, { force: true, recursive: true });
+}
+
+describe('SvelteKit', () => {
+	bench(
+		'cold sync for a route-heavy app',
+		async () => {
+			await run(process.execPath, [kit_cli, 'sync'], sync_app);
+			expect(fs.existsSync(path.join(sync_app, 'node_modules/$app/tsconfig.json'))).toBe(true);
+			expect(
+				fs.existsSync(
+					path.join(sync_app, '.svelte-kit/types/src/routes/generated/static-0/$types.d.ts')
+				)
+			).toBe(true);
+		},
+		{
+			...macro,
+			setup: (_task, mode) => {
+				if (mode === 'run') {
+					sync_app = create_workspace('kit');
+					generate_routes(sync_app, 72);
+				}
+			},
+			teardown: (_task, mode) => {
+				if (mode === 'run') remove_workspace(sync_app);
+			}
+		}
+	);
+
+	bench(
+		'production build for a representative app',
+		async () => {
+			await run(process.execPath, [vite_cli, 'build'], build_app);
+			expect(fs.existsSync(path.join(build_app, 'build/index.js'))).toBe(true);
+			expect(fs.existsSync(path.join(build_app, 'build/server/chunks'))).toBe(true);
+		},
+		{
+			...macro,
+			setup: (_task, mode) => {
+				if (mode === 'run') {
+					build_app = create_workspace('kit');
+					generate_routes(build_app, 48);
+				}
+			},
+			teardown: (_task, mode) => {
+				if (mode === 'run') remove_workspace(build_app);
+			}
+		}
+	);
+
+	bench(
+		'simple production SSR request',
+		async () => {
+			if (!simple_server) throw new Error('Preview server has not started');
+			const response = await fetch(simple_server.url);
+			const body = await response.text();
+			expect(response.status).toBe(200);
+			expect(body).toContain('SvelteKit benchmark');
+		},
+		{
+			...macro,
+			setup: async (_task, mode) => {
+				if (mode === 'run') {
+					simple_app = create_workspace('kit');
+					generate_routes(simple_app, 48);
+					await run(process.execPath, [vite_cli, 'build'], simple_app);
+					simple_server = await start_server(simple_app);
+				}
+			},
+			teardown: async (_task, mode) => {
+				if (mode === 'run') {
+					if (simple_server) await stop_server(simple_server.child);
+					remove_workspace(simple_app);
+				}
+			}
+		}
+	);
+
+	bench(
+		'data-heavy production SSR request',
+		async () => {
+			if (!data_server) throw new Error('Preview server has not started');
+			const response = await fetch(`${data_server.url}/ssr`);
+			const body = await response.text();
+			expect(response.status).toBe(200);
+			expect(body).toContain('benchmark-item-199');
+		},
+		{
+			...macro,
+			setup: async (_task, mode) => {
+				if (mode === 'run') {
+					data_app = create_workspace('kit');
+					generate_routes(data_app, 48);
+					await run(process.execPath, [vite_cli, 'build'], data_app);
+					data_server = await start_server(data_app);
+				}
+			},
+			teardown: async (_task, mode) => {
+				if (mode === 'run') {
+					if (data_server) await stop_server(data_server.child);
+					remove_workspace(data_app);
+				}
+			}
+		}
+	);
+});

--- a/benchmark/package.bench.js
+++ b/benchmark/package.bench.js
@@ -1,0 +1,39 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { bench, describe, expect } from 'vitest';
+import { create_workspace, generate_components, repo_root, run } from './utils.js';
+
+const package_cli = path.join(repo_root, 'packages/package/svelte-package.js');
+const macro = {
+	iterations: 1,
+	time: 0,
+	warmupIterations: 0,
+	warmupTime: 0
+};
+let workspace = '';
+
+describe('@sveltejs/package', () => {
+	bench(
+		'clean medium library build with declarations',
+		async () => {
+			await run(process.execPath, [package_cli], workspace);
+			expect(fs.existsSync(path.join(workspace, 'dist/Component0.svelte'))).toBe(true);
+			expect(fs.existsSync(path.join(workspace, 'dist/Component0.svelte.d.ts'))).toBe(true);
+			expect(fs.existsSync(path.join(workspace, 'dist/helper47.js'))).toBe(true);
+			expect(fs.existsSync(path.join(workspace, 'dist/helper47.d.ts'))).toBe(true);
+		},
+		{
+			...macro,
+			setup: (_task, mode) => {
+				if (mode === 'run') {
+					workspace = create_workspace('package');
+					generate_components(workspace, 48);
+				}
+			},
+			teardown: (_task, mode) => {
+				if (mode === 'run') fs.rmSync(workspace, { force: true, recursive: true });
+			}
+		}
+	);
+});

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "@sveltejs/benchmarks",
+	"private": true,
+	"type": "module",
+	"devDependencies": {
+		"@codspeed/vitest-plugin": "catalog:",
+		"@types/node": "catalog:",
+		"vitest": "catalog:"
+	}
+}

--- a/benchmark/tsconfig.json
+++ b/benchmark/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../tsconfig.json",
+	"compilerOptions": {
+		"types": ["node", "vitest"]
+	},
+	"include": ["*.js"]
+}

--- a/benchmark/utils.js
+++ b/benchmark/utils.js
@@ -1,0 +1,208 @@
+/** @import { ChildProcess } from 'node:child_process' */
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const benchmark_dir = path.dirname(fileURLToPath(import.meta.url));
+export const repo_root = path.dirname(benchmark_dir);
+
+/**
+ * @param {'kit' | 'package'} name
+ */
+export function create_workspace(name) {
+	const directory = fs.mkdtempSync(path.join(os.tmpdir(), `sveltekit-benchmark-${name}-`));
+	fs.rmSync(directory, { recursive: true });
+	fs.cpSync(path.join(benchmark_dir, 'fixtures', name), directory, { recursive: true });
+
+	if (name === 'kit') {
+		link_package(directory, '@sveltejs/kit', path.join(repo_root, 'packages/kit'));
+		link_package(
+			directory,
+			'@sveltejs/adapter-node',
+			path.join(repo_root, 'packages/adapter-node')
+		);
+		link_package(directory, 'svelte', path.join(repo_root, 'packages/kit/node_modules/svelte'));
+		link_package(directory, 'vite', path.join(repo_root, 'packages/kit/node_modules/vite'));
+	}
+
+	return directory;
+}
+
+/**
+ * @param {string} workspace
+ * @param {string} name
+ * @param {string} target
+ */
+function link_package(workspace, name, target) {
+	const destination = path.join(workspace, 'node_modules', name);
+	fs.mkdirSync(path.dirname(destination), { recursive: true });
+	fs.symlinkSync(target, destination, 'junction');
+}
+
+/**
+ * @param {string} workspace
+ * @param {number} count
+ */
+export function generate_routes(workspace, count) {
+	const routes = path.join(workspace, 'src/routes/generated');
+	const page = path.join(workspace, 'src/routes/+page.svelte');
+	const kinds = ['static', 'nested', 'dynamic', 'optional', 'rest', 'grouped'];
+
+	for (let index = 0; index < count; index += 1) {
+		const kind = kinds[index % kinds.length];
+		const base = path.join(routes, `${kind}-${index}`);
+		const directory =
+			kind === 'nested'
+				? path.join(base, 'child')
+				: kind === 'dynamic'
+					? path.join(base, '[slug]')
+					: kind === 'optional'
+						? path.join(base, '[[lang]]')
+						: kind === 'rest'
+							? path.join(base, '[...path]')
+							: kind === 'grouped'
+								? path.join(routes, `(group-${index})`, `grouped-${index}`)
+								: base;
+
+		fs.mkdirSync(directory, { recursive: true });
+		fs.copyFileSync(page, path.join(directory, '+page.svelte'));
+		fs.writeFileSync(
+			path.join(directory, '+page.server.js'),
+			`export function load() { return { route: ${JSON.stringify(`${kind}-${index}`)} }; }\n`
+		);
+	}
+
+	for (let index = 0; index < Math.ceil(count / 5); index += 1) {
+		const directory = path.join(routes, `api-${index}`);
+		fs.mkdirSync(directory, { recursive: true });
+		fs.writeFileSync(
+			path.join(directory, '+server.js'),
+			`export function GET() { return new Response(${JSON.stringify(`endpoint-${index}`)}); }\n`
+		);
+	}
+}
+
+/**
+ * @param {string} workspace
+ * @param {number} count
+ */
+export function generate_components(workspace, count) {
+	const library = path.join(workspace, 'src/lib');
+	const component = path.join(library, 'Component.svelte');
+
+	for (let index = 0; index < count; index += 1) {
+		fs.copyFileSync(component, path.join(library, `Component${index}.svelte`));
+		fs.writeFileSync(
+			path.join(library, `helper${index}.ts`),
+			`export const value${index}: number = ${index};\n`
+		);
+	}
+
+	const exports = Array.from(
+		{ length: count },
+		(_, index) =>
+			`export { default as Component${index} } from './Component${index}.svelte';\nexport { value${index} } from './helper${index}.js';`
+	);
+	fs.appendFileSync(path.join(library, 'index.ts'), `\n${exports.join('\n')}\n`);
+}
+
+/**
+ * @param {string} workspace
+ * @param {string[]} artifacts
+ */
+export function remove_artifacts(workspace, artifacts) {
+	for (const artifact of artifacts) {
+		fs.rmSync(path.join(workspace, artifact), { force: true, recursive: true });
+	}
+}
+
+/**
+ * @param {string} command
+ * @param {string[]} args
+ * @param {string} cwd
+ * @param {NodeJS.ProcessEnv} [env]
+ */
+export async function run(command, args, cwd, env) {
+	const child = spawn(command, args, {
+		cwd,
+		env: { ...process.env, NO_COLOR: '1', ...env },
+		stdio: ['ignore', 'pipe', 'pipe']
+	});
+
+	let output = '';
+	child.stdout.on('data', (chunk) => (output += chunk));
+	child.stderr.on('data', (chunk) => (output += chunk));
+
+	const code = await new Promise((resolve, reject) => {
+		child.on('error', reject);
+		child.on('exit', resolve);
+	});
+
+	if (code !== 0) {
+		throw new Error(`${command} ${args.join(' ')} exited with code ${code}\n${output}`);
+	}
+
+	return output;
+}
+
+/**
+ * @param {string} workspace
+ */
+export async function start_server(workspace) {
+	const port = await get_available_port();
+	const child = spawn(process.execPath, ['build/index.js'], {
+		cwd: workspace,
+		env: { ...process.env, HOST: '127.0.0.1', PORT: String(port), NO_COLOR: '1' },
+		stdio: ['ignore', 'pipe', 'pipe']
+	});
+	let output = '';
+	child.stdout.on('data', (chunk) => (output += chunk));
+	child.stderr.on('data', (chunk) => (output += chunk));
+
+	const url = `http://127.0.0.1:${port}`;
+	for (let attempt = 0; attempt < 100; attempt += 1) {
+		if (child.exitCode !== null) {
+			throw new Error(`Preview server exited with code ${child.exitCode}\n${output}`);
+		}
+
+		try {
+			const response = await fetch(url);
+			await response.body?.cancel();
+			if (response.ok) return { child, url };
+		} catch {
+			// The server is not listening yet.
+		}
+		await new Promise((resolve) => setTimeout(resolve, 25));
+	}
+
+	await stop_server(child);
+	throw new Error(`Preview server did not start\n${output}`);
+}
+
+/**
+ * @param {ChildProcess} child
+ */
+export async function stop_server(child) {
+	if (child.exitCode !== null) return;
+	child.kill('SIGTERM');
+	await new Promise((resolve) => child.once('exit', resolve));
+}
+
+function get_available_port() {
+	return new Promise((resolve, reject) => {
+		const server = net.createServer();
+		server.on('error', reject);
+		server.listen(0, '127.0.0.1', () => {
+			const address = server.address();
+			server.close((error) => {
+				if (error) reject(error);
+				else if (address && typeof address === 'object') resolve(address.port);
+				else reject(new Error('Could not allocate a port'));
+			});
+		});
+	});
+}

--- a/benchmark/vitest.config.js
+++ b/benchmark/vitest.config.js
@@ -1,0 +1,13 @@
+import codspeedPlugin from '@codspeed/vitest-plugin';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	plugins: [codspeedPlugin()],
+	test: {
+		benchmark: {
+			include: ['**/*.bench.js']
+		},
+		fileParallelism: false,
+		maxWorkers: 1
+	}
+});

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"test:others": "pnpm -F @sveltejs/kit prepublishOnly && pnpm -r --filter='./packages/*' --filter=!./packages/kit/ --workspace-concurrency=1 test",
 		"test:others:unit": "pnpm -F @sveltejs/kit prepublishOnly && pnpm -r --filter=\"./packages/*\" --filter=\"!./packages/kit\" --workspace-concurrency=1 test:unit",
 		"test:unit": "vitest run",
+		"bench": "pnpm -F @sveltejs/adapter-node build && pnpm --dir benchmark vitest bench --run --config vitest.config.js",
 		"check": "pnpm --filter='./packages/**' prepublishOnly && pnpm --filter='./packages/**' --filter='!./packages/kit/test/build-errors/**' check",
 		"lint": "oxfmt --check . && echo '\nRunning eslint...' && eslint --cache --cache-location node_modules/.eslintcache 'packages/**/*.{js,d.ts}'",
 		"format": "oxfmt --write .",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ catalogs:
     '@changesets/cli':
       specifier: ^3.0.0
       version: 3.0.0
+    '@codspeed/vitest-plugin':
+      specifier: ^5.7.1
+      version: 5.7.1
     '@fontsource/libre-barcode-128-text':
       specifier: ^5.3.0
       version: 5.3.0
@@ -227,6 +230,18 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.10)(jsdom@30.0.1)(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(jiti@2.4.2)(yaml@2.9.0))
+
+  benchmark:
+    devDependencies:
+      '@codspeed/vitest-plugin':
+        specifier: 'catalog:'
+        version: 5.7.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tinybench@2.9.0)(vite@7.3.6(@types/node@22.19.19)(jiti@2.4.2)(lightningcss@1.33.0)(yaml@2.9.0))(vitest@4.1.10)
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.19
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.10)(jsdom@30.0.1)(vite@7.3.6(@types/node@22.19.19)(jiti@2.4.2)(lightningcss@1.33.0)(yaml@2.9.0))
 
   packages/adapter-auto:
     devDependencies:
@@ -1993,6 +2008,16 @@ packages:
   '@cloudflare/workers-types@5.20260813.1':
     resolution: {integrity: sha512-RQNfm7xD10hNHEQZFxQPmyGMJ9+aDGPcdFZ0x1LtmjRoLFcgZkGvfaqJAbOMQBAUFSESO3bYJS4p9mOLv28Ihg==}
 
+  '@codspeed/core@5.7.1':
+    resolution: {integrity: sha512-7mrFkqaY14rXu3XHv3o7bK3btLK0LFRxfeK3bQC8dLduI/Ty9eq8Hv8rx04FAY/onQbRTx3rUUQg5xprYHpATQ==}
+
+  '@codspeed/vitest-plugin@5.7.1':
+    resolution: {integrity: sha512-yKNqaYVxZZPJYkhVHpz30Oem4TUgcI+/IRDD9YHvcAgi0P42CL6TB/+qYjuFOWghFzTPrm3TUbNFoBsevSTbUA==}
+    peerDependencies:
+      tinybench: '>=2.9.0'
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+      vitest: ^3.2 || ^4
+
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
@@ -2643,6 +2668,13 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@netlify/edge-functions@3.0.8':
     resolution: {integrity: sha512-ml1oCDsRTTRmZS2nUj8XRD1b6+foEiZT3lPk7qQ4nv/jnxylHJ20ooPzPDH+cJmGjXFrMeR14/91W1o6D2ftBg==}
     engines: {node: '>=18.0.0'}
@@ -3100,6 +3132,144 @@ packages:
       rollup:
         optional: true
 
+  '@rollup/rollup-android-arm-eabi@4.63.1':
+    resolution: {integrity: sha512-UZ8sUxPTiHWYX9QNdJedb1kDZSpS1t/VPWBWGSgqHNi9w3Cu6IXvu2mzbhiTiPvtrqgTQJ+zqiAq2iPIPilpaQ==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.63.1':
+    resolution: {integrity: sha512-cQ4nFQABN5cDvDpbvJ7bMStCpnaVxynZrRMfUJYgxcIk9Sh54FIO1vtfkg0B69REjER77ioZ/ov+eAApx/KmLQ==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.63.1':
+    resolution: {integrity: sha512-FQNqd1lRy/0QhDk3xeRIkSBiCpXCiDnZO3YLVdcDKN1UBiKToNftCzcXYNLshmPDUMlu2TdeS8tGcsU6f3YF1Q==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.63.1':
+    resolution: {integrity: sha512-pvD16V939D3CloK0+qikpGaxiPrDUXTe7Y5cWOMkMSy7m1cawa8EGy/kXYi/G/cKAC4HDAbSnzCIk1WmsoOKXg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.63.1':
+    resolution: {integrity: sha512-pcFGeL2345VwdTnJhA6zLbew+YgWB0qBG2+dMtXjCicf6+rm6kO6cOoh5VnTe0ZMrMRgRyuHmCJxZWrIdzYuOw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.63.1':
+    resolution: {integrity: sha512-mRJlqSRulVzcKq/LKA6ICSIc3K/l4fzlVn/gePn2nXIHy8seRi5z/eeRE0d/XMBxcMldiXtQTSpRj0tkkC3g8Q==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.63.1':
+    resolution: {integrity: sha512-YDUNvVM85TI3g/1OpnqKP1h4NeW/j64DfWMf+G3M809xNk1bJSnpFp4sh83NpmVE5DXnkh8ULor4LTVZKoYLHw==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.63.1':
+    resolution: {integrity: sha512-7Mcn71p9ZuQFAj+h+dhQXy/yeLePRS2yKRnmW1DijA9thKO5qap0GNOIQK4yQ6iP3SU0Mrb/yWo8h8vgRba8lw==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.63.1':
+    resolution: {integrity: sha512-4YiLQTX6U4CSl0L9cluep9A9W6UmTfqBDc2/CH6wlu54pl4E7Jn3cOD8oxzvBDEGk/JMKgJ47C8g+radF7mwvg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.63.1':
+    resolution: {integrity: sha512-2ra8F7w8OquwZN9z2/fKFnli69wa8PLwaVzRMIPGb13ByMJwC28Fbp8YcVGoUhlYMTt7j5j9bNgpysrN2UM+vw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.63.1':
+    resolution: {integrity: sha512-Sy20ncyhjmBP0Ml+UvQbimjlk6VFgjW5uNP+qqwHB00mTE8Bl2C1TuHTlRwK2YoXeZbee5lP2XevBWVkAQAtSQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.63.1':
+    resolution: {integrity: sha512-noITLp8oNjYliPnGWmLyelIHwULGqbHloQHGw1rtxbWhTuWooRpnZarZQJ1y9EUC4szuCusCc+HEpUtxpIwYvA==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.63.1':
+    resolution: {integrity: sha512-hlxxXd+F1mWiAcaFR7Sv9ZQT6m6UfI8+Vy/kFJzztq2pDMU/0wZ9sish0iszNZvsQDo8Gc0i5yuFEOz5dDf6fA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.63.1':
+    resolution: {integrity: sha512-EF7OpqQTQ/BvGqLzUi4rEHuagCV9MugAUXSHemwPW5vxZ75RR+jxO/2j95Ph2dalMpFHSVECjRoioHZgA9zOYA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.63.1':
+    resolution: {integrity: sha512-wQO3JesW9PRkwlabQ27y7sPfVOOTLRG73I4F2UYHG5PXun3J9U3y+b7ezVKSYbsvSKGQ1k1cq8Qlun4C9kLt3w==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.63.1':
+    resolution: {integrity: sha512-ouAGwhO6wHRXdnOVCOsB0tRFkA7nhNB2Nwax6oECXN0YiN8EYUTBAOudADOB1PI+yDL61TeNx/u7MVCzksNbkQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.63.1':
+    resolution: {integrity: sha512-q2R38Sn+1J8RxhfJ+T54wSWmyKXWec+9jgDfqO2AtArEqHO5R2aeayp5H5OYLr5UYDVGsVaZPEFUooMhYCdz5A==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.63.1':
+    resolution: {integrity: sha512-gfI5T24WLLuFfSKw7Go/zDXjAAV0fny0swTaDv+WjK7vqcw4cRhFfdsyKL1n+ukI+ooBxn3bVQnyrn06WpI50w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.63.1':
+    resolution: {integrity: sha512-4h6XqthmB4Hspji84wvgk+ElodTsGj+dbZqHJHHtKxj4mYq0ANSEEPX9ys3moJueqsRjwpaJYH7874Itwnj2ow==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.63.1':
+    resolution: {integrity: sha512-dlfCOa87o1VAYegLQ9EKilx2JCeRofiyPGhTCmqnuXZ6bMPiycO1rq1+sKoulAp7pGLIsTIw+1x5R+zgh5LhhA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.63.1':
+    resolution: {integrity: sha512-cjkLbOlfcm3QGhMM1J5zaZjsw1GggbN6rw9UTSSRrPrR1KkcXnN7Uq9rPw34xImQ9VOY9GN+6u2Zj80B9ptkcw==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.63.1':
+    resolution: {integrity: sha512-Li1KdUnWGE4N3e1F/B4RTB1ms+nG4WBgjByO46pkeBVX/2UBsY53xf5vK9WygVmnH3RwncIST7lkSdLSY6P9lg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.63.1':
+    resolution: {integrity: sha512-t4ZYOSoLTgwhuFMrmTMLx/+i1DQVK7HYqMc6kY46EApwi8X0nIVphzdNoThU3xt6n+N5urG1/gxBdCaKDLavfg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.63.1':
+    resolution: {integrity: sha512-RgroPfMmKlD1RzSDxvwgcPiy2HNQKoYV7OmwIXDsk73uKW5t6B/V8KIy27SMv/FNXFo/oSBtWc9J0X7t91ezZg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.63.1':
+    resolution: {integrity: sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==}
+    cpu: [x64]
+    os: [win32]
+
   '@sindresorhus/is@7.2.0':
     resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
     engines: {node: '>=18'}
@@ -3421,6 +3591,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   agent-base@7.1.3:
     resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==}
     engines: {node: '>= 14'}
@@ -3446,6 +3620,12 @@ packages:
 
   async-sema@3.1.1:
     resolution: {integrity: sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  axios@1.20.0:
+    resolution: {integrity: sha512-r8aOh8j9cGKpgQAqpzrUHnSIc6a59Y3Xf/cv8sy1DrHCkZHzQGEuoq1tARk6qSyDdtQGSDgpb9kFlruzPvrgwg==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -3474,6 +3654,10 @@ packages:
   cac@7.0.0:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
     engines: {node: '>=20.19.0'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -3508,6 +3692,10 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
@@ -3570,6 +3758,10 @@ packages:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -3582,6 +3774,10 @@ packages:
     hasBin: true
     peerDependencies:
       typescript: ^5.0.4 || ^6.0.0
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
 
   e2e-test-dep-cjs-only@file:packages/kit/test/apps/dev-only/_test_dependencies/cjs-only:
     resolution: {directory: packages/kit/test/apps/dev-only/_test_dependencies/cjs-only, type: directory}
@@ -3608,8 +3804,24 @@ packages:
   error-stack-parser-es@1.0.5:
     resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@2.3.1:
     resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
@@ -3771,12 +3983,29 @@ packages:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
 
+  find-up@6.3.0:
+    resolution: {integrity: sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
   flatted@3.4.3:
     resolution: {integrity: sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==}
+
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
+    engines: {node: '>= 6'}
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -3788,13 +4017,24 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
   get-port@5.1.1:
     resolution: {integrity: sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==}
     engines: {node: '>=8'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
@@ -3822,12 +4062,32 @@ packages:
   globrex@0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
 
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -4015,6 +4275,10 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  locate-path@7.2.0:
+    resolution: {integrity: sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
@@ -4031,8 +4295,20 @@ packages:
   magic-string@1.1.0:
     resolution: {integrity: sha512-kS3VHe0nEPST2saQV4Rbkchcd3UBRkVTQHo1D3h/ZTwFDhai/mfKkmtPAtD129EOI7K3HlHIsFOt0WrI2/oU9g==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
 
   miniflare@5.20260804.0-alpha:
     resolution: {integrity: sha512-UDegnTukIpJCI/lNyQXU7B8kYFLcMZihlxqqOocnc62tV8AO6XofmFmZm3ZLDXTWZpkZnLLJ2sKCSlTIEXO3dQ==}
@@ -4115,9 +4391,17 @@ packages:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
 
+  p-limit@4.0.0:
+    resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  p-locate@6.0.0:
+    resolution: {integrity: sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   package-manager-detector@1.8.0:
     resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
@@ -4128,6 +4412,10 @@ packages:
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
+
+  path-exists@5.0.0:
+    resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -4216,6 +4504,10 @@ packages:
     resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
 
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -4250,6 +4542,11 @@ packages:
   rolldown@1.2.3:
     resolution: {integrity: sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==}
     engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  rollup@4.63.1:
+    resolution: {integrity: sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
   sade@1.8.1:
@@ -4325,6 +4622,10 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  stack-trace@1.0.0-pre2:
+    resolution: {integrity: sha512-2ztBJRek8IVofG9DBJqdy2N5kulaacX30Nz7xmkYF6ale9WBVmIy6mFBchvGX7Vx/MyjBhx+Rcxqrj+dbOnQ6A==}
+    engines: {node: '>=16'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -4543,6 +4844,46 @@ packages:
     peerDependencies:
       vite: '>=8.0.0'
 
+  vite@7.3.6:
+    resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
   vite@8.2.1:
     resolution: {integrity: sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -4742,6 +5083,10 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  yocto-queue@1.2.2:
+    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
+    engines: {node: '>=12.20'}
+
   youch-core@0.3.3:
     resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
 
@@ -4923,6 +5268,27 @@ snapshots:
     optional: true
 
   '@cloudflare/workers-types@5.20260813.1': {}
+
+  '@codspeed/core@5.7.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)':
+    dependencies:
+      axios: 1.20.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      find-up: 6.3.0
+      form-data: 4.0.6
+      node-gyp-build: 4.8.0
+      stack-trace: 1.0.0-pre2
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@codspeed/vitest-plugin@5.7.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tinybench@2.9.0)(vite@7.3.6(@types/node@22.19.19)(jiti@2.4.2)(lightningcss@1.33.0)(yaml@2.9.0))(vitest@4.1.10)':
+    dependencies:
+      '@codspeed/core': 5.7.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      tinybench: 2.9.0
+      vite: 7.3.6(@types/node@22.19.19)(jiti@2.4.2)(lightningcss@1.33.0)(yaml@2.9.0)
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.10)(jsdom@30.0.1)(vite@7.3.6(@types/node@22.19.19)(jiti@2.4.2)(lightningcss@1.33.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -5377,6 +5743,9 @@ snapshots:
       - encoding
       - supports-color
 
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    optional: true
+
   '@netlify/edge-functions@3.0.8':
     dependencies:
       '@netlify/types': 2.8.0
@@ -5756,6 +6125,81 @@ snapshots:
       estree-walker: 2.0.2
       picomatch: 4.0.5
 
+  '@rollup/rollup-android-arm-eabi@4.63.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.63.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.63.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.63.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.63.1':
+    optional: true
+
   '@sindresorhus/is@7.2.0': {}
 
   '@speed-highlight/core@1.2.15': {}
@@ -5999,6 +6443,20 @@ snapshots:
       - rollup
       - supports-color
 
+  '@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@7.3.6(@types/node@22.19.19)(jiti@2.4.2)(lightningcss@1.33.0)(yaml@2.9.0))(vitest@4.1.10)':
+    dependencies:
+      '@vitest/browser': 4.1.10(vite@7.3.6(@types/node@22.19.19)(jiti@2.4.2)(lightningcss@1.33.0)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/mocker': 4.1.10(vite@7.3.6(@types/node@22.19.19)(jiti@2.4.2)(lightningcss@1.33.0)(yaml@2.9.0))
+      playwright: 1.62.1
+      tinyrainbow: 3.1.0
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.10)(jsdom@30.0.1)(vite@7.3.6(@types/node@22.19.19)(jiti@2.4.2)(lightningcss@1.33.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
   '@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(jiti@2.4.2)(yaml@2.9.0))(vitest@4.1.10)':
     dependencies:
       '@vitest/browser': 4.1.10(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(jiti@2.4.2)(yaml@2.9.0))(vitest@4.1.10)
@@ -6011,6 +6469,24 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
+
+  '@vitest/browser@4.1.10(vite@7.3.6(@types/node@22.19.19)(jiti@2.4.2)(lightningcss@1.33.0)(yaml@2.9.0))(vitest@4.1.10)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.10(vite@7.3.6(@types/node@22.19.19)(jiti@2.4.2)(lightningcss@1.33.0)(yaml@2.9.0))
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.0
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.10)(jsdom@30.0.1)(vite@7.3.6(@types/node@22.19.19)(jiti@2.4.2)(lightningcss@1.33.0)(yaml@2.9.0))
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
 
   '@vitest/browser@4.1.10(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(jiti@2.4.2)(yaml@2.9.0))(vitest@4.1.10)':
     dependencies:
@@ -6037,6 +6513,14 @@ snapshots:
       '@vitest/utils': 4.1.10
       chai: 6.2.2
       tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@7.3.6(@types/node@22.19.19)(jiti@2.4.2)(lightningcss@1.33.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.6(@types/node@22.19.19)(jiti@2.4.2)(lightningcss@1.33.0)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.10(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(jiti@2.4.2)(yaml@2.9.0))':
     dependencies:
@@ -6082,6 +6566,12 @@ snapshots:
 
   acorn@8.18.0: {}
 
+  agent-base@6.0.2(supports-color@10.2.2):
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+
   agent-base@7.1.3: {}
 
   ajv@6.15.0:
@@ -6102,6 +6592,18 @@ snapshots:
   assertion-error@2.0.1: {}
 
   async-sema@3.1.1: {}
+
+  asynckit@0.4.0: {}
+
+  axios@1.20.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2):
+    dependencies:
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@10.2.2))
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1(supports-color@10.2.2)
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   axobject-query@4.1.0: {}
 
@@ -6126,6 +6628,11 @@ snapshots:
       '@types/node': 22.19.19
 
   cac@7.0.0: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
 
   chai@6.2.2: {}
 
@@ -6154,6 +6661,10 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
 
   consola@3.4.2: {}
 
@@ -6201,6 +6712,8 @@ snapshots:
 
   deepmerge@4.3.1: {}
 
+  delayed-stream@1.0.0: {}
+
   detect-libc@2.1.2: {}
 
   devalue@5.9.0: {}
@@ -6216,6 +6729,12 @@ snapshots:
       tinyglobby: 0.2.17
       ts-api-utils: 1.3.0(typescript@6.0.3)
       typescript: 6.0.3
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
 
   e2e-test-dep-cjs-only@file:packages/kit/test/apps/dev-only/_test_dependencies/cjs-only: {}
 
@@ -6236,7 +6755,22 @@ snapshots:
 
   error-stack-parser-es@1.0.5: {}
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@2.3.1: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.4
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -6446,6 +6980,11 @@ snapshots:
       locate-path: 6.0.0
       path-exists: 4.0.0
 
+  find-up@6.3.0:
+    dependencies:
+      locate-path: 7.2.0
+      path-exists: 5.0.0
+
   flat-cache@4.0.1:
     dependencies:
       flatted: 3.4.3
@@ -6453,15 +6992,47 @@ snapshots:
 
   flatted@3.4.3: {}
 
+  follow-redirects@1.16.0(debug@4.4.3(supports-color@10.2.2)):
+    optionalDependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+
+  form-data@4.0.6:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
+
   fsevents@2.3.2:
     optional: true
 
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   get-caller-file@2.0.5: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
   get-port@5.1.1: {}
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
 
   get-tsconfig@4.14.0:
     dependencies:
@@ -6485,13 +7056,32 @@ snapshots:
 
   globrex@0.1.2: {}
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
 
   html-encoding-sniffer@6.0.0:
     dependencies:
       '@exodus/bytes': 1.15.1
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  https-proxy-agent@5.0.1(supports-color@10.2.2):
+    dependencies:
+      agent-base: 6.0.2(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
 
   https-proxy-agent@7.0.6(supports-color@10.2.2):
     dependencies:
@@ -6651,6 +7241,10 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  locate-path@7.2.0:
+    dependencies:
+      p-locate: 6.0.0
+
   lodash.camelcase@4.3.0: {}
 
   long@5.3.2: {}
@@ -6665,7 +7259,15 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  math-intrinsics@1.1.0: {}
+
   mdn-data@2.27.1: {}
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   miniflare@5.20260804.0-alpha:
     dependencies:
@@ -6751,9 +7353,17 @@ snapshots:
     dependencies:
       yocto-queue: 0.1.0
 
+  p-limit@4.0.0:
+    dependencies:
+      yocto-queue: 1.2.2
+
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  p-locate@6.0.0:
+    dependencies:
+      p-limit: 4.0.0
 
   package-manager-detector@1.8.0: {}
 
@@ -6762,6 +7372,8 @@ snapshots:
       entities: 8.0.0
 
   path-exists@4.0.0: {}
+
+  path-exists@5.0.0: {}
 
   path-key@3.1.1: {}
 
@@ -6837,6 +7449,8 @@ snapshots:
       '@types/node': 22.19.19
       long: 5.3.2
 
+  proxy-from-env@2.1.0: {}
+
   punycode@2.3.1: {}
 
   readdirp@4.1.2: {}
@@ -6877,6 +7491,38 @@ snapshots:
       '@rolldown/binding-openharmony-arm64': 1.2.3
       '@rolldown/binding-win32-arm64-msvc': 1.2.3
       '@rolldown/binding-win32-x64-msvc': 1.2.3
+
+  rollup@4.63.1:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@napi-rs/lzma-linux-x64-gnu': 1.5.1
+      '@rollup/rollup-android-arm-eabi': 4.63.1
+      '@rollup/rollup-android-arm64': 4.63.1
+      '@rollup/rollup-darwin-arm64': 4.63.1
+      '@rollup/rollup-darwin-x64': 4.63.1
+      '@rollup/rollup-freebsd-arm64': 4.63.1
+      '@rollup/rollup-freebsd-x64': 4.63.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.63.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.63.1
+      '@rollup/rollup-linux-arm64-gnu': 4.63.1
+      '@rollup/rollup-linux-arm64-musl': 4.63.1
+      '@rollup/rollup-linux-loong64-gnu': 4.63.1
+      '@rollup/rollup-linux-loong64-musl': 4.63.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.63.1
+      '@rollup/rollup-linux-ppc64-musl': 4.63.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.63.1
+      '@rollup/rollup-linux-riscv64-musl': 4.63.1
+      '@rollup/rollup-linux-s390x-gnu': 4.63.1
+      '@rollup/rollup-linux-x64-gnu': 4.63.1
+      '@rollup/rollup-linux-x64-musl': 4.63.1
+      '@rollup/rollup-openbsd-x64': 4.63.1
+      '@rollup/rollup-openharmony-arm64': 4.63.1
+      '@rollup/rollup-win32-arm64-msvc': 4.63.1
+      '@rollup/rollup-win32-ia32-msvc': 4.63.1
+      '@rollup/rollup-win32-x64-gnu': 4.63.1
+      '@rollup/rollup-win32-x64-msvc': 4.63.1
+      fsevents: 2.3.3
 
   sade@1.8.1:
     dependencies:
@@ -6993,6 +7639,8 @@ snapshots:
   smol-toml@1.8.0: {}
 
   source-map-js@1.2.1: {}
+
+  stack-trace@1.0.0-pre2: {}
 
   stackback@0.0.2: {}
 
@@ -7223,6 +7871,21 @@ snapshots:
       - '@types/node'
       - rollup
 
+  vite@7.3.6(@types/node@22.19.19)(jiti@2.4.2)(lightningcss@1.33.0)(yaml@2.9.0):
+    dependencies:
+      esbuild: 0.28.1
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rollup: 4.63.1
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 22.19.19
+      fsevents: 2.3.3
+      jiti: 2.4.2
+      lightningcss: 1.33.0
+      yaml: 2.9.0
+
   vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(jiti@2.4.2)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
@@ -7240,6 +7903,36 @@ snapshots:
   vitefu@1.1.3(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(jiti@2.4.2)(yaml@2.9.0)):
     optionalDependencies:
       vite: 8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(jiti@2.4.2)(yaml@2.9.0)
+
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.10)(jsdom@30.0.1)(vite@7.3.6(@types/node@22.19.19)(jiti@2.4.2)(lightningcss@1.33.0)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@7.3.6(@types/node@22.19.19)(jiti@2.4.2)(lightningcss@1.33.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 7.3.6(@types/node@22.19.19)(jiti@2.4.2)(lightningcss@1.33.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 22.19.19
+      '@vitest/browser-playwright': 4.1.10(playwright@1.62.1)(vite@7.3.6(@types/node@22.19.19)(jiti@2.4.2)(lightningcss@1.33.0)(yaml@2.9.0))(vitest@4.1.10)
+      jsdom: 30.0.1
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.10)(jsdom@30.0.1)(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(jiti@2.4.2)(yaml@2.9.0)):
     dependencies:
@@ -7371,6 +8064,8 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  yocto-queue@1.2.2: {}
 
   youch-core@0.3.3:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,6 +19,7 @@ shellEmulator: true
 engineStrict: true
 
 packages:
+  - benchmark
   - packages/*
   - packages/adapter-bun/test/apps/*
   - packages/adapter-cloudflare/test/apps/*
@@ -46,6 +47,7 @@ allowBuilds:
 # see https://github.com/changesets/changesets/issues/1707
 catalog:
   '@changesets/cli': ^3.0.0
+  '@codspeed/vitest-plugin': ^5.7.1
   # pin the version of changelog-github because we're using the experimental
   # template feature which can change in a patch version
   '@changesets/changelog-github': 1.0.0-next.9


### PR DESCRIPTION
SvelteKit currently lacks a stable way to detect performance regressions across package changes. This adds deterministic CodSpeed walltime coverage so subsequent pull requests can be compared against a baseline established on `version-3`.

The first merge establishes the baseline; later pull requests will receive faster/slower comparisons.
