### PR TITLE
fix: percent-encode route parameters in `resolve`

### DIFF
--- a/.changeset/encode-resolve-params.md
+++ b/.changeset/encode-resolve-params.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: percent-encode route parameters in `resolve`

--- a/packages/kit/src/runtime/app/paths/client.js
+++ b/packages/kit/src/runtime/app/paths/client.js
@@ -74,7 +74,9 @@ export function resolve(...args) {
 		}
 
 		return (
-			/** @type {ResolvedPathname} */ (base + pathname_prefix + resolve_route(id, params ?? {}))
+			/** @type {ResolvedPathname} */ (
+				base + pathname_prefix + resolve_route(id, params ?? {}, true)
+			)
 		);
 	}
 

--- a/packages/kit/src/runtime/app/paths/server.js
+++ b/packages/kit/src/runtime/app/paths/server.js
@@ -33,7 +33,7 @@ export function resolve(id, params) {
 			throw new Error(`Missing params for dynamic route ID ${id}`);
 		}
 
-		resolved = resolve_route(id, params ?? {});
+		resolved = resolve_route(id, params ?? {}, true);
 	} else {
 		resolved = '/' + id;
 	}

--- a/packages/kit/src/utils/routing.js
+++ b/packages/kit/src/utils/routing.js
@@ -289,9 +289,10 @@ export const segment_pattern = new RegExp(
  * ```
  * @param {string} id
  * @param {Record<string, ParamValue | undefined>} params
+ * @param {boolean} [encode] percent-encode the values, so the pathname is a valid URI
  * @returns {string}
  */
-export function resolve_route(id, params) {
+export function resolve_route(id, params, encode = false) {
 	const segments = get_route_segments(id);
 	const has_id_trailing_slash = id != '/' && id.endsWith('/');
 
@@ -317,7 +318,17 @@ export function resolve_route(id, params) {
 							);
 						}
 
-						return value;
+						if (!encode) return value;
+
+						// A rest parameter spans segments, so its slashes separate them and
+						// survive. Anywhere else a slash would push the value into the next
+						// segment, where the route no longer matches.
+						return rest
+							? value
+									.split('/')
+									.map((segment) => encodeURIComponent(segment))
+									.join('/')
+							: encodeURIComponent(value);
 					}
 
 					if (

--- a/packages/kit/src/utils/routing.spec.js
+++ b/packages/kit/src/utils/routing.spec.js
@@ -657,3 +657,37 @@ describe('find_route', () => {
 		assert.equal(result?.params.slug, 'hello world');
 	});
 });
+
+describe('resolve_route with encoding', () => {
+	test('encodes a non-ASCII value', () => {
+		assert.equal(resolve_route('/blog/[slug]', { slug: 'møte' }, true), '/blog/m%C3%B8te');
+	});
+
+	test('leaves an ASCII value unchanged', () => {
+		assert.equal(resolve_route('/blog/[slug]', { slug: 'hello-world' }, true), '/blog/hello-world');
+	});
+
+	test('escapes a slash, so the value stays in one segment', () => {
+		assert.equal(resolve_route('/blog/[slug]', { slug: 'a/b' }, true), '/blog/a%2Fb');
+	});
+
+	test('keeps the separators in a rest parameter', () => {
+		assert.equal(resolve_route('/blog/[...rest]', { rest: 'æ/ø' }, true), '/blog/%C3%A6/%C3%B8');
+	});
+
+	test('stringifies a non-string value', () => {
+		assert.equal(resolve_route('/blog/[slug]', { slug: 2 }, true), '/blog/2');
+	});
+
+	test('substitutes verbatim when not encoding', () => {
+		assert.equal(resolve_route('/blog/[slug]', { slug: 'møte' }), '/blog/møte');
+	});
+
+	test('resolves back to the parameters it was given', () => {
+		const { pattern, params } = parse_route_id('/blog/[slug]');
+		const pathname = resolve_route('/blog/[slug]', { slug: 'a/b' }, true);
+		const match = pattern.exec(decodeURI(pathname));
+
+		assert.deepEqual(match && exec(match, params, {}), { slug: 'a/b' });
+	});
+});


### PR DESCRIPTION
closes #17087

`resolve` substitutes parameter values verbatim, so a non-ASCII value produces a pathname that is not a valid URI. It survives an `href`, where the browser encodes it against the UTF-8 document, but a `Location` header is Latin-1:

```js
resolve('/[slug]', { slug: 'møte' }); // '/møte'
```

```
location: /m\370te
```

The browser re-encodes that byte as `%F8`, which is not valid UTF-8, so the request fails to decode. Any redirect naming such a value is unreachable.

`resolve_route` takes an `encode` flag, and the two `$app/paths` entry points pass it. The prerenderer does not: its entries reach `enqueue(referrer, decoded, …)`, which does `encoded || encodeURI(decoded)` (`prerender.js:355`) and would double-encode an already-encoded value.

Encoding inside `resolve_route` means the rest parameter is already known, so slashes are kept where they separate segments and escaped everywhere else. That also makes the pathname route back to the parameters it was built from, which it did not before:

| route | pathname | matches |
| --- | --- | --- |
| `/blog/[slug]` | `/blog/a/b` | nothing |
| `/blog/[slug]` | `/blog/a%2Fb` | `{ slug: 'a/b' }` |
| `/blog/[...rest]` | `/blog/a/b` | `{ rest: 'a/b' }` |

Non-string values are stringified as before, having nothing to encode.

Escaping a slash in a non-rest parameter is a behaviour change beyond the encoding fix. I think it belongs here, since the first row is the same class of bug as the leading and trailing slash that `resolve_route` already rejects, but say if you would rather have it separately.

One more for you to decide: anyone already working around this with `encodeURIComponent(value)` starts double-encoding, silently. I marked the changeset `patch` per the guidance below.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

`pnpm lint`, `pnpm check` and the `routing.spec.js` unit tests pass. I could not run the full integration suite locally, so CI is the first real exercise of it.

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
